### PR TITLE
Note the directory change in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ MTG Arena Tool is developed using Electron JS, To get started simply clone this 
 
 ```
 git clone https://github.com/Manuel-777/MTG-Arena-Tool
+cd MTG-Arena-Tool
 npm install
 npm start
 ```


### PR DESCRIPTION
It's kind of a silly little note, but if you run this command you should end up one directory down from where you need to npm install and npm start. I'm just recommending adding the "cd MTG-Arena-Tool" to avoid any confusion.

In my less than awake state I just ran them all and felt silly for a half second.

(You might also include notes about the prerequisite node package manager, but if the user is at that point it may not matter)