### PR TITLE
Login bugfix

### DIFF
--- a/window_background/http-api.js
+++ b/window_background/http-api.js
@@ -342,14 +342,15 @@ function httpBasic() {
                 });
               }
               if (_headers.method == "auth") {
-                if (parsedResult.error == "Invalid credentials.") {
-                  tokenAuth = undefined;
-                  rstore.set("email", "");
-                  rstore.set("token", "");
-                  ipc_send("auth", {});
-                  ipc_send("clear_pwd", 1);
-                  ipc_send("set_remember", false);
-                }
+                tokenAuth = undefined;
+                rstore.set("email", "");
+                rstore.set("token", "");
+                ipc_send("auth", {});
+                ipc_send("clear_pwd", 1);
+                ipc_send("popup", {
+                  text: `Error: ${parsedResult.error}`,
+                  time: 3000
+                });
               }
               // errors here
             } else if (!parsedResult && _headers.method == "auth") {

--- a/window_main/index.html
+++ b/window_main/index.html
@@ -96,7 +96,7 @@
                     <div class="message_sub white">Just a moment..</div>
                 </div>
 
-                <div class="authenticate">
+                <form id="authenticate_form" class="authenticate">
                     <div class="message_big green">Welcome!</div>
                         <label style="display: table">Email</label>
                     <div class="input_login_container">
@@ -107,6 +107,7 @@
                         <input type="password" id="signin_pass" autocomplete="off" />
                     </div>
                     <div class="button_simple_disabled centered login_link">Login</div>
+                    <input type="submit" style="display:none" />
 
                     <label class="check_container check_container_centered hover_label">Remember me?
                         <input type="checkbox" id="rememberme" onclick="rememberMe()" />
@@ -116,7 +117,7 @@
                     <div class="message_small">Dont have an account? <a class="signup_link">Sign up!</a></div>
                     <div class="message_small">You can also <a class="offline_link">continue offline</a></div>
                     --<div class="message_small">Did you <a class="forgot_link">forget your password?</a></div>
-                </div>
+                </form>
             </div>
         </div>
     </body>

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -237,6 +237,7 @@ ipc.on("set_db", function(event, arg) {
     canLogin = true;
     cardsDb.set(arg);
     $(".button_simple_disabled").addClass("button_simple");
+    $("#signin_user").focus();
   } catch (e) {
     pop("Error parsing metadata", null);
     console.log("Error parsing metadata", e);
@@ -855,7 +856,7 @@ $(document).ready(function() {
     shell.openExternal("https://mtgatool.com/resetpassword/");
   });
 
-  $(".login_link").click(function() {
+  function submitAuthenticateForm() {
     if (canLogin) {
       var user = document.getElementById("signin_user").value;
       var pass = document.getElementById("signin_pass").value;
@@ -865,7 +866,14 @@ $(document).ready(function() {
       ipc_send("login", { username: user, password: pass });
       canLogin = false;
     }
+  }
+
+  $("#authenticate_form").on("submit", e => {
+    e.preventDefault();
+    submitAuthenticateForm();
   });
+
+  $(".login_link").click(submitAuthenticateForm);
 
   //
   $(".close").click(function() {


### PR DESCRIPTION
### Issue
- Auth response handler will silently swallow all errors other than "Invalid credentials." This causes the login form to be unresponsive in many cases, for example upon attempting to login with an invalid user name.
![image](https://user-images.githubusercontent.com/14894693/56061429-42a4a800-5d1e-11e9-9298-f5826be63803.png)

### Fix
- Catch all errors, always reset form, and bubble up error message to client.

### Bonus Login Form Tweaks 
- Hitting enter key now submits form.
- When login button is activated, window will autofocus on username field.