### PR TITLE
Refactored deck details screen into it's own file and split into simplier sub functions

### DIFF
--- a/window_main/deck_details.js
+++ b/window_main/deck_details.js
@@ -1,24 +1,10 @@
 /*
 global
-    setsList,
-    cardsDb,
-    makeId,
-    ConicGradient,
-    daysPast,
-    timeSince,
-    toMMSS,
-    toHHMM,
-    selectAdd,
-    addCardHover,
-    get_set_scryfall,
-    get_colation_set,
-    getEventId,
-    addCardSeparator,
-    addCardTile,
-    getReadableEvent,
-    get_collection_export,
-    get_collection_stats,
-    get_deck_colors,
+    change_background,
+    drawDeck,
+    drawDeckVisual,
+    ipc_send,
+    change_background,
     get_deck_types_ammount,
     get_deck_curve,
     get_deck_colors_ammount,
@@ -26,24 +12,17 @@ global
     get_deck_missing,
     get_deck_export,
     get_deck_export_txt,
-    get_rank_index_16,
-    get_rank_index,
-    draftRanks
-    get_card_type_sort,
-    collectionSortSet,
-    collectionSortName,
-    collectionSortCmc,
-    collectionSortRarity,
-    compare_colors,
-    compare_cards,
-    timestamp
+    mana,
+    ConicGradient,
+    getDeckWinrate,
+    cardsDb
 */
 
 // We need to store a sorted list of card types so we create the card counts in the same order.
-var orderedCardTypes = ['cre','lan','ins','sor','enc','art','pla'];
+var orderedCardTypes = ['cre', 'lan', 'ins', 'sor', 'enc', 'art', 'pla'];
 var orderedCardRarities = ['common', 'uncommon', 'rare', 'mythic'];
 var orderedColorCodes = ['w', 'u', 'b', 'r', 'g', 'c'];
