### PR TITLE
Add Deck Filter to History Page

### DIFF
--- a/shared/util.js
+++ b/shared/util.js
@@ -1136,6 +1136,18 @@ function getReadableEvent(arg) {
 }
 
 //
+function getReadableDeckName(deck_id) {
+  if (typeof decks === 'undefined') {
+    return deck_id;
+  }
+  matches = decks.filter(deck => deck.id == deck_id);
+  if (matches.length) {
+    return matches[0].name;
+  }
+  return deck_id;
+}
+
+//
 function getEventId(arg) {
   var ret = arg;
   Object.keys(eventsList).forEach(function(key) {

--- a/shared/util.js
+++ b/shared/util.js
@@ -1156,6 +1156,25 @@ function getReadableDeckName(deck_id) {
 }
 
 //
+function getReadableDeckNameWithCost(deck_id) {
+  if (typeof decks === 'undefined') {
+    return deck_id;
+  }
+  matches = decks.filter(deck => deck.id == deck_id);
+  console.log(matches);
+  if (matches.length) {
+    let colorsString = '';
+    if (matches[0].colors) {
+      matches[0].colors.forEach(color => {
+          colorsString += `<div class="mana_s16 mana_${orderedColorCodes[color-1]}"></div>`;
+      });
+    }
+    return `${matches[0].name}<div class="flex_item">${colorsString}</div>`;
+  }
+  return deck_id;
+}
+
+//
 function getEventId(arg) {
   var ret = arg;
   Object.keys(eventsList).forEach(function(key) {

--- a/shared/util.js
+++ b/shared/util.js
@@ -835,13 +835,16 @@ function addCardTile(grpId, indent, quantity, element) {
  * Creates a select box
  * This is a "fixed" version of SelectAdd and should replace it.
  **/
-function createSelect(parent, options, current, callback, divClass) {
+function createSelect(parent, options, current, callback, divClass, optionFormatter) {
   let selectContainer = createDivision(["select_container", divClass]);
   selectContainer.id = divClass;
   if (!options.includes(current)) current = options[0];
   selectContainer.value = current;
-
-  let selectButton = createDivision(["select_button"], current);
+  let currentDisplay = current;
+  if (typeof optionFormatter === 'function') {
+    currentDisplay = optionFormatter(current);
+  }
+  let selectButton = createDivision(["select_button"], currentDisplay);
   let selectOptions = createDivision(["select_options_container"]);
 
   selectContainer.appendChild(selectButton);
@@ -855,12 +858,17 @@ function createSelect(parent, options, current, callback, divClass) {
       selectOptions.style.display = "block";
       for (let i = 0; i < options.length; i++) {
         if (options[i] !== current) {
-          let option = createDivision(["select_option"], options[i]);
+          let optionDisplay = options[i];
+          if (typeof optionFormatter === 'function') {
+            optionDisplay = optionFormatter(optionDisplay);
+          }
+
+          let option = createDivision(["select_option"], optionDisplay);
           selectOptions.appendChild(option);
 
           option.addEventListener("click", () => {
             selectButton.classList.remove("active");
-            selectButton.innerHTML = options[i];
+            selectButton.innerHTML = optionDisplay;
             selectContainer.value = options[i];
             selectOptions.style.display = "none";
             selectOptions.innerHTML = "";

--- a/window_main/history.js
+++ b/window_main/history.js
@@ -44,16 +44,14 @@ function isDraftMatch(match) {
 }
 
 function filterMatch(match) {
-  let passesEventFilter = (
+  let passesEventFilter =
     filterEvent == DEFAULT_FORMAT ||
     match.eventId == filterEvent ||
     (filterEvent == ALL_DRAFTS_FORMAT && isDraftMatch(match)) ||
-    (filterEvent == DRAFT_REPLAYS_FORMAT && match.type == "draft")
-  );
-  let passesDeckFilter = (
+    (filterEvent == DRAFT_REPLAYS_FORMAT && match.type == "draft");
+  let passesDeckFilter =
     filterDeck == DEFAULT_DECK ||
-    match.playerDeck && match.playerDeck.id == filterDeck
-  );
+    (match.playerDeck && match.playerDeck.id == filterDeck);
   return passesEventFilter && passesDeckFilter;
 }
 
@@ -114,9 +112,16 @@ function open_history_tab(loadMore) {
     });
 
     // count matches which match the current filter
+    let filteredDecks = [DEFAULT_DECK];
     validMatches.filter(filterMatch).forEach(match => {
       wins += match.player.win;
       losses += match.opponent.win;
+
+      let deckId = match.playerDeck.id;
+      if (filteredDecks.indexOf(deckId) == -1) {
+        filteredDecks.push(deckId);
+      }
+
       // some of the data is wierd. Games which last years or have no data.
       if (match.duration !== undefined && match.duration < 3600) {
         totalMatchTime += match.duration;
@@ -164,11 +169,14 @@ function open_history_tab(loadMore) {
     );
     formatSelect.style.margin = "12px auto auto auto";
 
-    let sortedDecks = [...decks];
-    sortedDecks.sort((a, b) => a.name.localeCompare(b.name));
+    //let sortedDecks = [...decks];
+    //sortedDecks.sort((a, b) => a.name.localeCompare(b.name));
+    filteredDecks.sort((a, b) =>
+      getReadableDeckName(a).localeCompare(getReadableDeckName(b))
+    );
     let deckSelect = createSelect(
       historyTopFilter,
-      [DEFAULT_DECK, ...sortedDecks.map(deck => deck.id)],
+      filteredDecks,
       filterDeck,
       filterHistoryByDeck,
       "history_query_deck",

--- a/window_main/history.js
+++ b/window_main/history.js
@@ -14,6 +14,7 @@ globals
   selectAdd,
   createSelect,
   compare_cards,
+  sort_decks,
   getReadableEvent,
   getReadableDeckName,
   getReadableDeckNameWithCost,
@@ -34,6 +35,7 @@ const DEFAULT_DECK = "All Decks";
 let loadHistory = 0;
 let filterEvent = DEFAULT_FORMAT;
 let filterDeck = DEFAULT_DECK;
+let filteredDecks = null;
 let filteredSampleSize = 0;
 let viewingLimitSeason = false;
 
@@ -113,13 +115,17 @@ function open_history_tab(loadMore) {
     });
 
     // count matches which match the current filter
-    let filteredDecks = [DEFAULT_DECK];
+    let getFilteredDecks = false;
+    if (filteredDecks == null) {
+      filteredDecks = [DEFAULT_DECK];
+      getFilteredDecks = true;
+    }
     validMatches.filter(filterMatch).forEach(match => {
       wins += match.player.win;
       losses += match.opponent.win;
 
       let deckId = match.playerDeck.id;
-      if (filteredDecks.indexOf(deckId) == -1) {
+      if (getFilteredDecks && filteredDecks.indexOf(deckId) == -1) {
         filteredDecks.push(deckId);
       }
 
@@ -721,6 +727,7 @@ function filterHistoryByEvent(filter) {
   filterEvent = filter;
   // automatically clear deck filter upon changing format filter
   // helps prevent user confusion caused by invalid filter combinations
+  filteredDecks = null;
   filterDeck = DEFAULT_DECK;
   open_history_tab(0);
 }

--- a/window_main/history.js
+++ b/window_main/history.js
@@ -16,12 +16,12 @@ globals
   compare_cards,
   getReadableEvent,
   getReadableDeckName,
+  getReadableDeckNameWithCost,
   getWinrateClass,
   createDivision,
   playerData,
   tags_colors,
   showLoadingBars,
-  decks,
   $$
 */
 
@@ -56,6 +56,7 @@ function filterMatch(match) {
 }
 
 function open_history_tab(loadMore) {
+  sort_decks();
   var mainDiv = document.getElementById("ux_0");
   var div, d;
   mainDiv.classList.add("flex_item");
@@ -180,8 +181,9 @@ function open_history_tab(loadMore) {
       filterDeck,
       filterHistoryByDeck,
       "history_query_deck",
-      getReadableDeckName
+      getReadableDeckNameWithCost
     );
+    deckSelect.style.width = "300px";
     deckSelect.style.margin = "12px 4px auto 16px";
 
     historyColumn.appendChild(historyTop);

--- a/window_main/index.css
+++ b/window_main/index.css
@@ -2220,6 +2220,7 @@ a:hover {
 
 .select_button {
     color: #FAE5D2;
+    overflow: hidden;
     line-height: 32px;
     text-indent: 16px;
     cursor: pointer;
@@ -2279,11 +2280,14 @@ a:hover {
 }
 
 .select_option {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
     white-space: nowrap;
     color: #FAE5D2;
     margin: 0;
-    padding: 7px 0;
-    text-indent: 15px;
+    height: 33px;
+    padding: 0 12px;
     border-top: 1px solid rgba(145, 121, 97, 0.5);
     -webkit-transition: all .25s cubic-bezier(0.2, 0.5, 0.35, 1);
 }


### PR DESCRIPTION
## Demo
![history-deck-filter](https://user-images.githubusercontent.com/14894693/55689492-def33700-5939-11e9-969d-517c1a88c8d2.gif)

## Motivation
- When iterating on deck design, I want to be able to focus on recent and historic matches for that particular deck.
- When I play decks across multiple formats, I want to be able to answer questions like "what is the win rate of this deck for purely Ranked play?"

## Potential Concerns
- This approach does not attempt to filter the options in the deck dropdown selector to help the user find valid selections. For example, when I have "Ranked Draft RNA" selected in the format dropdown selector, I should ideally only see the relevant corresponding draft decks in the deck selector.
  - A more user-friendly approach would require dynamically changing the values of one dropdown based on the selection in the other.
- Although Arena currently limits the user to 60(?) decks, at some point in the future this limit may be removed. If users are given the ability to create 100s of decks, this approach will not scale.

### Note
This supersedes the earlier work in https://github.com/Manuel-777/MTG-Arena-Tool/pull/248
