### PR TITLE
Wildcards and Estimated Booster Stats by Set

### DIFF
--- a/shared/util.js
+++ b/shared/util.js
@@ -1829,6 +1829,22 @@ function getCardsMissingCount(deck, grpid) {
 }
 
 //
+function getBoosterCountEstimate(wildcards) {
+  let boosterCost = 0;
+  let boosterEstimates = { common: 3, uncommon: 3, rare: 6, mythic: 13 };
+  for (let rarity in boosterEstimates) {
+    // accept either short or long form of keys in argument
+    let shortForm = rarity[0]; // grab first letter
+    let missing = wildcards[rarity] || wildcards[shortForm] || 0;
+    boosterCost = Math.max(
+        boosterCost,
+        boosterEstimates[rarity] * missing
+    );
+  }
+  return boosterCost;
+}
+
+//
 function get_deck_uniquestring(deck, side = true) {
   if (!deck) return "";
   deck.mainDeck.sort(compare_cards);

--- a/shared/util.js
+++ b/shared/util.js
@@ -1870,7 +1870,7 @@ function getCardsMissingCount(deck, grpid) {
 //
 function getBoosterCountEstimate(wildcards) {
   let boosterCost = 0;
-  let boosterEstimates = { common: 3, uncommon: 3, rare: 6, mythic: 13 };
+  let boosterEstimates = { common: 3.36, uncommon: 2.6, rare: 5.72, mythic: 13.24 };
   for (let rarity in boosterEstimates) {
     // accept either short or long form of keys in argument
     let shortForm = rarity[0]; // grab first letter
@@ -1880,7 +1880,7 @@ function getBoosterCountEstimate(wildcards) {
         boosterEstimates[rarity] * missing
     );
   }
-  return boosterCost;
+  return Math.round(boosterCost);
 }
 
 //

--- a/shared/util.js
+++ b/shared/util.js
@@ -1,6 +1,7 @@
 /*
 global
   cards
+  decks
   shell
   settings
 */
@@ -1430,6 +1431,13 @@ function get_collection_stats() {
           stats.complete[card.rarity].owned += owned;
           stats.singles[card.rarity].owned += 1;
         }
+
+        // count cards we know we want across decks
+        let deckWantedCounts = decks.map(deck => getCardsMissingCount(deck, grpId));
+        let wanted = Math.max(...deckWantedCounts);
+        stats[card.set][card.rarity].wanted += wanted;
+        stats.complete[card.rarity].wanted += wanted;
+        stats.singles[card.rarity].wanted += Math.min(1, wanted);
       }
     }
   });

--- a/shared/util.js
+++ b/shared/util.js
@@ -1810,6 +1810,15 @@ function get_deck_missing_short(deck) {
 }
 
 //
