### PR TITLE
Colorize event results to match deck winrates

### DIFF
--- a/window_main/events.js
+++ b/window_main/events.js
@@ -201,17 +201,14 @@ function createEventRow(course) {
   );
 
   var winLossText = "0:0";
-  var winLossClass = "list_match_result_win";
-
+  var matchResultClass = "list_match_result";
   var wlGate = course.ModuleInstanceData.WinLossGate;
   if (wlGate !== undefined) {
     winLossText = wlGate.CurrentWins + ":" + wlGate.CurrentLosses;
-    if (wlGate.MaxWins !== wlGate.CurrentWins) {
-      winLossClass = "list_match_result_loss";
-    }
   }
+  var winLossClass = getEventWinLossClass(wlGate);
 
-  flexRight.appendChild(createDivision([winLossClass], winLossText));
+  flexRight.appendChild(createDivision([matchResultClass, winLossClass], winLossText));
 
   return eventContainer;
 }
@@ -344,9 +341,7 @@ function createMatchRow(match) {
 
   // insert contents of flexRight
 
-  var resultClass = `list_match_result_${
-    match.player.win > match.opponent.win ? "win" : "loss"
-  }`;
+  var resultClass = "list_match_result";
   flexRight.appendChild(
     createDivision([resultClass], match.player.win + ":" + match.opponent.win)
   );

--- a/window_main/history.js
+++ b/window_main/history.js
@@ -325,9 +325,8 @@ function open_history_tab(loadMore) {
 
       d = createDivision(
         [
-          match.player.win > match.opponent.win
-            ? "list_match_result_win"
-            : "list_match_result_loss"
+          "list_match_result",
+          match.player.win > match.opponent.win ? "green" : "red"
         ],
         `${match.player.win}:${match.opponent.win}`
       );

--- a/window_main/index.css
+++ b/window_main/index.css
@@ -556,20 +556,11 @@ span.top_nav_item_text {
     margin-right: 18px;
 }
 
-.list_match_result_win {
+.list_match_result {
 font-family:  var(--main-font-name);
     font-size: 20px;
     line-height: 64px;
     margin-right: 8px;
-    color: rgba(183, 200, 158, 1);
-}
-
-.list_match_result_loss {
-    line-height: 64px;
-    font-family:  var(--main-font-name);
-    font-size: 20px;
-    margin-right: 8px;
-    color: rgba(221, 130, 99, 1);
 }
 
 .list_match_result_score {

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -2675,6 +2675,14 @@ function getWinrateClass(wr) {
   return "white";
 }
 
+function getEventWinLossClass(wlGate) {
+  if (wlGate === undefined) return "white";
+  if (wlGate.MaxWins === wlGate.CurrentWins) return "blue";
+  if (wlGate.CurrentWins > wlGate.CurrentLosses) return "green";
+  if (wlGate.CurrentWins * 2 > wlGate.CurrentLosses) return "orange";
+  return "red";
+}
+
 //
 function getDeckWinrate(deckid, lastEdit) {
   var wins = 0;


### PR DESCRIPTION
### Current Event Results
<img width="516" alt="Event-results-before" src="https://user-images.githubusercontent.com/14894693/55653782-6ad35a80-57a4-11e9-8f45-6544763550e2.PNG">

### Proposed Colors on this PR
<img width="515" alt="Event-results-colored" src="https://user-images.githubusercontent.com/14894693/55653787-7030a500-57a4-11e9-93d3-831a76129a89.PNG">

### Approach
- clone logic from `renderer.getWinrateClass` into `renderer.getEventWinLossClass`
- modify `renderer.getEventWinLossClass` to handle event results data (former logic was inline in `events.js`)
- New logic is more "positive" about results that are "economically good":
  - total event victory now blue
  - winning more than losing now green
  - wins * 2 > losses now orange (arbitrary decision that seems to work for most event types)
  - losing horribly now red
- update `events.js` to call new function and pass class result to `createDivision`
- refactor prior CSS style to work with all result types
