### PR TITLE
Manage card counter < 0

### DIFF
--- a/window_background/background.js
+++ b/window_background/background.js
@@ -2047,8 +2047,8 @@ function forceDeckUpdate() {
                             if (card.id == gameObjs[key].grpId) {
                                 //console.log(gameObjs[key].instanceId, cardsDb.get(gameObjs[key].grpId).name, zones[gameObjs[key].zoneId].type);
                                 if (card.quantity > 0) {
-			            card.quantity -= 1;
-				}
+                                    card.quantity -= 1;
+                                }
                             }
                         });
                     }

--- a/window_background/background.js
+++ b/window_background/background.js
@@ -2046,7 +2046,9 @@ function forceDeckUpdate() {
                         currentDeckUpdated.mainDeck.forEach(function(card) {
                             if (card.id == gameObjs[key].grpId) {
                                 //console.log(gameObjs[key].instanceId, cardsDb.get(gameObjs[key].grpId).name, zones[gameObjs[key].zoneId].type);
-                                card.quantity -= 1;
+                                if (card.quantity > 0) {
+			            card.quantity -= 1;
+				}
                             }
                         });
                     }


### PR DESCRIPTION
I am not familiar with the codebase so this is just me trying to understand where the code for #89 lives.

The counter shouldn't be updated if it is already at 0. A better solution would be to check if there was an action that caused the bounce. Can I use `AbilityType.AbilityType_Bounce_Test` for that?

Is there a good way to test this on macOS or do I have to install dev tools in my Windows VM?