### PR TITLE
Sideboard wildcard bug 198

### DIFF
--- a/shared/util.js
+++ b/shared/util.js
@@ -694,7 +694,7 @@ function wrap(element, wrapper) {
   return element;
 }
 
-function addCardTile(grpId, indent, quantity, element) {
+function addCardTile(grpId, indent, quantity, element, showWildcards = false, deck = null, isSideboard = false) {
   // if element is a jquery object convert to bare DOM element
   // TODO: Remove this once jQuery is removed.
   if (element instanceof jQuery) {
@@ -798,30 +798,29 @@ function addCardTile(grpId, indent, quantity, element) {
       prevc = /^\d+$/.test(cost);
     });
 
-    if (renderer == 0) {
+    if (showWildcards && renderer == 0) {
       if (card.type.indexOf("Basic Land") == -1) {
-        quantity = get_wc_missing(grpId, quantity);
-
-        //if (grpId == 67306 && quantity > 4) {
-        //  quantity = 4;
-        //}
+        let missing = 0;
+        if (deck) {
+            missing = get_wc_missing(deck, grpId, isSideboard);
+        }
 
         let xoff = rarities.indexOf(card.rarity) * -24;
 
         //if (cards[grpId] == undefined) {
-        if (quantity > 0) {
-          let yoff = quantity * -24;
+        if (missing > 0) {
+          let yoff = missing * -24;
 
           var asasdf = createDivision(["not_owned_sprite"]);
           asasdf.style.cssText = `background-position: ${xoff}px ${yoff}px; left: calc(0px - 100% + ${ww -
             14}px);`;
-          asasdf.title = "${quantity} missing";
+          asasdf.title = "${missing} missing";
           cont.appendChild(asasdf);
         }
         /*}
-        else if (quantity > cards[grpId]) {
-          let yoff = (quantity - cards[grpId]) * -24;
-          cont.append(`<div style="background-position: ${xoff}px ${yoff}px; left: calc(0px - 100% + ${(ww-14)}px);" class="not_owned_sprite" title="${(quantity-cards[grpId])} missing"></div>`);
+        else if (missing > cards[grpId]) {
+          let yoff = (missing - cards[grpId]) * -24;
+          cont.append(`<div style="background-position: ${xoff}px ${yoff}px; left: calc(0px - 100% + ${(ww-14)}px);" class="not_owned_sprite" title="${(missing-cards[grpId])} missing"></div>`);
         }
         */
       }
@@ -1754,16 +1753,27 @@ function get_rank_class(ranking) {
 }
 
 //
-function get_wc_missing(grpid, quantity) {
+function get_wc_missing(deck, grpid, isSideboard) {
+  let mainQuantity = 0;
+  let mainMatches = deck.mainDeck.filter(card => card.id == grpid);
+  if (mainMatches.length) {
+    mainQuantity = mainMatches[0].quantity;
+  }
+
+  let sideboardQuantity = 0;
+  let sideboardMatches = deck.sideboard.filter(card => card.id == grpid);
+  if (sideboardMatches.length) {
+    sideboardQuantity = sideboardMatches[0].quantity;
+  }
+
+  let needed = mainQuantity;
+  if (isSideboard) {
+    needed = sideboardQuantity;
+  }
+  // cap at 4 copies to handle petitioners, rat colony, etc
+  needed = Math.min(4, needed);
+
   let card = cardsDb.get(grpid);
-
-  if (grpid == 67306 && quantity > 4) {
-    quantity = 4;
-  }
-  if (grpid == 69172 && quantity > 4) {
-    quantity = 4;
-  }
-
   let arr = card.reprints;
   if (!arr) arr = [grpid];
   else arr.push(grpid);
@@ -1776,102 +1786,34 @@ function get_wc_missing(grpid, quantity) {
     }
   });
 
-  return Math.max(0, quantity - have);
+  let copiesLeft = have;
+  if (isSideboard) {
+    copiesLeft = Math.max(0, copiesLeft - mainQuantity);
+
+    let infiniteCards = [ 67306, 69172 ] // petitioners, rat colony, etc
+    if (have >= 4 && infiniteCards.indexOf(grpid) >= 0) {
+      copiesLeft = 4;
+    }
+  }
+
+  return Math.max(0, needed - copiesLeft);
 }
 
 //
 function get_deck_missing(deck) {
-  var missing = { rare: 0, common: 0, uncommon: 0, mythic: 0 };
+  let missing = { rare: 0, common: 0, uncommon: 0, mythic: 0 };
+  let alreadySeenIds = new Set(); // prevents double counting cards across main/sideboard
+  let entireDeck = [...deck.mainDeck, ...deck.sideboard];
 
-  deck.mainDeck.forEach(function(card) {
-    var grpid = card.id;
-    var quantity = card.quantity;
-    var rarity = cardsDb.get(grpid).rarity;
-
-    let add = get_wc_missing(grpid, quantity);
-
-    if (rarity == "common") {
-      missing.common += add;
+  entireDeck.forEach(card => {
+    let grpid = card.id;
+    // process each card at most once
+    if (alreadySeenIds.has(grpid)) {
+        return;
     }
-    if (rarity == "uncommon") {
-      missing.uncommon += add;
-    }
-    if (rarity == "rare") {
-      missing.rare += add;
-    }
-    if (rarity == "mythic") {
-      missing.mythic += add;
-    }
-  });
-
-  deck.sideboard.forEach(function(card) {
-    var grpid = card.id;
-    var quantity = card.quantity;
-    var rarity = cardsDb.get(grpid).rarity;
-
-    let add = get_wc_missing(grpid, quantity);
-
-    if (rarity == "common") {
-      missing.common += add;
-    }
-    if (rarity == "uncommon") {
-      missing.uncommon += add;
-    }
-    if (rarity == "rare") {
-      missing.rare += add;
-    }
-    if (rarity == "mythic") {
-      missing.mythic += add;
-    }
-  });
-
-  return missing;
-}
-
-//
-function get_deck_missing_short(deck) {
-  var missing = { r: 0, c: 0, u: 0, m: 0 };
-
-  deck.mainDeck.forEach(function(card) {
-    var grpid = card.id;
-    var quantity = card.quantity;
-    var rarity = cardsDb.get(grpid).rarity;
-
-    let add = get_wc_missing(grpid, quantity);
-
-    if (rarity == "common") {
-      missing.c += add;
-    }
-    if (rarity == "uncommon") {
-      missing.u += add;
-    }
-    if (rarity == "rare") {
-      missing.r += add;
-    }
-    if (rarity == "mythic") {
-      missing.m += add;
-    }
-  });
-
-  deck.sideboard.forEach(function(card) {
-    var grpid = card.id;
-    var quantity = card.quantity;
-    var rarity = cardsDb.get(grpid).rarity;
-
-    let add = get_wc_missing(grpid, quantity);
-
-    if (rarity == "common") {
-      missing.c += add;
-    }
-    if (rarity == "uncommon") {
-      missing.u += add;
-    }
-    if (rarity == "rare") {
-      missing.r += add;
-    }
-    if (rarity == "mythic") {
-      missing.m += add;
-    }
+    let rarity = cardsDb.get(grpid).rarity;
+    missing[rarity] += getCardsMissingCount(deck, grpid);
+    alreadySeenIds.add(grpid); // remember this card
   });
 
   return missing;
@@ -1879,11 +1821,9 @@ function get_deck_missing_short(deck) {
 
 //
 function getCardsMissingCount(deck, grpid) {
-  let neededCount = 0;
-  let entireDeck = [...deck.mainDeck, ...deck.sideboard];
-  let matches = entireDeck.filter(card => card.id == grpid);
-  matches.forEach(card => neededCount += card.quantity);
-  return get_wc_missing(grpid, neededCount);
+  let mainMissing = get_wc_missing(deck, grpid, false);
+  let sideboardMissing = get_wc_missing(deck, grpid, true);
+  return mainMissing + sideboardMissing;
 }
 
 //

--- a/window_main/deck_details.js
+++ b/window_main/deck_details.js
@@ -261,11 +261,9 @@ function deckStatsSection(deck, deck_type) {
   // Mana Curve
   deckManaCurve(deck).appendTo(stats);
 
-  //let missing = get_deck_missing(deck);
+  // Deck colors
   let pieContainer = $('<div class="pie_container_outer"></div>');
   pieContainer.appendTo(stats);
-
-  // Deck colors
   let colorCounts = get_deck_colors_ammount(deck);
   let pieChart;
   pieChart = colorPieChart(colorCounts, "Mana Symbols");
@@ -344,7 +342,7 @@ function openDeck(deck, deck_type) {
   }
 
   let deckListSection = $('<div class="decklist"></div>');
-  drawDeck(deckListSection, deck);
+  drawDeck(deckListSection, deck, true);
 
   let statsSection = deckStatsSection(deck, deck_type);
 

--- a/window_main/home.js
+++ b/window_main/home.js
@@ -845,7 +845,7 @@ function selectTourneyDeck() {
   tournamentDeck = document.getElementById("deck_select").value;
   decks.forEach(_deck => {
     if (_deck.id == tournamentDeck) {
-      drawDeck($(".join_decklist"), _deck);
+      drawDeck($(".join_decklist"), _deck, true);
     }
   });
 

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -1000,7 +1000,7 @@ ipc.on("tou_set", function(event, arg) {
 });
 
 //
-function drawDeck(div, deck) {
+function drawDeck(div, deck, showWildcards = false) {
   var unique = makeId(4);
   div.html("");
   var prevIndex = 0;
@@ -1019,7 +1019,7 @@ function drawDeck(div, deck) {
     }
 
     if (card.quantity > 0) {
-      addCardTile(grpId, unique + "a", card.quantity, div);
+      addCardTile(grpId, unique + "a", card.quantity, div, showWildcards, deck, false);
     }
 
     prevIndex = grpId;
@@ -1033,7 +1033,7 @@ function drawDeck(div, deck) {
         var grpId = card.id;
         //var type = cardsDb.get(grpId).type;
         if (card.quantity > 0) {
-          addCardTile(grpId, unique + "b", card.quantity, div);
+          addCardTile(grpId, unique + "b", card.quantity, div, showWildcards, deck, true);
         }
       });
     }


### PR DESCRIPTION
## Bugfix Wildcard Math and Icon Display
- Fixes problems described in https://github.com/Manuel-777/MTG-Arena-Tool/issues/198
  - Current wildcard counting math treats main deck and sideboard as 2 separate decks
  - Current wildcard icons appear on visual deck display as if main deck and sideboard are separate

## Approach
- Refactor wildcard counting math to group main deck and sideboard and process as a set of cards.
  - Math and plumbing was straightforward in places where old code was already "entire-deck"
  - Plumbing got a little hairy where old code assumed an individual card could know about wildcard count without context of entire deck
- Refactor display logic in `addCardTile` and `drawDeck` to handle new awkward plumbing.
  - essentially just optionally pass around deck references to allow us to correctly compute WCs
  - new plumbing is optional for backwards compatibility and to minimize refactor risk
  - NOTE: wildcard icons no longer display on event history page (where they arguable didn't mean much anyway)

## Testing
My current collection includes:
- 4 Dauntless Bodyguard
- 1 Isolate
- 2 Moment of Triumph

### Before (with bug)
![image](https://user-images.githubusercontent.com/14894693/55937431-d62a8b80-5bed-11e9-872b-7af77b20b142.png)
![image](https://user-images.githubusercontent.com/14894693/55937547-0f62fb80-5bee-11e9-82ee-30957a1cdc05.png)

### After
![image](https://user-images.githubusercontent.com/14894693/55937640-505b1000-5bee-11e9-99a9-9167c39fa1eb.png)
![image](https://user-images.githubusercontent.com/14894693/55937656-5b15a500-5bee-11e9-8895-bba4af845128.png)


