### PR TITLE
 Don't throw if an event's match is not found

### DIFF
--- a/window_background/background.js
+++ b/window_background/background.js
@@ -2063,6 +2063,7 @@ function saveMatch(matchId) {
     .getVersion()
     .split(".")
     .reduce((acc, cur) => +acc * 256 + +cur);
+  match.toolRunFromSource = !electron.remote.app.isPackaged;
 
   console.log("Save match:", match);
   var matches_index = store.get("matches_index");

--- a/window_main/events.js
+++ b/window_main/events.js
@@ -88,15 +88,7 @@ function getMatchesHistoryIndex(matchIndex) {
     return matchIndex;
   }
 
-  let newStyleMatchIndex = `${matchIndex}-${playerData.arenaId}`;
-  if (matchesHistory.hasOwnProperty(newStyleMatchIndex)) {
-    return newStyleMatchIndex;
-  }
-
-  // data appears corrupt
-  throw new Exception(
-    `Could not find valid match index for match index "${matchIndex}"!`
-  );
+  return `${matchIndex}-${playerData.arenaId}`;
 }
 
 // Given a courses object returns all of the matches


### PR DESCRIPTION
This was preventing me from opening the events tab, just because one match of a recent event happened to have been played without Tool recording it.

Also, added a flag in match record for running from source.