-var orderedManaColors = ['#E7CA8E', '#AABEDF','#A18E87','#DD8263','#B7C89E','#E3E3E3'];
+var orderedManaColors = ['#E7CA8E', '#AABEDF', '#A18E87', '#DD8263', '#B7C89E', '#E3E3E3'];
 
 function deckColorBar(deck) {
     let deckColors = $('<div class="deck_top_colors" style="align-self: center;"></div>');
@@ -55,7 +34,7 @@ function deckColorBar(deck) {
 
 function deckManaCurve(deck) {
     let manaCounts = get_deck_curve(deck);
-    let curveMax = Math.max(...manaCounts.map(v=>v||0));
+    let curveMax = Math.max(...manaCounts.map(v => v || 0));
 
     console.log('deckManaCurve', manaCounts, curveMax);
 
@@ -110,7 +89,7 @@ function deckWinrateCurve(deck) {
     let colorsWinrates = deckWinrates.colors
 
     //$('<span>w/l vs Color combinations</span>').appendTo(stats);
-    let curveMax = Math.max(...colorsWinrates.map(cwr=>Math.max(cwr.wins||0, cwr.losses||0)));
+    let curveMax = Math.max(...colorsWinrates.map(cwr => Math.max(cwr.wins || 0, cwr.losses || 0)));
     console.log('curveMax', curveMax);
 
     let curve = $('<div class="mana_curve"></div>');
@@ -140,10 +119,10 @@ function deckWinrateCurve(deck) {
 function deckStatsSection(deck, deck_type) {
     let stats = $('<div class="stats"></div>');
 
-    $('<div class="button_simple visualView">Visual View</div>').appendTo(stats);
-    $('<div class="button_simple openHistory">History of changes</div>').appendTo(stats);
-    $('<div class="button_simple exportDeck">Export to Arena</div>').appendTo(stats);
-    $('<div class="button_simple exportDeckStandard">Export to .txt</div>').appendTo(stats);
+    $(`<div class="button_simple visualView">Visual View</div>
+    <div class="button_simple openHistory">History of changes</div>
+    <div class="button_simple exportDeck">Export to Arena</div>
+    <div class="button_simple exportDeckStandard">Export to .txt</div>`).appendTo(stats);
 
     let cardTypes = get_deck_types_ammount(deck);
     let typesContainer = $('<div class="types_container"></div>');
@@ -166,6 +145,7 @@ function deckStatsSection(deck, deck_type) {
 
     // Deck colors
     let colorCounts = get_deck_colors_ammount(deck);
+    let pieChart;
     pieChart = colorPieChart(colorCounts, 'Mana Symbols');
     pieChart.appendTo(pieContainer);
 
@@ -230,21 +210,21 @@ function openDeck(deck, deck_type) {
     container.append(fld);
 
     // Attach event handlers
-    $(".visualView").click(e => drawDeckVisual(deckListSection, statsSection, deck));
+    $(".visualView").click(() => drawDeckVisual(deckListSection, statsSection, deck));
 
-    $(".openHistory").click(e => ipc_send('get_deck_changes', deck.id));
+    $(".openHistory").click(() => ipc_send('get_deck_changes', deck.id));
 
-    $(".exportDeck").click(e => {
+    $(".exportDeck").click(() => {
         let list = get_deck_export(deck);
         ipc_send('set_clipboard', list);
     });
 
-    $(".exportDeckStandard").click(e => {
+    $(".exportDeckStandard").click(() => {
         let list = get_deck_export_txt(deck);
         ipc_send('export_txt', {str: list, name: deck.name});
     });
 
-    $(".back").click(e => {
+    $(".back").click(() => {
         change_background("default");
         $('.moving_ux').animate({'left': '0px'}, 250, 'easeInOutCubic'); 
     });

--- a/window_main/deck_details.js
+++ b/window_main/deck_details.js
@@ -67,7 +67,7 @@ function open_deck(deck, type) {
 
     let dl = $('<div class="decklist"></div>');
     drawDeck(dl, deck);
-    var stats = $('<div class="stats"></div>');
+    let stats = $('<div class="stats"></div>');
 
 
     $('<div class="button_simple visualView">Visual View</div>').appendTo(stats);
@@ -75,8 +75,8 @@ function open_deck(deck, type) {
     $('<div class="button_simple exportDeck">Export to Arena</div>').appendTo(stats);
     $('<div class="button_simple exportDeckStandard">Export to .txt</div>').appendTo(stats);
 
-    var types = get_deck_types_ammount(deck);
-    var typesdiv = $('<div class="types_container"></div>');
+    let types = get_deck_types_ammount(deck);
+    let typesdiv = $('<div class="types_container"></div>');
     $('<div class="type_icon_cont"><div title="Creatures"       class="type_icon type_cre"></div><span>'+types.cre+'</span></div>').appendTo(typesdiv);
     $('<div class="type_icon_cont"><div title="Lands"           class="type_icon type_lan"></div><span>'+types.lan+'</span></div>').appendTo(typesdiv);
     $('<div class="type_icon_cont"><div title="Instants"        class="type_icon type_ins"></div><span>'+types.ins+'</span></div>').appendTo(typesdiv);
@@ -86,10 +86,10 @@ function open_deck(deck, type) {
     $('<div class="type_icon_cont"><div title="Planeswalkers"   class="type_icon type_pla"></div><span>'+types.pla+'</span></div>').appendTo(typesdiv);
     typesdiv.appendTo(stats);
 
-    var curvediv = $('<div class="mana_curve"></div>');
-    var curve = get_deck_curve(deck);
+    let curvediv = $('<div class="mana_curve"></div>');
+    let curve = get_deck_curve(deck);
 
-    var curveMax = 0;
+    let curveMax = 0;
     for (let i=0; i<curve.length; i++) {
         if (curve[i] == undefined) {
             curve[i] = 0;
@@ -109,23 +109,23 @@ function open_deck(deck, type) {
     }
     curvediv.appendTo(stats);
 
-    //var missing = get_deck_missing(deck);
-    var cont = $('<div class="pie_container_outer"></div>');
+    //let missing = get_deck_missing(deck);
+    let cont = $('<div class="pie_container_outer"></div>');
 
     // Deck colors
-    var colorspie = get_deck_colors_ammount(deck);
-    var wp = colorspie.w / colorspie.total * 100;
-    var up = wp+colorspie.u / colorspie.total * 100;
-    var bp = up+colorspie.b / colorspie.total * 100;
-    var rp = bp+colorspie.r / colorspie.total * 100;
-    var gp = rp+colorspie.g / colorspie.total * 100;
-    var cp = gp+colorspie.c / colorspie.total * 100;
+    let colorspie = get_deck_colors_ammount(deck);
+    let wp = colorspie.w / colorspie.total * 100;
+    let up = wp+colorspie.u / colorspie.total * 100;
+    let bp = up+colorspie.b / colorspie.total * 100;
+    let rp = bp+colorspie.r / colorspie.total * 100;
+    let gp = rp+colorspie.g / colorspie.total * 100;
+    let cp = gp+colorspie.c / colorspie.total * 100;
 
-    var gradient = new ConicGradient({
+    let gradient = new ConicGradient({
         stops: '#E7CA8E '+wp+'%, #AABEDF 0 '+up+'%, #A18E87 0 '+bp+'%, #DD8263 0 '+rp+'%, #B7C89E 0 '+gp+'%, #E3E3E3 0 '+cp+'%', // required
         size: 400 // Default: Math.max(innerWidth, innerHeight)
     });
-    var piechart = $('<div class="pie_container"><span>Mana Symbols</span><svg class="pie">'+gradient.svg+'</svg></div>');
+    let piechart = $('<div class="pie_container"><span>Mana Symbols</span><svg class="pie">'+gradient.svg+'</svg></div>');
     piechart.appendTo(cont);
 
     // Lands colors
@@ -147,7 +147,7 @@ function open_deck(deck, type) {
     cont.appendTo(stats);
 
     if (type == 0 || type == 2) {
-        var wr = getDeckWinrate(deck.id, deck.lastUpdated);
+        let wr = getDeckWinrate(deck.id, deck.lastUpdated);
         if (wr != 0) {
             //$('<span>w/l vs Color combinations</span>').appendTo(stats);
             curvediv = $('<div class="mana_curve"></div>');
@@ -174,10 +174,10 @@ function open_deck(deck, type) {
             curvediv = $('<div class="mana_curve_costs"></div>');
             for (let i=0; i<wr.colors.length; i++) {
                 if (wr.colors[i].wins + wr.colors[i].losses > 2) {
-                    var cn = $('<div class="mana_curve_column_number">'+wr.colors[i].wins+'/'+wr.colors[i].losses+'</div>');
+                    let cn = $('<div class="mana_curve_column_number">'+wr.colors[i].wins+'/'+wr.colors[i].losses+'</div>');
                     cn.append($('<div style="margin: 0 auto !important" class=""></div>'));
 
-                    var colors = wr.colors[i].colors;
+                    let colors = wr.colors[i].colors;
                     colors.forEach(function(color) {
                         cn.append($('<div style="margin: 0 auto !important" class="mana_s16 mana_'+mana[color]+'"></div>'));
                     })
@@ -188,20 +188,20 @@ function open_deck(deck, type) {
         }
     }
 
-    var missingWildcards = get_deck_missing(deck);
+    let missingWildcards = get_deck_missing(deck);
 
-    var cost = $('<div class="wildcards_cost"><span>Wildcards Needed</span></div>');
+    let cost = $('<div class="wildcards_cost"><span>Wildcards Needed</span></div>');
 
-    var _c = $('<div class="wc_cost wc_common">'+missingWildcards.common+'</div>');
+    let _c = $('<div class="wc_cost wc_common">'+missingWildcards.common+'</div>');
     _c.attr("title", "Common");
     _c.appendTo(cost);
-    var _u = $('<div class="wc_cost wc_uncommon">'+missingWildcards.uncommon+'</div>');
+    let _u = $('<div class="wc_cost wc_uncommon">'+missingWildcards.uncommon+'</div>');
     _u.appendTo(cost);
     _u.attr("title", "Uncommon");
-    var _r = $('<div class="wc_cost wc_rare">'+missingWildcards.rare+'</div>');
+    let _r = $('<div class="wc_cost wc_rare">'+missingWildcards.rare+'</div>');
     _r.appendTo(cost);
     _r.attr("title", "Rare");
-    var _m = $('<div class="wc_cost wc_mythic">'+missingWildcards.mythic+'</div>');
+    let _m = $('<div class="wc_cost wc_mythic">'+missingWildcards.mythic+'</div>');
     _m.appendTo(cost);
     _m.attr("title", "Mythic Rare");
 
@@ -212,23 +212,21 @@ function open_deck(deck, type) {
     $("#ux_1").append(top);
     $("#ux_1").append(fld);
 
-    //
     $(".visualView").click(function () {
         drawDeckVisual(dl, stats, deck);
     });
 
-    //
     $(".openHistory").click(function () {
         ipc_send('get_deck_changes', deck.id);
     });
 
     $(".exportDeck").click(function () {
-        var list = get_deck_export(deck);
+        let list = get_deck_export(deck);
         ipc_send('set_clipboard', list);
     });
 
     $(".exportDeckStandard").click(function () {
-        var list = get_deck_export_txt(deck);
+        let list = get_deck_export_txt(deck);
         ipc_send('export_txt', {str: list, name: deck.name});
     });
 

--- a/window_main/deck_details.js
+++ b/window_main/deck_details.js
@@ -39,203 +39,215 @@ global
     timestamp
 */
 
+// We need to store a sorted list of card types so we create the card counts in the same order.
+var orderedCardTypes = ['cre','lan','ins','sor','enc','art','pla'];
+var orderedCardRarities = ['common', 'uncommon', 'rare', 'mythic'];
+var orderedColorCodes = ['w', 'u', 'b', 'r', 'g', 'c'];
+var orderedManaColors = ['#E7CA8E', '#AABEDF','#A18E87','#DD8263','#B7C89E','#E3E3E3'];
 
-
-function open_deck(deck, type) {
-    /*
-        type is either 1 or 2.
-        1 = event deck
-        2 = normal deck
-    */
-
-    $("#ux_1").html('');
-
-    let top = $('<div class="decklist_top"><div class="button back"></div><div class="deck_name">'+deck.name+'</div></div>');
-    let flr = $('<div class="deck_top_colors" style="align-self: center;"></div>');
-
-    deck.colors.forEach(function(color) {
-        let m = $('<div class="mana_s20 mana_'+mana[color]+'"></div>');
-        flr.append(m);
+function deckColorBar(deck) {
+    let deckColors = $('<div class="deck_top_colors" style="align-self: center;"></div>');
+    deck.colors.forEach(color => {
+        deckColors.append($(`<div class="mana_s20 mana_${mana[color]}"></div>`));
     });
-    top.append(flr);
+    return deckColors;
+}
 
-    let tileGrpid = deck.deckTileId;
-    if (cardsDb.get(tileGrpid)) {
-        change_background("", tileGrpid);
+function deckManaCurve(deck) {
+    let manaCounts = get_deck_curve(deck);
+    let curveMax = Math.max(...manaCounts);
+
+    let curve = $('<div class="mana_curve"></div>');
+    let numbers = $('<div class="mana_curve_numbers"></div>');
+    manaCounts.forEach((count, i) => {
+        curve.append($(`<div class="mana_curve_column" style="height: ${manaCounts[i]/curveMax*100}%"></div>`))
+        numbers.append($(`<div class="mana_curve_column_number"><div style="margin: 0 auto !important" class="mana_s16 mana_${i}"></div></div>`))
+    })
+
+    let container = $('<div>').append(curve, numbers);
+    return container;
+}
+
+function colorPieChart(colorCounts, title) {
+    /*
+    used for land / card pie charts.
+    colorCounts should be object with values for each of the color codes wubrgc and total.
+    */
+    console.log('making colorPieChart', colorCounts, title);
+
+    var stops = [];
+    var start = 0;
+    orderedColorCodes.forEach((colorCode, i) => {
+        let currentColor = orderedManaColors[i];
+        var stop = start + (colorCounts[colorCode] || 0) / colorCounts.total * 100;
+        stops.push(`${currentColor} 0 ${stop}%`);
+        // console.log('\t', start, stop, currentColor);
+        start = stop;
+    });
+    let gradient = new ConicGradient({
+        stops: stops.join(', '),
+        size: 400
+        // Default size: Math.max(innerWidth, innerHeight)
+    });
+    let chart = $(`<div class="pie_container"><span>${title}</span><svg class="pie">${gradient.svg}</svg></div>`);
+    return chart;
+}
+
+function deckWinrateCurve(deck) {
+
+    // getDeckWinrate returns
+    // {total: winrate, wins: wins, losses: loss, lastEdit: winrateLastEdit, colors: colorsWinrates};
+    // or 0 if there is no data
+
+    let deckWinrates = getDeckWinrate(deck.id, deck.lastUpdated);
+    if (!deckWinrates) {
+        console.log('no deck winrate data');
+        return;
     }
-    let fld = $('<div class="flex_item"></div>');
 
-    let dl = $('<div class="decklist"></div>');
-    drawDeck(dl, deck);
+    let colorsWinrates = deckWinrates.colors
+
+    //$('<span>w/l vs Color combinations</span>').appendTo(stats);
+    let curveMax = Math.max(...colorsWinrates.map(cwr=>Math.max(cwr.wins, cwr.losses)));
+    console.log('curveMax', curveMax);
+
+    let curve = $('<div class="mana_curve"></div>');
+    let numbers = $('<div class="mana_curve_costs"></div>');
+
+    colorsWinrates.forEach(cwr => {
+        if (cwr.wins + cwr.losses > 2) {
+            curve.append($(`<div class="mana_curve_column back_green" style="height: ${(cwr.wins/curveMax*100)}%"></div>`));
+            curve.append($(`<div class="mana_curve_column back_red" style="height: ${(cwr.losses/curveMax*100)}%"></div>`));
+
+            let curveNumber = $(`<div class="mana_curve_column_number">
+                ${cwr.wins}/${cwr.losses}
+                <div style="margin: 0 auto !important" class=""></div>
+            </div>`);
+
+            let colors = cwr.colors;
+            colors.forEach(function(color) {
+                curveNumber.append($(`<div style="margin: 0 auto !important" class="mana_s16 mana_${mana[color]}"></div>`));
+            })
+            numbers.append(curveNumber);
+        }
+    });
+    let container = $('<div>').append(curve, numbers);
+    return container;
+}
+
+function deckStatsSection(deck, deck_type) {
     let stats = $('<div class="stats"></div>');
-
 
     $('<div class="button_simple visualView">Visual View</div>').appendTo(stats);
     $('<div class="button_simple openHistory">History of changes</div>').appendTo(stats);
     $('<div class="button_simple exportDeck">Export to Arena</div>').appendTo(stats);
     $('<div class="button_simple exportDeckStandard">Export to .txt</div>').appendTo(stats);
 
-    let types = get_deck_types_ammount(deck);
-    let typesdiv = $('<div class="types_container"></div>');
-    $('<div class="type_icon_cont"><div title="Creatures"       class="type_icon type_cre"></div><span>'+types.cre+'</span></div>').appendTo(typesdiv);
-    $('<div class="type_icon_cont"><div title="Lands"           class="type_icon type_lan"></div><span>'+types.lan+'</span></div>').appendTo(typesdiv);
-    $('<div class="type_icon_cont"><div title="Instants"        class="type_icon type_ins"></div><span>'+types.ins+'</span></div>').appendTo(typesdiv);
-    $('<div class="type_icon_cont"><div title="Sorceries"       class="type_icon type_sor"></div><span>'+types.sor+'</span></div>').appendTo(typesdiv);
-    $('<div class="type_icon_cont"><div title="Enchantments"    class="type_icon type_enc"></div><span>'+types.enc+'</span></div>').appendTo(typesdiv);
-    $('<div class="type_icon_cont"><div title="Artifacts"       class="type_icon type_art"></div><span>'+types.art+'</span></div>').appendTo(typesdiv);
-    $('<div class="type_icon_cont"><div title="Planeswalkers"   class="type_icon type_pla"></div><span>'+types.pla+'</span></div>').appendTo(typesdiv);
-    typesdiv.appendTo(stats);
+    let cardTypes = get_deck_types_ammount(deck);
+    let typesContainer = $('<div class="types_container"></div>');
+    orderedCardTypes.forEach(cardTypeKey => {
+        $(`<div class="type_icon_cont">
+            <div title="Creatures" class="type_icon type_${cardTypeKey}"></div>
+            <span>${cardTypes[cardTypeKey]}</span>
+        </div>`)
+        .appendTo(typesContainer);
+    });
+    typesContainer.appendTo(stats);
 
-    let curvediv = $('<div class="mana_curve"></div>');
-    let curve = get_deck_curve(deck);
 
-    let curveMax = 0;
-    for (let i=0; i<curve.length; i++) {
-        if (curve[i] == undefined) {
-            curve[i] = 0;
-        }
-        if (curve[i] > curveMax) {
-            curveMax = curve[i];
-        }
-    }
-
-    for (let i=0; i<curve.length; i++) {
-        curvediv.append($('<div class="mana_curve_column" style="height: '+(curve[i]/curveMax*100)+'%"></div>'))
-    }
-    curvediv.appendTo(stats);
-    curvediv = $('<div class="mana_curve_numbers"></div>');
-    for (let i=0; i<curve.length; i++) {
-        curvediv.append($('<div class="mana_curve_column_number"><div style="margin: 0 auto !important" class="mana_s16 mana_'+i+'"></div></div>'))
-    }
-    curvediv.appendTo(stats);
+    // Mana Curve
+    deckManaCurve(deck).appendTo(stats);
 
     //let missing = get_deck_missing(deck);
-    let cont = $('<div class="pie_container_outer"></div>');
+    let pieContainer = $('<div class="pie_container_outer"></div>');
+    pieContainer.appendTo(stats);
 
     // Deck colors
-    let colorspie = get_deck_colors_ammount(deck);
-    let wp = colorspie.w / colorspie.total * 100;
-    let up = wp+colorspie.u / colorspie.total * 100;
-    let bp = up+colorspie.b / colorspie.total * 100;
-    let rp = bp+colorspie.r / colorspie.total * 100;
-    let gp = rp+colorspie.g / colorspie.total * 100;
-    let cp = gp+colorspie.c / colorspie.total * 100;
-
-    let gradient = new ConicGradient({
-        stops: '#E7CA8E '+wp+'%, #AABEDF 0 '+up+'%, #A18E87 0 '+bp+'%, #DD8263 0 '+rp+'%, #B7C89E 0 '+gp+'%, #E3E3E3 0 '+cp+'%', // required
-        size: 400 // Default: Math.max(innerWidth, innerHeight)
-    });
-    let piechart = $('<div class="pie_container"><span>Mana Symbols</span><svg class="pie">'+gradient.svg+'</svg></div>');
-    piechart.appendTo(cont);
+    let colorCounts = get_deck_colors_ammount(deck);
+    pieChart = colorPieChart(colorCounts, 'Mana Symbols');
+    pieChart.appendTo(pieContainer);
 
     // Lands colors
-    colorspie = get_deck_lands_ammount(deck);
-    wp = colorspie.w / colorspie.total * 100;
-    up = wp+colorspie.u / colorspie.total * 100;
-    bp = up+colorspie.b / colorspie.total * 100;
-    rp = bp+colorspie.r / colorspie.total * 100;
-    gp = rp+colorspie.g / colorspie.total * 100;
-    cp = gp+colorspie.c / colorspie.total * 100;
+    let landCounts = get_deck_lands_ammount(deck);
+    pieChart = colorPieChart(landCounts, 'Mana Sources');
+    pieChart.appendTo(pieContainer);
 
-    gradient = new ConicGradient({
-        stops: '#E7CA8E '+wp+'%, #AABEDF 0 '+up+'%, #A18E87 0 '+bp+'%, #DD8263 0 '+rp+'%, #B7C89E 0 '+gp+'%, #E3E3E3 0 '+cp+'%', // required
-        size: 400 // Default: Math.max(innerWidth, innerHeight)
-    });
-    piechart = $('<div class="pie_container"><span>Mana Sources</span><svg class="pie">'+gradient.svg+'</svg></div>');
-    piechart.appendTo(cont);
 
-    cont.appendTo(stats);
-
-    if (type == 0 || type == 2) {
-        let wr = getDeckWinrate(deck.id, deck.lastUpdated);
-        if (wr != 0) {
-            //$('<span>w/l vs Color combinations</span>').appendTo(stats);
-            curvediv = $('<div class="mana_curve"></div>');
-            // curve = get_deck_curve(deck);
-
-            curveMax = 0;
-            for (let i=0; i<wr.colors.length; i++) {
-                if (wr.colors[i].wins > curveMax) {
-                    curveMax = wr.colors[i].wins;
-                }
-                if (wr.colors[i].losses > curveMax) {
-                    curveMax = wr.colors[i].losses;
-                }
-            }
-
-            for (let i=0; i<wr.colors.length; i++) {
-                if (wr.colors[i].wins + wr.colors[i].losses > 2) {
-                    curvediv.append($('<div class="mana_curve_column back_green" style="height: '+(wr.colors[i].wins/curveMax*100)+'%"></div>'))
-                    curvediv.append($('<div class="mana_curve_column back_red" style="height: '+(wr.colors[i].losses/curveMax*100)+'%"></div>'))
-                }
-            }
-
-            curvediv.appendTo(stats);
-            curvediv = $('<div class="mana_curve_costs"></div>');
-            for (let i=0; i<wr.colors.length; i++) {
-                if (wr.colors[i].wins + wr.colors[i].losses > 2) {
-                    let cn = $('<div class="mana_curve_column_number">'+wr.colors[i].wins+'/'+wr.colors[i].losses+'</div>');
-                    cn.append($('<div style="margin: 0 auto !important" class=""></div>'));
-
-                    let colors = wr.colors[i].colors;
-                    colors.forEach(function(color) {
-                        cn.append($('<div style="margin: 0 auto !important" class="mana_s16 mana_'+mana[color]+'"></div>'));
-                    })
-                    curvediv.append(cn);
-                }
-            }
-            curvediv.appendTo(stats);
+    if (deck_type == 0 || deck_type == 2) {
+        let winrateCurveSection = deckWinrateCurve(deck);
+        if (winrateCurveSection) {
+            winrateCurveSection.appendTo(stats);
         }
+    } else {
+        console.log('skipping winrate curve. deck_type is', deck_type);
     }
 
+    // Deck crafting cost section
     let missingWildcards = get_deck_missing(deck);
-
-    let cost = $('<div class="wildcards_cost"><span>Wildcards Needed</span></div>');
-
-    let _c = $('<div class="wc_cost wc_common">'+missingWildcards.common+'</div>');
-    _c.attr("title", "Common");
-    _c.appendTo(cost);
-    let _u = $('<div class="wc_cost wc_uncommon">'+missingWildcards.uncommon+'</div>');
-    _u.appendTo(cost);
-    _u.attr("title", "Uncommon");
-    let _r = $('<div class="wc_cost wc_rare">'+missingWildcards.rare+'</div>');
-    _r.appendTo(cost);
-    _r.attr("title", "Rare");
-    let _m = $('<div class="wc_cost wc_mythic">'+missingWildcards.mythic+'</div>');
-    _m.appendTo(cost);
-    _m.attr("title", "Mythic Rare");
-
-    cost.appendTo(stats);
-
-    dl.appendTo(fld);
-    stats.appendTo(fld);
-    $("#ux_1").append(top);
-    $("#ux_1").append(fld);
-
-    $(".visualView").click(function () {
-        drawDeckVisual(dl, stats, deck);
+    let costSection = $('<div class="wildcards_cost"><span>Wildcards Needed</span></div>');
+    orderedCardRarities.forEach(cardRarity => {
+        $(`<div title="${cardRarity}" class="wc_cost wc_${cardRarity}">
+            ${missingWildcards[cardRarity]}</div>`)
+            .appendTo(costSection);
     });
+    costSection.appendTo(stats);
 
-    $(".openHistory").click(function () {
-        ipc_send('get_deck_changes', deck.id);
-    });
+    return stats;
+}
 
-    $(".exportDeck").click(function () {
+function openDeck(deck, deck_type) {
+    /*
+        deck_type is either 1 or 2.
+        1 = event deck
+        2 = normal deck
+    */
+
+    // #ux_1 is right side, #ux_0 is left side
+    let container = $("#ux_1");
+    container.empty();
+
+    let top = $(`<div class="decklist_top"><div class="button back"></div><div class="deck_name">${deck.name}</div></div>`);
+
+    deckColorBar(deck)
+        .appendTo(top);
+
+    let tileGrpId = deck.deckTileId;
+    if (cardsDb.get(tileGrpId)) {
+        change_background("", tileGrpId);
+    }
+
+    let deckListSection = $('<div class="decklist"></div>');
+    drawDeck(deckListSection, deck);
+
+    let statsSection = deckStatsSection(deck, deck_type);
+
+    let fld = $('<div class="flex_item"></div>');
+    deckListSection.appendTo(fld);
+    statsSection.appendTo(fld);
+    container.append(top);
+    container.append(fld);
+
+    // Attach event handlers
+    $(".visualView").click(e => drawDeckVisual(deckListSection, statsSection, deck));
+
+    $(".openHistory").click(e => ipc_send('get_deck_changes', deck.id));
+
+    $(".exportDeck").click(e => {
         let list = get_deck_export(deck);
         ipc_send('set_clipboard', list);
     });
 
-    $(".exportDeckStandard").click(function () {
+    $(".exportDeckStandard").click(e => {
         let list = get_deck_export_txt(deck);
         ipc_send('export_txt', {str: list, name: deck.name});
     });
 
-    $(".back").click(function () {
+    $(".back").click(e => {
         change_background("default");
         $('.moving_ux').animate({'left': '0px'}, 250, 'easeInOutCubic'); 
     });
 }
 
 module.exports = {
-    open_deck: open_deck
+    open_deck: openDeck
 }

--- a/window_main/deck_details.js
+++ b/window_main/deck_details.js
@@ -55,12 +55,14 @@ function deckColorBar(deck) {
 
 function deckManaCurve(deck) {
     let manaCounts = get_deck_curve(deck);
-    let curveMax = Math.max(...manaCounts);
+    let curveMax = Math.max(...manaCounts.map(v=>v||0));
+
+    console.log('deckManaCurve', manaCounts, curveMax);
 
     let curve = $('<div class="mana_curve"></div>');
     let numbers = $('<div class="mana_curve_numbers"></div>');
     manaCounts.forEach((count, i) => {
-        curve.append($(`<div class="mana_curve_column" style="height: ${manaCounts[i]/curveMax*100}%"></div>`))
+        curve.append($(`<div class="mana_curve_column" style="height: ${count/curveMax*100}%"></div>`))
         numbers.append($(`<div class="mana_curve_column_number"><div style="margin: 0 auto !important" class="mana_s16 mana_${i}"></div></div>`))
     })
 
@@ -108,7 +110,7 @@ function deckWinrateCurve(deck) {
     let colorsWinrates = deckWinrates.colors
 
     //$('<span>w/l vs Color combinations</span>').appendTo(stats);
-    let curveMax = Math.max(...colorsWinrates.map(cwr=>Math.max(cwr.wins, cwr.losses)));
+    let curveMax = Math.max(...colorsWinrates.map(cwr=>Math.max(cwr.wins||0, cwr.losses||0)));
     console.log('curveMax', curveMax);
 
     let curve = $('<div class="mana_curve"></div>');

--- a/window_main/deck_details.js
+++ b/window_main/deck_details.js
@@ -1,0 +1,243 @@
+/*
+global
+    setsList,
+    cardsDb,
+    makeId,
+    ConicGradient,
+    daysPast,
+    timeSince,
+    toMMSS,
+    toHHMM,
+    selectAdd,
+    addCardHover,
+    get_set_scryfall,
+    get_colation_set,
+    getEventId,
+    addCardSeparator,
+    addCardTile,
+    getReadableEvent,
+    get_collection_export,
+    get_collection_stats,
+    get_deck_colors,
+    get_deck_types_ammount,
+    get_deck_curve,
+    get_deck_colors_ammount,
+    get_deck_lands_ammount,
+    get_deck_missing,
+    get_deck_export,
+    get_deck_export_txt,
+    get_rank_index_16,
+    get_rank_index,
+    draftRanks
+    get_card_type_sort,
+    collectionSortSet,
+    collectionSortName,
+    collectionSortCmc,
+    collectionSortRarity,
+    compare_colors,
+    compare_cards,
+    timestamp
+*/
+
+
+
+function open_deck(deck, type) {
+    /*
+        type is either 1 or 2.
+        1 = event deck
+        2 = normal deck
+    */
+
+    $("#ux_1").html('');
+
+    let top = $('<div class="decklist_top"><div class="button back"></div><div class="deck_name">'+deck.name+'</div></div>');
+    let flr = $('<div class="deck_top_colors" style="align-self: center;"></div>');
+
+    deck.colors.forEach(function(color) {
+        let m = $('<div class="mana_s20 mana_'+mana[color]+'"></div>');
+        flr.append(m);
+    });
+    top.append(flr);
+
+    let tileGrpid = deck.deckTileId;
+    if (cardsDb.get(tileGrpid)) {
+        change_background("", tileGrpid);
+    }
+    let fld = $('<div class="flex_item"></div>');
+
+    let dl = $('<div class="decklist"></div>');
+    drawDeck(dl, deck);
+    var stats = $('<div class="stats"></div>');
+
+
+    $('<div class="button_simple visualView">Visual View</div>').appendTo(stats);
+    $('<div class="button_simple openHistory">History of changes</div>').appendTo(stats);
+    $('<div class="button_simple exportDeck">Export to Arena</div>').appendTo(stats);
+    $('<div class="button_simple exportDeckStandard">Export to .txt</div>').appendTo(stats);
+
+    var types = get_deck_types_ammount(deck);
+    var typesdiv = $('<div class="types_container"></div>');
+    $('<div class="type_icon_cont"><div title="Creatures"       class="type_icon type_cre"></div><span>'+types.cre+'</span></div>').appendTo(typesdiv);
+    $('<div class="type_icon_cont"><div title="Lands"           class="type_icon type_lan"></div><span>'+types.lan+'</span></div>').appendTo(typesdiv);
+    $('<div class="type_icon_cont"><div title="Instants"        class="type_icon type_ins"></div><span>'+types.ins+'</span></div>').appendTo(typesdiv);
+    $('<div class="type_icon_cont"><div title="Sorceries"       class="type_icon type_sor"></div><span>'+types.sor+'</span></div>').appendTo(typesdiv);
+    $('<div class="type_icon_cont"><div title="Enchantments"    class="type_icon type_enc"></div><span>'+types.enc+'</span></div>').appendTo(typesdiv);
+    $('<div class="type_icon_cont"><div title="Artifacts"       class="type_icon type_art"></div><span>'+types.art+'</span></div>').appendTo(typesdiv);
+    $('<div class="type_icon_cont"><div title="Planeswalkers"   class="type_icon type_pla"></div><span>'+types.pla+'</span></div>').appendTo(typesdiv);
+    typesdiv.appendTo(stats);
+
+    var curvediv = $('<div class="mana_curve"></div>');
+    var curve = get_deck_curve(deck);
+
+    var curveMax = 0;
+    for (let i=0; i<curve.length; i++) {
+        if (curve[i] == undefined) {
+            curve[i] = 0;
+        }
+        if (curve[i] > curveMax) {
+            curveMax = curve[i];
+        }
+    }
+
+    for (let i=0; i<curve.length; i++) {
+        curvediv.append($('<div class="mana_curve_column" style="height: '+(curve[i]/curveMax*100)+'%"></div>'))
+    }
+    curvediv.appendTo(stats);
+    curvediv = $('<div class="mana_curve_numbers"></div>');
+    for (let i=0; i<curve.length; i++) {
+        curvediv.append($('<div class="mana_curve_column_number"><div style="margin: 0 auto !important" class="mana_s16 mana_'+i+'"></div></div>'))
+    }
+    curvediv.appendTo(stats);
+
+    //var missing = get_deck_missing(deck);
+    var cont = $('<div class="pie_container_outer"></div>');
+
+    // Deck colors
+    var colorspie = get_deck_colors_ammount(deck);
+    var wp = colorspie.w / colorspie.total * 100;
+    var up = wp+colorspie.u / colorspie.total * 100;
+    var bp = up+colorspie.b / colorspie.total * 100;
+    var rp = bp+colorspie.r / colorspie.total * 100;
+    var gp = rp+colorspie.g / colorspie.total * 100;
+    var cp = gp+colorspie.c / colorspie.total * 100;
+
+    var gradient = new ConicGradient({
+        stops: '#E7CA8E '+wp+'%, #AABEDF 0 '+up+'%, #A18E87 0 '+bp+'%, #DD8263 0 '+rp+'%, #B7C89E 0 '+gp+'%, #E3E3E3 0 '+cp+'%', // required
+        size: 400 // Default: Math.max(innerWidth, innerHeight)
+    });
+    var piechart = $('<div class="pie_container"><span>Mana Symbols</span><svg class="pie">'+gradient.svg+'</svg></div>');
+    piechart.appendTo(cont);
+
+    // Lands colors
+    colorspie = get_deck_lands_ammount(deck);
+    wp = colorspie.w / colorspie.total * 100;
+    up = wp+colorspie.u / colorspie.total * 100;
+    bp = up+colorspie.b / colorspie.total * 100;
+    rp = bp+colorspie.r / colorspie.total * 100;
+    gp = rp+colorspie.g / colorspie.total * 100;
+    cp = gp+colorspie.c / colorspie.total * 100;
+
+    gradient = new ConicGradient({
+        stops: '#E7CA8E '+wp+'%, #AABEDF 0 '+up+'%, #A18E87 0 '+bp+'%, #DD8263 0 '+rp+'%, #B7C89E 0 '+gp+'%, #E3E3E3 0 '+cp+'%', // required
+        size: 400 // Default: Math.max(innerWidth, innerHeight)
+    });
+    piechart = $('<div class="pie_container"><span>Mana Sources</span><svg class="pie">'+gradient.svg+'</svg></div>');
+    piechart.appendTo(cont);
+
+    cont.appendTo(stats);
+
+    if (type == 0 || type == 2) {
+        var wr = getDeckWinrate(deck.id, deck.lastUpdated);
+        if (wr != 0) {
+            //$('<span>w/l vs Color combinations</span>').appendTo(stats);
+            curvediv = $('<div class="mana_curve"></div>');
+            // curve = get_deck_curve(deck);
+
+            curveMax = 0;
+            for (let i=0; i<wr.colors.length; i++) {
+                if (wr.colors[i].wins > curveMax) {
+                    curveMax = wr.colors[i].wins;
+                }
+                if (wr.colors[i].losses > curveMax) {
+                    curveMax = wr.colors[i].losses;
+                }
+            }
+
+            for (let i=0; i<wr.colors.length; i++) {
+                if (wr.colors[i].wins + wr.colors[i].losses > 2) {
+                    curvediv.append($('<div class="mana_curve_column back_green" style="height: '+(wr.colors[i].wins/curveMax*100)+'%"></div>'))
+                    curvediv.append($('<div class="mana_curve_column back_red" style="height: '+(wr.colors[i].losses/curveMax*100)+'%"></div>'))
+                }
+            }
+
+            curvediv.appendTo(stats);
+            curvediv = $('<div class="mana_curve_costs"></div>');
+            for (let i=0; i<wr.colors.length; i++) {
+                if (wr.colors[i].wins + wr.colors[i].losses > 2) {
+                    var cn = $('<div class="mana_curve_column_number">'+wr.colors[i].wins+'/'+wr.colors[i].losses+'</div>');
+                    cn.append($('<div style="margin: 0 auto !important" class=""></div>'));
+
+                    var colors = wr.colors[i].colors;
+                    colors.forEach(function(color) {
+                        cn.append($('<div style="margin: 0 auto !important" class="mana_s16 mana_'+mana[color]+'"></div>'));
+                    })
+                    curvediv.append(cn);
+                }
+            }
+            curvediv.appendTo(stats);
+        }
+    }
+
+    var missingWildcards = get_deck_missing(deck);
+
+    var cost = $('<div class="wildcards_cost"><span>Wildcards Needed</span></div>');
+
+    var _c = $('<div class="wc_cost wc_common">'+missingWildcards.common+'</div>');
+    _c.attr("title", "Common");
+    _c.appendTo(cost);
+    var _u = $('<div class="wc_cost wc_uncommon">'+missingWildcards.uncommon+'</div>');
+    _u.appendTo(cost);
+    _u.attr("title", "Uncommon");
+    var _r = $('<div class="wc_cost wc_rare">'+missingWildcards.rare+'</div>');
+    _r.appendTo(cost);
+    _r.attr("title", "Rare");
+    var _m = $('<div class="wc_cost wc_mythic">'+missingWildcards.mythic+'</div>');
+    _m.appendTo(cost);
+    _m.attr("title", "Mythic Rare");
+
+    cost.appendTo(stats);
+
+    dl.appendTo(fld);
+    stats.appendTo(fld);
+    $("#ux_1").append(top);
+    $("#ux_1").append(fld);
+
+    //
+    $(".visualView").click(function () {
+        drawDeckVisual(dl, stats, deck);
+    });
+
+    //
+    $(".openHistory").click(function () {
+        ipc_send('get_deck_changes', deck.id);
+    });
+
+    $(".exportDeck").click(function () {
+        var list = get_deck_export(deck);
+        ipc_send('set_clipboard', list);
+    });
+
+    $(".exportDeckStandard").click(function () {
+        var list = get_deck_export_txt(deck);
+        ipc_send('export_txt', {str: list, name: deck.name});
+    });
+
+    $(".back").click(function () {
+        change_background("default");
+        $('.moving_ux').animate({'left': '0px'}, 250, 'easeInOutCubic'); 
+    });
+}
+
+module.exports = {
+    open_deck: open_deck
+}

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -2405,6 +2405,7 @@ function setDecks(arg) {
 
 			$('.'+deck.id).on('click', function() {
 				var deck = decks[index];
+				currentOpenDeck = deck;
 				open_deck(deck, 2);
 				$('.moving_ux').animate({'left': '-100%'}, 250, 'easeInOutCubic'); 
 			});


### PR DESCRIPTION
I took the code from open_deck and put it into its own file, `deck_details.js`. I then re-factored the code into simpler sub components and cleaned it up a bit.

Internally to deck_details.js I have been using the standard javascript camel-case naming. So deck_details defines `openDeck` internally, but this is exported as `open_deck` to match the existing code in renderer. I think it would probably be best if used camel-case was used for everything but constants and classes.

The new code no longer has access to the global scope so should not set or read `currentOpenDeck`. Code which calls open_deck should first set the current deck if required.