### PR TITLE
Fallback to look for output_log.txt in current directory on non-win32

### DIFF
--- a/window_background/background.js
+++ b/window_background/background.js
@@ -545,6 +545,10 @@ if (process.platform === 'win32') {
 else {
     // Path for Wine, could change depending on installation method
     var logUri = process.env.HOME+'/.wine/drive_c/user/'+process.env.USER+'/AppData/LocalLow/Wizards of the Coast/MTGA/output_log.txt';
+    // Fall back to using log file from the current directory if default logUri does not exist but one from CWD does.
+    if (!fs.existsSync(logUri) && fs.existsSync('output_log.txt')) {
+        logUri = 'output_log.txt';
+    }
 }
 console.log(logUri);
 


### PR DESCRIPTION
This will help non-Windows users since not many people will be running their Wine prefix in the default location. With this change, it's possible to create a link to the `output_log.txt` in the current directory and if the log file does not exist in the default location but does in the CWD then that will be used. 