+function getCardsMissingCount(deck, grpid) {
+  let neededCount = 0;
+  let entireDeck = [...deck.mainDeck, ...deck.sideboard];
+  let matches = entireDeck.filter(card => card.id == grpid);
+  matches.forEach(card => neededCount += card.quantity);
+  return get_wc_missing(grpid, neededCount);
+}
+
+//
 function get_deck_uniquestring(deck, side = true) {
   if (!deck) return "";
   deck.mainDeck.sort(compare_cards);

--- a/shared/util.js
+++ b/shared/util.js
@@ -1355,9 +1355,10 @@ function get_set_code(set) {
 
 //
 class CountStats {
-  constructor(owned = 0, total = 0) {
+  constructor(owned = 0, total = 0, wanted = 0) {
     this.owned = owned;
     this.total = total;
+    this.wanted = wanted;
   }
 
   get percentage() {
@@ -1389,6 +1390,7 @@ class SetStats {
     ].reduce((acc, c) => {
       acc.owned += c.owned;
       acc.total += c.total;
+      acc.wanted += c.wanted;
       return acc;
     });
   }

--- a/shared/util.js
+++ b/shared/util.js
@@ -1395,10 +1395,13 @@ function get_set_code(set) {
 
 //
 class CountStats {
-  constructor(owned = 0, total = 0, wanted = 0) {
+  constructor(owned = 0, total = 0, unique = 0, complete = 0, wanted = 0, uniqueWanted = 0) {
     this.owned = owned;
     this.total = total;
+    this.unique = unique;
+    this.complete = complete; // all 4 copies of a card
     this.wanted = wanted;
+    this.uniqueWanted = uniqueWanted;
   }
 
   get percentage() {
@@ -1430,6 +1433,7 @@ class SetStats {
     ].reduce((acc, c) => {
       acc.owned += c.owned;
       acc.total += c.total;
+      acc.unique += c.unique;
       acc.wanted += c.wanted;
       return acc;
     });
@@ -1462,6 +1466,9 @@ function get_collection_stats() {
         stats[card.set][card.rarity].total += 4;
         stats.complete[card.rarity].total += 4;
         stats.singles[card.rarity].total += 1;
+        stats[card.set][card.rarity].unique += 1;
+        stats.complete[card.rarity].unique += 1;
+        stats.singles[card.rarity].unique += 1;
 
         // add cards we own
         if (cards[grpId] !== undefined) {
@@ -1469,6 +1476,13 @@ function get_collection_stats() {
           stats[card.set][card.rarity].owned += owned;
           stats.complete[card.rarity].owned += owned;
           stats.singles[card.rarity].owned += 1;
+
+          // count complete sets we own
+          if (owned == 4) {
+            stats[card.set][card.rarity].complete += 1;
+            stats.complete[card.rarity].complete += 1;
+            stats.singles[card.rarity].complete += 1;
+          }
         }
 
         // count cards we know we want across decks
@@ -1477,6 +1491,11 @@ function get_collection_stats() {
         stats[card.set][card.rarity].wanted += wanted;
         stats.complete[card.rarity].wanted += wanted;
         stats.singles[card.rarity].wanted += Math.min(1, wanted);
+
+        // count unique cards we know we want across decks
+        stats[card.set][card.rarity].uniqueWanted += Math.min(1, wanted);
+        stats.complete[card.rarity].uniqueWanted += Math.min(1, wanted);
+        stats.singles[card.rarity].uniqueWanted += Math.min(1, wanted);
       }
     }
   });

--- a/window_main/collection.js
+++ b/window_main/collection.js
@@ -38,10 +38,10 @@ function openCollectionTab() {
 
   orderedSets.sort((a, b) => {
     if (setsList[a].release < setsList[b].release) {
-      return -1;
+      return 1;
     }
     if (setsList[a].release > setsList[b].release) {
-      return 1;
+      return -1;
     }
     return 0;
   });

--- a/window_main/collection.js
+++ b/window_main/collection.js
@@ -498,27 +498,43 @@ function renderSetStats(setStats, setIconCode, setName) {
     });
 
     // If the set has a collationId, it means boosters for it exists
-    if (setsList[setName].collation) {
-      let wantedDiv = createDivision(["stats_set_completion"]);
-      let wantedCost = getBoosterCountEstimate(wanted);
-      let wantedIcon = createDivision(["stats_set_icon", "bo_explore_cost"]);
-      wantedIcon.style.height = "30px";
-      let wantedSpan = document.createElement("span");
-      wantedSpan.innerHTML = `<i>~${wantedCost} boosters to craft wanted cards using wilds.</i>`;
-      wantedIcon.appendChild(wantedSpan);
-      wantedDiv.appendChild(wantedIcon);
-      substats.appendChild(wantedDiv);
+    if (setsList[setName] && setsList[setName].collation) {
+      let chanceBoosterHasMythic = 0.125; // assume 1/8 of packs have a mythic
+      let chanceBoosterHasRare = 1 - chanceBoosterHasMythic;
+      let wantedText =
+        "<abbr title='missing copy of a card in a current deck'>wanted</abbr>";
 
-      // This is exact because we can depend on duplicate protection
-      let rareMythicCompletion = missing["rare"] + missing["mythic"];
-      let completionDiv = createDivision(["stats_set_completion"]);
-      let completionIcon = createDivision(["stats_set_icon", "bo_explore_cost"]);
-      completionIcon.style.height = "30px";
-      let completionSpan = document.createElement("span");
-      completionSpan.innerHTML = `<i>${rareMythicCompletion} boosters to open all rares and mythics.</i>`;
-      completionIcon.appendChild(completionSpan);
-      completionDiv.appendChild(completionIcon);
-      substats.appendChild(completionDiv);
+      // chance that the next booster opened contains a rare missing from one of our decks
+      let possibleRares = setStats["rare"].unique - setStats["rare"].complete;
+      let chanceBoosterRareWanted = (
+        (chanceBoosterHasRare * setStats["rare"].uniqueWanted) /
+        possibleRares
+      ).toLocaleString([], { style: "percent", maximumSignificantDigits: 2 });
+      let rareWantedDiv = createDivision(["stats_set_completion"]);
+      let rareWantedIcon = createDivision(["stats_set_icon", "bo_explore_cost"]);
+      rareWantedIcon.style.height = "30px";
+      let rareWantedSpan = document.createElement("span");
+      rareWantedSpan.innerHTML = `<i>~${chanceBoosterRareWanted} chance next booster has ${wantedText} rare.</i>`;
+      rareWantedSpan.style.fontSize = "13px";
+      rareWantedIcon.appendChild(rareWantedSpan);
+      rareWantedDiv.appendChild(rareWantedIcon);
+      substats.appendChild(rareWantedDiv);
+
+      // chance that the next booster opened contains a mythic missing from one of our decks
+      let possibleMythics = setStats["mythic"].unique - setStats["mythic"].complete;
+      let chanceBoosterMythicWanted = (
+        (chanceBoosterHasMythic * setStats["mythic"].uniqueWanted) /
+        possibleMythics
+      ).toLocaleString([], { style: "percent", maximumSignificantDigits: 2 });
+      let mythicWantedDiv = createDivision(["stats_set_completion"]);
+      let mythicWantedIcon = createDivision(["stats_set_icon", "bo_explore_cost"]);
+      mythicWantedIcon.style.height = "30px";
+      let mythicWantedSpan = document.createElement("span");
+      mythicWantedSpan.innerHTML = `<i>~${chanceBoosterMythicWanted} chance next booster has ${wantedText} mythic.</i>`;
+      mythicWantedSpan.style.fontSize = "13px";
+      mythicWantedIcon.appendChild(mythicWantedSpan);
+      mythicWantedDiv.appendChild(mythicWantedIcon);
+      substats.appendChild(mythicWantedDiv);
     }
   });
 
@@ -531,12 +547,30 @@ function renderCompletionDiv(countStats, image, title) {
 
   let setIcon = createDivision(["stats_set_icon"]);
   setIcon.style.backgroundImage = `url(../images/${image})`;
-
   let setIconSpan = document.createElement("span");
-  setIconSpan.innerHTML = `${title} <i>(${countStats.owned}/${countStats.total}, ${Math.round(countStats.percentage)}%, ${countStats.wanted} wanted)</i>`;
-
+  setIconSpan.innerHTML = title;
   setIcon.appendChild(setIconSpan);
   completionDiv.appendChild(setIcon);
+
+  const wrapperDiv = createDivision([]);
+  const detailsDiv = createDivision(["stats_set_details"]);
+
+  const percentSpan = document.createElement("span");
+  percentSpan.innerHTML = Math.round(countStats.percentage) + "%";
+  detailsDiv.appendChild(percentSpan);
+
+  const countSpan = document.createElement("span");
+  countSpan.innerHTML = countStats.owned + " / " + countStats.total;
+  detailsDiv.appendChild(countSpan);
+
+  const wantedSpan = document.createElement("span");
+  wantedSpan.innerHTML =
+    countStats.wanted +
+    " <abbr title='missing copies of cards in current decks'>wanted cards</abbr>";
+  detailsDiv.appendChild(wantedSpan);
+
+  wrapperDiv.appendChild(detailsDiv);
+  completionDiv.appendChild(wrapperDiv);
 
   let setBar = createDivision(["stats_set_bar"]);
   setBar.style.width = countStats.percentage + "%";

--- a/window_main/collection.js
+++ b/window_main/collection.js
@@ -497,37 +497,40 @@ function renderSetStats(setStats, setIconCode, setName) {
       missing[rarity] = countStats.total - countStats.owned;
     });
 
-    let wantedDiv = createDivision(["stats_set_completion"]);
-    let wantedCost = getBoosterCountEstimate(wanted);
-    let wantedIcon = createDivision(["stats_set_icon", "bo_explore_cost"]);
-    wantedIcon.style.height = "30px";
-    let wantedSpan = document.createElement("span");
-    wantedSpan.innerHTML = `<i>~${wantedCost} estimated boosters for wanted cards.</i>`;
-    wantedIcon.appendChild(wantedSpan);
-    wantedDiv.appendChild(wantedIcon);
-    substats.appendChild(wantedDiv);
+    // If the set has a collationId, it means boosters for it exists
+    if (setsList[setName].collation) {
+      let wantedDiv = createDivision(["stats_set_completion"]);
+      let wantedCost = getBoosterCountEstimate(wanted);
+      let wantedIcon = createDivision(["stats_set_icon", "bo_explore_cost"]);
+      wantedIcon.style.height = "30px";
+      let wantedSpan = document.createElement("span");
+      wantedSpan.innerHTML = `<i>~${wantedCost} estimated boosters for wanted cards.</i>`;
+      wantedIcon.appendChild(wantedSpan);
+      wantedDiv.appendChild(wantedIcon);
+      substats.appendChild(wantedDiv);
 
-    // This is very vague, assuming the distribution of mythic cards is 7 rares out of 8 packs.
-    let estimatedRareCompletion = Math.round(missing["rare"] / 0.875);
-    let missingRaresDiv = createDivision(["stats_set_completion"]);
-    let missingRaresIcon = createDivision(["stats_set_icon", "bo_explore_cost"]);
-    missingRaresIcon.style.height = "30px";
-    let missingRaresSpan = document.createElement("span");
-    missingRaresSpan.innerHTML = `<i>~${estimatedRareCompletion} estimated boosters for all rares.</i>`;
-    missingRaresIcon.appendChild(missingRaresSpan);
-    missingRaresDiv.appendChild(missingRaresIcon);
-    substats.appendChild(missingRaresDiv);
+      // This is very vague, assuming the distribution of mythic cards is 7 rares out of 8 packs.
+      let estimatedRareCompletion = Math.round(missing["rare"] / 0.875);
+      let missingRaresDiv = createDivision(["stats_set_completion"]);
+      let missingRaresIcon = createDivision(["stats_set_icon", "bo_explore_cost"]);
+      missingRaresIcon.style.height = "30px";
+      let missingRaresSpan = document.createElement("span");
+      missingRaresSpan.innerHTML = `<i>~${estimatedRareCompletion} estimated boosters for all rares.</i>`;
+      missingRaresIcon.appendChild(missingRaresSpan);
+      missingRaresDiv.appendChild(missingRaresIcon);
+      substats.appendChild(missingRaresDiv);
 
-    // Same as above, assuming 1 every 8 packs has a mythic.
-    let estimatedMythicsCompletion = Math.round(missing["rare"] / 0.125);
-    let missingMythicsDiv = createDivision(["stats_set_completion"]);
-    let missingMythicsIcon = createDivision(["stats_set_icon", "bo_explore_cost"]);
-    missingMythicsIcon.style.height = "30px";
-    let missingMythicsSpan = document.createElement("span");
-    missingMythicsSpan.innerHTML = `<i>~${estimatedMythicsCompletion} estimated boosters for all mythics.</i>`;
-    missingMythicsIcon.appendChild(missingMythicsSpan);
-    missingMythicsDiv.appendChild(missingMythicsIcon);
-    substats.appendChild(missingMythicsDiv);
+      // Same as above, assuming 1 every 8 packs has a mythic.
+      let estimatedMythicsCompletion = Math.round(missing["rare"] / 0.125);
+      let missingMythicsDiv = createDivision(["stats_set_completion"]);
+      let missingMythicsIcon = createDivision(["stats_set_icon", "bo_explore_cost"]);
+      missingMythicsIcon.style.height = "30px";
+      let missingMythicsSpan = document.createElement("span");
+      missingMythicsSpan.innerHTML = `<i>~${estimatedMythicsCompletion} estimated boosters for all mythics.</i>`;
+      missingMythicsIcon.appendChild(missingMythicsSpan);
+      missingMythicsDiv.appendChild(missingMythicsIcon);
+      substats.appendChild(missingMythicsDiv);
+    }
   });
 
   return setDiv;

--- a/window_main/collection.js
+++ b/window_main/collection.js
@@ -480,7 +480,7 @@ function renderSetStats(setStats, setIconCode, setName) {
 
     let wanted = {};
     let missing = {};
-    ["common", "uncommon", "rare", "mythic"].forEach(rarity => {
+    orderedCardRarities.forEach(rarity => {
       const countStats = setStats[rarity];
       if (countStats.total > 0) {
         const capitalizedRarity =
@@ -516,6 +516,28 @@ function renderSetStats(setStats, setIconCode, setName) {
     missingIcon.appendChild(missingSpan);
     missingDiv.appendChild(missingIcon);
     substats.appendChild(missingDiv);
+
+    // This is very vague, assuming the distribution of mythic cards is 7 rares out of 8 packs.
+    let estimatedRareCompletion = Math.round(missing["rare"] / 0.875);
+    let missingRaresDiv = createDivision(["stats_set_completion"]);
+    let missingRaresIcon = createDivision(["stats_set_icon", "bo_explore_cost"]);
+    missingRaresIcon.style.height = "30px";
+    let missingRaresSpan = document.createElement("span");
+    missingRaresSpan.innerHTML = `<i>~${estimatedRareCompletion} estimated boosters for all rares.</i>`;
+    missingRaresIcon.appendChild(missingRaresSpan);
+    missingRaresDiv.appendChild(missingRaresIcon);
+    substats.appendChild(missingRaresDiv);
+
+    // Same as above, assuming 1 every 8 packs has a mythic.
+    let estimatedMythicsCompletion = Math.round(missing["rare"] / 0.125);
+    let missingMythicsDiv = createDivision(["stats_set_completion"]);
+    let missingMythicsIcon = createDivision(["stats_set_icon", "bo_explore_cost"]);
+    missingMythicsIcon.style.height = "30px";
+    let missingMythicsSpan = document.createElement("span");
+    missingMythicsSpan.innerHTML = `<i>~${estimatedMythicsCompletion} estimated boosters for all mythics.</i>`;
+    missingMythicsIcon.appendChild(missingMythicsSpan);
+    missingMythicsDiv.appendChild(missingMythicsIcon);
+    substats.appendChild(missingMythicsDiv);
   });
 
   return setDiv;

--- a/window_main/collection.js
+++ b/window_main/collection.js
@@ -20,7 +20,8 @@ global
   addCardHover,
   shell,
   get_set_scryfall,
-  createSelect
+  createSelect,
+  getBoosterCountEstimate
 */
 let collectionPage = 0;
 let sortingAlgorithm = "Sort by Set";
@@ -477,6 +478,8 @@ function renderSetStats(setStats, setIconCode, setName) {
     label.innerHTML = setName + " completion";
     substats.appendChild(label);
 
+    let wanted = {};
+    let missing = {};
     ["common", "uncommon", "rare", "mythic"].forEach(rarity => {
       const countStats = setStats[rarity];
       if (countStats.total > 0) {
@@ -490,7 +493,29 @@ function renderSetStats(setStats, setIconCode, setName) {
           )
         );
       }
+      wanted[rarity] = countStats.wanted;
+      missing[rarity] = countStats.total - countStats.owned;
     });
+
+    let wantedDiv = createDivision(["stats_set_completion"]);
+    let wantedCost = getBoosterCountEstimate(wanted);
+    let wantedIcon = createDivision(["stats_set_icon", "bo_explore_cost"]);
+    wantedIcon.style.height = "30px";
+    let wantedSpan = document.createElement("span");
+    wantedSpan.innerHTML = `<i>~${wantedCost} estimated boosters for wanted cards.</i>`;
+    wantedIcon.appendChild(wantedSpan);
+    wantedDiv.appendChild(wantedIcon);
+    substats.appendChild(wantedDiv);
+
+    let missingDiv = createDivision(["stats_set_completion"]);
+    let missingCost = getBoosterCountEstimate(missing);
+    let missingIcon = createDivision(["stats_set_icon", "bo_explore_cost"]);
+    missingIcon.style.height = "30px";
+    let missingSpan = document.createElement("span");
+    missingSpan.innerHTML = `<i>~${missingCost} estimated boosters for all cards.</i>`;
+    missingIcon.appendChild(missingSpan);
+    missingDiv.appendChild(missingIcon);
+    substats.appendChild(missingDiv);
   });
 
   return setDiv;
@@ -504,7 +529,7 @@ function renderCompletionDiv(countStats, image, title) {
   setIcon.style.backgroundImage = `url(../images/${image})`;
 
   let setIconSpan = document.createElement("span");
-  setIconSpan.innerHTML = `${title} <i>(${countStats.owned}/${countStats.total}, ${Math.round(countStats.percentage)}%)</i>`;
+  setIconSpan.innerHTML = `${title} <i>(${countStats.owned}/${countStats.total}, ${Math.round(countStats.percentage)}%, ${countStats.wanted} wanted)</i>`;
 
   setIcon.appendChild(setIconSpan);
   completionDiv.appendChild(setIcon);

--- a/window_main/collection.js
+++ b/window_main/collection.js
@@ -504,32 +504,21 @@ function renderSetStats(setStats, setIconCode, setName) {
       let wantedIcon = createDivision(["stats_set_icon", "bo_explore_cost"]);
       wantedIcon.style.height = "30px";
       let wantedSpan = document.createElement("span");
-      wantedSpan.innerHTML = `<i>~${wantedCost} estimated boosters for wanted cards.</i>`;
+      wantedSpan.innerHTML = `<i>~${wantedCost} boosters to craft wanted cards using wilds.</i>`;
       wantedIcon.appendChild(wantedSpan);
       wantedDiv.appendChild(wantedIcon);
       substats.appendChild(wantedDiv);
 
-      // This is very vague, assuming the distribution of mythic cards is 7 rares out of 8 packs.
-      let estimatedRareCompletion = Math.round(missing["rare"] / 0.875);
-      let missingRaresDiv = createDivision(["stats_set_completion"]);
-      let missingRaresIcon = createDivision(["stats_set_icon", "bo_explore_cost"]);
-      missingRaresIcon.style.height = "30px";
-      let missingRaresSpan = document.createElement("span");
-      missingRaresSpan.innerHTML = `<i>~${estimatedRareCompletion} estimated boosters for all rares.</i>`;
-      missingRaresIcon.appendChild(missingRaresSpan);
-      missingRaresDiv.appendChild(missingRaresIcon);
-      substats.appendChild(missingRaresDiv);
-
-      // Same as above, assuming 1 every 8 packs has a mythic.
-      let estimatedMythicsCompletion = Math.round(missing["rare"] / 0.125);
-      let missingMythicsDiv = createDivision(["stats_set_completion"]);
-      let missingMythicsIcon = createDivision(["stats_set_icon", "bo_explore_cost"]);
-      missingMythicsIcon.style.height = "30px";
-      let missingMythicsSpan = document.createElement("span");
-      missingMythicsSpan.innerHTML = `<i>~${estimatedMythicsCompletion} estimated boosters for all mythics.</i>`;
-      missingMythicsIcon.appendChild(missingMythicsSpan);
-      missingMythicsDiv.appendChild(missingMythicsIcon);
-      substats.appendChild(missingMythicsDiv);
+      // This is exact because we can depend on duplicate protection
+      let rareMythicCompletion = missing["rare"] + missing["mythic"];
+      let completionDiv = createDivision(["stats_set_completion"]);
+      let completionIcon = createDivision(["stats_set_icon", "bo_explore_cost"]);
+      completionIcon.style.height = "30px";
+      let completionSpan = document.createElement("span");
+      completionSpan.innerHTML = `<i>${rareMythicCompletion} boosters to open all rares and mythics.</i>`;
+      completionIcon.appendChild(completionSpan);
+      completionDiv.appendChild(completionIcon);
+      substats.appendChild(completionDiv);
     }
   });
 

--- a/window_main/collection.js
+++ b/window_main/collection.js
@@ -507,16 +507,6 @@ function renderSetStats(setStats, setIconCode, setName) {
     wantedDiv.appendChild(wantedIcon);
     substats.appendChild(wantedDiv);
 
-    let missingDiv = createDivision(["stats_set_completion"]);
-    let missingCost = getBoosterCountEstimate(missing);
-    let missingIcon = createDivision(["stats_set_icon", "bo_explore_cost"]);
-    missingIcon.style.height = "30px";
-    let missingSpan = document.createElement("span");
-    missingSpan.innerHTML = `<i>~${missingCost} estimated boosters for all cards.</i>`;
-    missingIcon.appendChild(missingSpan);
-    missingDiv.appendChild(missingIcon);
-    substats.appendChild(missingDiv);
-
     // This is very vague, assuming the distribution of mythic cards is 7 rares out of 8 packs.
     let estimatedRareCompletion = Math.round(missing["rare"] / 0.875);
     let missingRaresDiv = createDivision(["stats_set_completion"]);

--- a/window_main/deck_details.js
+++ b/window_main/deck_details.js
@@ -17,7 +17,8 @@ global
     getDeckWinrate,
     economyHistory,
     cardsDb,
-    add
+    add,
+    getBoosterCountEstimate
 */
 
 // We need to store a sorted list of card types so we create the card counts in the same order.
@@ -296,12 +297,8 @@ function deckStatsSection(deck, deck_type) {
   let costSection = $(
     '<div class="wildcards_cost"><span>Wildcards you have/need</span></div>'
   );
-  let boosterCost = 0;
+  let boosterCost = getBoosterCountEstimate(missingWildcards);
   orderedCardRarities.forEach(cardRarity => {
-    let bp =
-      rarityBooster[cardRarity] *
-      (missingWildcards[cardRarity] - ownedWildcards[cardRarity]);
-    if (bp > boosterCost) boosterCost = bp;
     $(
       `<div title="${cardRarity}" class="wc_cost wc_${cardRarity}">${
         ownedWildcards[cardRarity] > 0 ? ownedWildcards[cardRarity] + " / " : ""

--- a/window_main/decks.js
+++ b/window_main/decks.js
@@ -9,7 +9,8 @@ global
 	open_deck,
 	tags_colors,
 	ipc_send,
-	selectAdd
+	selectAdd,
+  getBoosterCountEstimate
 */
 
 let filterTag = "All";
@@ -139,16 +140,10 @@ function open_decks_tab() {
 
         let wc;
         let n = 0;
-        let boosterCost = 0;
+        let boosterCost = getBoosterCountEstimate(missingWildcards);
         orderedCardRarities.forEach(cardRarity => {
           if (missingWildcards[cardRarity]) {
             n++;
-            let bc =
-              rarityBooster[cardRarity] *
-              (missingWildcards[cardRarity] - ownedWildcards[cardRarity]);
-            if (bc > boosterCost) {
-              boosterCost = bc;
-            }
             wc = document.createElement("div");
             wc.classList.add("wc_explore_cost");
             wc.classList.add("wc_" + cardRarity);

--- a/window_main/explore.js
+++ b/window_main/explore.js
@@ -18,6 +18,7 @@ globals
   createDivision,
   removeDuplicates,
   compare_cards,
+  getBoosterCountEstimate,
   $$
 */
 
@@ -39,7 +40,6 @@ let ranks_list = ["Bronze", "Silver", "Gold", "Platinum", "Diamond", "Mythic"];
 
 const open_deck = require("./deck_details").open_deck;
 
-let rarityBooster = { c: 3, u: 3, r: 6, m: 13 };
 let raritySort = { c: "common", u: "uncommon", r: "rare", m: "mythic" };
 
 function openExploreTab() {
@@ -444,20 +444,15 @@ function deckLoad(_deck, index) {
 
   let wc;
   let n = 0;
-  let boosterCost = 0;
+  let boosterCost = getBoosterCountEstimate(_deck.wildcards);
   for (var key in raritySort) {
     if (_deck.wildcards.hasOwnProperty(key) && _deck.wildcards[key] > 0) {
       wc = createDivision(
         ["wc_explore_cost", "wc_" + raritySort[key]],
         _deck.wildcards[key]
       );
-      wc.title = raritySort[key].capitalize() + " wldcards needed.";
+      wc.title = raritySort[key].capitalize() + " wildcards needed.";
       flcf.appendChild(wc);
-
-      boosterCost = Math.max(
-        boosterCost,
-        rarityBooster[key] * _deck.wildcards[key]
-      );
       n++;
     }
   }
@@ -588,7 +583,7 @@ function eventLoad(event, index) {
 
   let wc;
   let n = 0;
-  let boosterCost = 0;
+  let boosterCost = getBoosterCountEstimate(event.wildcards);
   for (var key in raritySort) {
     if (event.wildcards.hasOwnProperty(key) && event.wildcards[key] > 0) {
       wc = createDivision(
@@ -597,11 +592,6 @@ function eventLoad(event, index) {
       );
       wc.title = raritySort[key].capitalize() + " wldcards needed.";
       flcf.appendChild(wc);
-
-      boosterCost = Math.max(
-        boosterCost,
-        rarityBooster[key] * event.wildcards[key]
-      );
       n++;
     }
   }

--- a/window_main/index.css
+++ b/window_main/index.css
@@ -1310,8 +1310,7 @@ a:hover {
 
 .stats_set_completion {
     max-width: 320px;
-    margin: 0 auto;
-    height: 40px;
+    margin: 24px auto;
     display: flex;
     flex-direction: column;
 }
@@ -1322,7 +1321,7 @@ a:hover {
     height: 24px;
     background-repeat: no-repeat;
     background-size: cover;
-    margin: 6px;
+    margin: 0 6px;
     background-size: contain;
     opacity: 0.7;
     -webkit-transition: all .2s ease-in;
@@ -1350,13 +1349,35 @@ a:hover {
     opacity: 1;
 }
 
+.stats_set_details {
+    cursor: pointer;
+    display: inline-flex;
+    justify-content: space-between;
+    width: 100%;
+    opacity: 0.7;
+    -webkit-transition: all .2s ease-in;
+}
+
+.stats_set_details span {
+    cursor: pointer;
+    line-height: 24px;
+    margin: 0 6px;
+    font-size: 13px;
+    color: #fae5d2;
+    opacity: 0.8;
+    -webkit-transition: all .2s ease-in;
+}
+.stats_set_details span:hover {
+    opacity: 1;
+}
+
 .stats_rarity_icon {
     cursor: pointer;
     /*width: 24px;*/
     height: 24px;
     background-repeat: no-repeat;
     background-size: cover;
-    margin: 6px;
+    margin: 0 6px;
     background-size: contain;
 }
 

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -68,7 +68,6 @@ var orderedManaColors = [
   "#B7C89E",
   "#E3E3E3"
 ];
-var rarityBooster = { common: 3.36, uncommon: 2.6, rare: 5.72, mythic: 13.24 };
 
 let shell = electron.shell;
 let ipc = electron.ipcRenderer;


### PR DESCRIPTION
## Motivation
- Given the partially complete decks I have on Arena, which booster pack should I buy next?
  - How many cards do I want in each set? How many do I want by rarity?
  - How many booster packs in each set would I need to complete all my decks?
- ~~How many booster packs in each set would I need to complete the entire set?~~
  - This math is much harder than estimations based on wildcards or duplicate protection only. Also, this probably isn't useful.
- ~~How many booster packs in each set would I need to complete the entire set of rares/mythics?~~
  - ~~This math is simple because of duplicate protection and more useful for deck building or knowing when you will only get gems from packs.~~
  - This math is also hard. 😖 
- For the next booster pack I buy in each set, what is the chance that the rare or mythic would help me complete my decks? 💯 ✅ 2️⃣ ➕ 2️⃣ ✅  

## Demo
![image](https://user-images.githubusercontent.com/14894693/55761108-14b81e80-5a13-11e9-98df-ec49855e439d.png)

## Other Thoughts
- This is probably closely related to https://github.com/Manuel-777/MTG-Arena-Tool/issues/198 and https://github.com/Manuel-777/MTG-Arena-Tool/issues/190 but hopefully only tangential. Those bugs probably relate to `util.get_deck_missing`, which this PR avoids.
- I have yet to set up any kind of performance-related profiling. Empirical tests on my machine seem to show that this doesn't add much additional load time to the stats panel, but an increase in the number of decks might require us to push this into background computation.