### PR TITLE
Full-screen scroll logic bugfix

### DIFF
--- a/window_main/explore.js
+++ b/window_main/explore.js
@@ -95,7 +95,7 @@ function openExploreTab() {
 
   $(this).off();
   mainDiv.addEventListener("scroll", () => {
-    if (mainDiv.scrollTop + mainDiv.offsetHeight >= mainDiv.scrollHeight) {
+    if (Math.round(mainDiv.scrollTop + mainDiv.offsetHeight) >= mainDiv.scrollHeight) {
       queryExplore(filterSkip);
     }
   });

--- a/window_main/history.js
+++ b/window_main/history.js
@@ -389,7 +389,7 @@ function open_history_tab(loadMore) {
 
   historyColumn.addEventListener("scroll", () => {
     if (
-      historyColumn.scrollTop + historyColumn.offsetHeight >=
+      Math.round(historyColumn.scrollTop + historyColumn.offsetHeight) >=
       historyColumn.scrollHeight
     ) {
       open_history_tab(20);


### PR DESCRIPTION
- handles full-screen case properly in scroll action listener on the explore and history pages
  - imitates logic found in scroll-handlers currently in `economy.js` and `events.js`
- this makes me want to have a centralized place to handle display logic