### PR TITLE
Fix total win rate for deck list without any wins

### DIFF
--- a/window_main/decks.js
+++ b/window_main/decks.js
@@ -258,6 +258,7 @@ function open_decks_tab() {
 		d = document.createElement("div");
 		d.classList.add('list_deck_winrate');
 		wrTotal = 1 / wrTotal * wrTotalWins;
+        wrTotal = wrTotal || 0;
 
 		let colClass = getWinrateClass(wrTotal);
 		d.innerHTML = `Wins: ${wrTotalWins} / Losses: ${wrTotalLosses} (<span class="${colClass}_bright">${Math.round(wrTotal*100)}%</span>)`;


### PR DESCRIPTION
In deck list if you apply filter to show decks where total wins is 0, than you will see text: "Wins: 0 / Losses: 0 (NaN%)". Now it will be "Wins: 0 / Losses: 0 (0%)"