### PR TITLE
Auto login and Launch to tray

### DIFF
--- a/main.js
+++ b/main.js
@@ -176,7 +176,7 @@ function startApp() {
 
       case "set_settings":
         //console.log("set settings: ", arg);
-        saveSettings(arg);
+        setSettings(arg);
         mainWindow.webContents.send("set_settings", arg);
         overlay.webContents.send("set_settings", arg);
         break;
@@ -201,12 +201,6 @@ function startApp() {
       case "set_cards":
         mainWindow.webContents.send("set_cards", arg.cards, arg.new);
         overlay.webContents.send("set_cards", arg.cards);
-        break;
-
-      case "save_settings":
-        saveSettings(arg);
-        background.webContents.send("save_settings", arg);
-        overlay.webContents.send("set_settings", arg);
         break;
 
       case "renderer_update_install":
@@ -382,7 +376,7 @@ function startApp() {
   });
 }
 
-function saveSettings(settings) {
+function setSettings(settings) {
   app.setLoginItemSettings({
     openAtLogin: settings.startup
   });

--- a/main.js
+++ b/main.js
@@ -36,6 +36,7 @@ const ipc = electron.ipcMain;
 
 var mainLoaded = false;
 var backLoaded = false;
+var firstSettingsRead = true;
 
 //commandLine, workingDirectory
 const singleLock = app.requestSingleInstanceLock();
@@ -132,7 +133,6 @@ function startApp() {
     mainLoaded = true;
     if (backLoaded == true) {
       background.webContents.send("set_renderer_state", 1);
-      showWindow();
     }
   });
 
@@ -140,7 +140,6 @@ function startApp() {
     backLoaded = true;
     if (mainLoaded == true) {
       background.webContents.send("set_renderer_state", 1);
-      showWindow();
     }
   });
 
@@ -188,9 +187,6 @@ function startApp() {
         overlay.webContents.send("set_db", arg);
         if (autoLogin) {
           background.webContents.send("auto_login");
-          if (launchToTray) {
-            hideWindow();
-          }
         }
         break;
 
@@ -392,11 +388,16 @@ function setSettings(settings) {
   autoLogin = settings.auto_login;
   launchToTray = settings.launch_to_tray;
 
+  if (!launchToTray && firstSettingsRead) {
+    showWindow();
+  }
+
   var oldAlphaEnabled = alphaEnabled;
   alphaEnabled = settings.overlay_alpha_back < 1;
   if (oldAlphaEnabled != alphaEnabled) {
     recreateOverlay();
   }
+  firstSettingsRead = false;
 }
 
 // Catch exceptions

--- a/main.js
+++ b/main.js
@@ -28,6 +28,7 @@ var background;
 var overlay;
 var tray = null;
 var closeToTray = true;
+let autoLogin = false;
 var alphaEnabled = false;
 
 const ipc = electron.ipcMain;
@@ -184,6 +185,9 @@ function startApp() {
       case "set_db":
         mainWindow.webContents.send("set_db", arg);
         overlay.webContents.send("set_db", arg);
+        if (autoLogin) {
+          background.webContents.send("auto_login");
+        }
         break;
 
       case "popup":
@@ -381,6 +385,7 @@ function setSettings(settings) {
     openAtLogin: settings.startup
   });
   closeToTray = settings.close_to_tray;
+  autoLogin = settings.auto_login;
 
   var oldAlphaEnabled = alphaEnabled;
   alphaEnabled = settings.overlay_alpha_back < 1;

--- a/main.js
+++ b/main.js
@@ -29,6 +29,7 @@ var overlay;
 var tray = null;
 var closeToTray = true;
 let autoLogin = false;
+let launchToTray = false;
 var alphaEnabled = false;
 
 const ipc = electron.ipcMain;
@@ -130,16 +131,16 @@ function startApp() {
   mainWindow.webContents.once("dom-ready", () => {
     mainLoaded = true;
     if (backLoaded == true) {
-      showWindow();
       background.webContents.send("set_renderer_state", 1);
+      showWindow();
     }
   });
 
   background.webContents.once("dom-ready", () => {
     backLoaded = true;
     if (mainLoaded == true) {
-      showWindow();
       background.webContents.send("set_renderer_state", 1);
+      showWindow();
     }
   });
 
@@ -187,6 +188,9 @@ function startApp() {
         overlay.webContents.send("set_db", arg);
         if (autoLogin) {
           background.webContents.send("auto_login");
+          if (launchToTray) {
+            hideWindow();
+          }
         }
         break;
 
@@ -386,6 +390,7 @@ function setSettings(settings) {
   });
   closeToTray = settings.close_to_tray;
   autoLogin = settings.auto_login;
+  launchToTray = settings.launch_to_tray;
 
   var oldAlphaEnabled = alphaEnabled;
   alphaEnabled = settings.overlay_alpha_back < 1;

--- a/shared/util.js
+++ b/shared/util.js
@@ -16,6 +16,9 @@ const BLACK = 3;
 const RED = 4;
 const GREEN = 5;
 
+// Magic constant to represent auth token in form
+const HIDDEN_PW = "********";
+
 const math = require("mathjs");
 math.config({ precision: 2000 });
 

--- a/window_background/background.js
+++ b/window_background/background.js
@@ -275,8 +275,6 @@ ipc.on("save_app_settings", function(event, arg) {
     rstore.set("email", "");
     rstore.set("token", "");
   }
-  // launch to tray depends on auto login
-  updated.launch_to_tray = updated.auto_login && updated.launch_to_tray;
 
   rstore.set("settings", updated);
   loadSettings();

--- a/window_background/background.js
+++ b/window_background/background.js
@@ -36,7 +36,8 @@ global
   onLabelInEventCompleteDraft,
   onLabelMatchGameRoomStateChangedEvent,
   onLabelInEventGetSeasonAndRankDetail,
-  onLabelGetPlayerInventoryGetRewardSchedule
+  onLabelGetPlayerInventoryGetRewardSchedule,
+  HIDDEN_PW
 */
 var electron = require("electron");
 
@@ -297,7 +298,7 @@ ipc.on("set_renderer_state", function(event, arg) {
 
 //
 ipc.on("login", function(event, arg) {
-  if (arg.password == "********") {
+  if (arg.password == HIDDEN_PW) {
     tokenAuth = rstore.get("token");
     playerData.userName = arg.username;
     httpApi.httpAuth(arg.username, arg.password);

--- a/window_background/background.js
+++ b/window_background/background.js
@@ -64,6 +64,7 @@ const rememberCfg = {
   email: "",
   token: "",
   settings: {
+    auto_login: false,
     remember_me: true
   }
 };

--- a/window_background/background.js
+++ b/window_background/background.js
@@ -317,6 +317,7 @@ ipc.on("set_renderer_state", function(event, arg) {
 
 function offlineLogin() {
   ipc_send("auth", { ok: true, user: -1 });
+  ipc_send("set_offline", true);
   loadPlayerConfig(playerData.arenaId);
   playerData.userName = "";
 }

--- a/window_background/background.js
+++ b/window_background/background.js
@@ -65,6 +65,7 @@ const rememberCfg = {
   token: "",
   settings: {
     auto_login: false,
+    launch_to_tray: false,
     remember_me: true
   }
 };
@@ -274,6 +275,8 @@ ipc.on("save_app_settings", function(event, arg) {
     rstore.set("email", "");
     rstore.set("token", "");
   }
+  // launch to tray depends on auto login
+  updated.launch_to_tray = updated.auto_login && updated.launch_to_tray;
 
   rstore.set("settings", updated);
   loadSettings();
@@ -1274,7 +1277,6 @@ function processLogUser(rawString) {
     if (value.indexOf(strCheck) > -1) {
       playerData.name = dataChop(value, strCheck, '"');
       ipc_send("set_player_data", playerData);
-      ipc_send("init_login", true);
       ipc_send("ipc_log", "Arena screen name: " + playerData.name);
     }
 

--- a/window_background/background.js
+++ b/window_background/background.js
@@ -312,6 +312,29 @@ ipc.on("set_renderer_state", function(event, arg) {
   });
 });
 
+function offlineLogin() {
+  ipc_send("auth", { ok: true, user: -1 });
+  loadPlayerConfig(playerData.arenaId);
+  playerData.userName = "";
+}
+
+//
+ipc.on("auto_login", () => {
+  const rSettings = rstore.get("settings");
+  if (!rSettings.auto_login) return;
+
+  tokenAuth = rstore.get("token");
+  ipc_send("popup", {
+    text: "Logging in automatically...",
+    time: 0
+  });
+  if (rSettings.remember_me) {
+    httpApi.httpAuth(rstore.get("email"), HIDDEN_PW);
+  } else {
+    offlineLogin();
+  }
+});
+
 //
 ipc.on("login", function(event, arg) {
   if (arg.password == HIDDEN_PW) {
@@ -319,9 +342,7 @@ ipc.on("login", function(event, arg) {
     playerData.userName = arg.username;
     httpApi.httpAuth(arg.username, arg.password);
   } else if (arg.username == "" && arg.password == "") {
-    ipc_send("auth", { ok: true, user: -1 });
-    loadPlayerConfig(playerData.arenaId);
-    playerData.userName = "";
+    offlineLogin();
   } else {
     playerData.userName = arg.username;
     tokenAuth = "";

--- a/window_background/http-api.js
+++ b/window_background/http-api.js
@@ -2,7 +2,6 @@
 global
   tokenAuth,
   decks,
-  rememberMe,
   rstore,
   loadPlayerConfig,
   cardsDb,
@@ -253,7 +252,7 @@ function httpBasic() {
 
                 ipc_send("auth", parsedResult);
                 //ipc_send("auth", parsedResult.arenaids);
-                if (rememberMe) {
+                if (rstore.get("settings").remember_me) {
                   rstore.set("token", tokenAuth);
                   rstore.set("email", playerData.userName);
                 }

--- a/window_background/http-api.js
+++ b/window_background/http-api.js
@@ -89,6 +89,7 @@ function httpBasic() {
         _headers.method != "get_status" &&
         debugLog == false
       ) {
+        ipc_send("set_offline", true);
         callback({
           message: "Settings dont allow sending data! > " + _headers.method
         });

--- a/window_background/http-api.js
+++ b/window_background/http-api.js
@@ -319,6 +319,7 @@ function httpBasic() {
                   time: 1000
                 });
                 ipc_send("set_db", results);
+                ipc_send("show_login", true);
               }
             } else if (_headers.method == "tou_join") {
               ipc_send("popup", {
@@ -380,6 +381,9 @@ function httpBasic() {
         });
       });
       req.on("error", function(e) {
+        if (_headers.method == "get_database") {
+          ipc_send("show_login", true);
+        }
         console.error(`problem with request: ${e.message}`);
         if (!metadataState) {
           ipc_send("popup", {

--- a/window_main/history.js
+++ b/window_main/history.js
@@ -23,6 +23,8 @@ globals
   playerData,
   tags_colors,
   showLoadingBars,
+  sidebarActive,
+  decks
   $$
 */
 
@@ -58,6 +60,8 @@ function filterMatch(match) {
 }
 
 function open_history_tab(loadMore) {
+  if (sidebarActive != 1 || decks == null) return;
+
   sort_decks();
   var mainDiv = document.getElementById("ux_0");
   var div, d;

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -922,6 +922,7 @@ $(document).ready(function() {
       }
       if ($(this).hasClass("it0")) {
         sidebarActive = 0;
+        $("#ux_0").html("");
         open_decks_tab();
       }
       if ($(this).hasClass("it1")) {

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -1963,7 +1963,7 @@ function toggleVisibility(...ids) {
 }
 
 //
-function add_checkbox(div, label, iid, def, func = "updateSettings()") {
+function add_checkbox(div, label, iid, def, func = "updateUserSettings()") {
   label = $('<label class="check_container hover_label">' + label + "</label>");
   label.appendTo(div);
   var check_new = $(
@@ -2010,6 +2010,13 @@ function open_settings(openSection) {
   section.appendTo(div);
   section.append('<div class="settings_title">Behaviour</div>');
 
+  add_checkbox(
+    section,
+    "Remember me",
+    "settings_rememberme",
+    settings.remember_me,
+    "updateAppSettings()"
+  );
   add_checkbox(
     section,
     "Launch on startup",
@@ -2208,7 +2215,7 @@ function open_settings(openSection) {
 
   colorPick.on("move.spectrum", function(e, color) {
     $(".main_wrapper").css("background-color", color.toRgbString());
-    updateSettings();
+    updateUsersettings();
   });
 
   label = $('<label class="but_container_label">Cards quality:</label>');
@@ -2412,12 +2419,12 @@ function open_settings(openSection) {
 
   url_input.on("keyup", function(e) {
     if (e.keyCode == 13) {
-      updateSettings();
+      updateUsersettings();
     }
   });
 
   export_input.on("keyup", function() {
-    updateSettings();
+    updateUsersettings();
   });
 
   $(".sliderA").off();
@@ -2440,7 +2447,7 @@ function open_settings(openSection) {
 
   $(".sliderA").on("click mouseup", function() {
     cardSizePos = Math.round(parseInt(this.value));
-    updateSettings();
+    updateUsersettings();
   });
 
   $(".sliderB").off();
@@ -2454,7 +2461,7 @@ function open_settings(openSection) {
 
   $(".sliderB").on("click mouseup", function() {
     overlayAlpha = alphaFromTransparency(parseInt(this.value));
-    updateSettings();
+    updateUsersettings();
   });
 
   $(".sliderC").on("click mousemove", function() {
@@ -2468,7 +2475,7 @@ function open_settings(openSection) {
 
   $(".sliderC").on("click mouseup", function() {
     overlayAlphaBack = alphaFromTransparency(parseInt(this.value));
-    updateSettings();
+    updateUsersettings();
   });
 
   $(".sliderD").off();
@@ -2480,7 +2487,7 @@ function open_settings(openSection) {
 
   $(".sliderD").on("click mouseup", function() {
     overlayScale = parseInt(this.value);
-    updateSettings();
+    updateUsersettings();
   });
 
   $(".sliderSoundVolume").off();
@@ -2491,7 +2498,7 @@ function open_settings(openSection) {
     );
     let { Howl, Howler } = require("howler");
     let sound = new Howl({ src: ["../sounds/blip.mp3"] });
-    updateSettings();
+    updateUsersettings();
     Howler.volume(settings.sound_priority_volume);
     sound.play();
   });
@@ -2569,7 +2576,7 @@ function changeQuality(dom) {
     cardQuality = "normal";
   }
   dom.innerHTML = cardQuality;
-  updateSettings();
+  updateUsersettings();
   open_settings(lastSettingsSection);
 }
 
@@ -2588,7 +2595,7 @@ function eraseData() {
 /* eslint-enable */
 
 //
-function updateSettings() {
+function updateUserSettings() {
   var startup = document.getElementById("settings_startup").checked;
   var readonlogin = document.getElementById("settings_readlogonlogin").checked;
   var showOverlay = document.getElementById("settings_showoverlay").checked;
@@ -2651,6 +2658,14 @@ function updateSettings() {
   };
   cardSize = 100 + cardSizePos * 10;
   ipc_send("save_user_settings", settings);
+}
+
+//
+function updateAppSettings() {
+  const rSettings = {
+    remember_me: document.getElementById("settings_rememberme").checked
+  };
+  ipc_send("save_app_settings", rSettings);
 }
 
 //

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -838,7 +838,6 @@ window.addEventListener("resize", event => {
 });
 
 $(document).ready(function() {
-  //document.getElementById("rememberme").checked = false;
   $(".signup_link").click(function() {
     shell.openExternal("https://mtgatool.com/signup/");
   });
@@ -2009,13 +2008,6 @@ function open_settings(openSection) {
 
   add_checkbox(
     section,
-    "Remember me",
-    "settings_rememberme",
-    settings.remember_me,
-    "updateAppSettings()"
-  );
-  add_checkbox(
-    section,
     "Login automatically",
     "settings_autologin",
     settings.auto_login,
@@ -2683,8 +2675,7 @@ function updateAppSettings() {
   }
   const rSettings = {
     auto_login,
-    launch_to_tray,
-    remember_me: document.getElementById("settings_rememberme").checked
+    launch_to_tray
   };
   ipc_send("save_app_settings", rSettings);
 }

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -734,6 +734,11 @@ ipc.on("log_ok", function() {
 });
 
 //
+ipc.on("set_offline", (_event, arg) => {
+  offlineMode = arg;
+});
+
+//
 ipc.on("offline", function() {
   showOfflineSplash();
 });
@@ -844,7 +849,6 @@ $(document).ready(function() {
 
   $(".offline_link").click(function() {
     ipc_send("login", { username: "", password: "" });
-    offlineMode = true;
     $(".unlink").show();
   });
 

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -2369,6 +2369,12 @@ function open_settings(openSection) {
   });
 
   $(".login_link_about").click(function() {
+    const clearAppSettings = {
+      remember_me: false,
+      auto_login: false,
+      launch_to_tray: false
+    };
+    ipc_send("save_app_settings", clearAppSettings);
     remote.app.relaunch();
     remote.app.exit(0);
   });

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -2033,7 +2033,6 @@ function open_settings(openSection) {
     settings.launch_to_tray,
     "updateAppSettings()"
   );
-  launchToTrayCheckbox.attr("style", "margin-left:64px;");
   add_checkbox(
     section,
     "Launch on startup",
@@ -2687,11 +2686,6 @@ function updateUserSettings() {
 function updateAppSettings() {
   const auto_login = document.getElementById("settings_autologin").checked;
   let launch_to_tray = document.getElementById("settings_launchtotray").checked;
-  // launch to tray depends on auto login
-  if (!auto_login) {
-    launch_to_tray = false;
-    document.getElementById("settings_launchtotray").checked = false;
-  }
   const rSettings = {
     auto_login,
     launch_to_tray

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -617,19 +617,18 @@ ipc.on("init_login", function() {
 });
 
 //
-ipc.on("set_remember", function(event, arg) {
-  if (arg != "") {
-    document.getElementById("rememberme").checked = true;
-    document.getElementById("signin_user").value = arg;
-    document.getElementById("signin_pass").value = "********";
-  } else {
-    document.getElementById("rememberme").checked = false;
-  }
+ipc.on("prefill_auth_form", function(event, arg) {
+  document.getElementById("rememberme").checked = arg.remember_me;
+  document.getElementById("signin_user").value = arg.username;
+  document.getElementById("signin_pass").value = arg.password;
 });
 
 //
 function rememberMe() {
-  ipc_send("remember", document.getElementById("rememberme").checked);
+  const rSettings = {
+    remember_me: document.getElementById("rememberme").checked
+  };
+  ipc_send("save_app_settings", rSettings);
 }
 
 //
@@ -2651,7 +2650,7 @@ function updateSettings() {
     skip_firstpass: !readonlogin
   };
   cardSize = 100 + cardSizePos * 10;
-  ipc_send("save_settings", settings);
+  ipc_send("save_user_settings", settings);
 }
 
 //

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -22,6 +22,7 @@ global
   windowRenderer,
   deck_count_types,
   removeDuplicates,
+  HIDDEN_PW,
   $$
 */
 
@@ -860,7 +861,7 @@ $(document).ready(function() {
     if (canLogin) {
       var user = document.getElementById("signin_user").value;
       var pass = document.getElementById("signin_pass").value;
-      if (pass != "********") {
+      if (pass != HIDDEN_PW) {
         pass = sha1(pass);
       }
       ipc_send("login", { username: user, password: pass });

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -178,6 +178,7 @@ ipc.on("auth", function(event, arg) {
     loggedIn = true;
   } else {
     canLogin = true;
+    ipc_send("renderer_show");
     pop(arg.error, -1);
   }
 });
@@ -237,6 +238,9 @@ ipc.on("set_db", function(event, arg) {
     delete arg.ranked_events;
     canLogin = true;
     cardsDb.set(arg);
+    $(".authenticate").show();
+    $(".message_center").css("display", "none");
+    $(".init_loading").hide();
     $(".button_simple_disabled").addClass("button_simple");
     $("#signin_user").focus();
   } catch (e) {
@@ -607,13 +611,6 @@ ipc.on("force_open_settings", function() {
 //
 ipc.on("force_open_about", function() {
   force_open_about();
-});
-
-//
-ipc.on("init_login", function() {
-  $(".authenticate").show();
-  $(".message_center").css("display", "none");
-  $(".init_loading").hide();
 });
 
 //
@@ -2024,6 +2021,14 @@ function open_settings(openSection) {
     settings.auto_login,
     "updateAppSettings()"
   );
+  const launchToTrayCheckbox = add_checkbox(
+    section,
+    "Launch to tray",
+    "settings_launchtotray",
+    settings.launch_to_tray,
+    "updateAppSettings()"
+  );
+  launchToTrayCheckbox.attr("style", "margin-left:64px;");
   add_checkbox(
     section,
     "Launch on startup",
@@ -2669,8 +2674,16 @@ function updateUserSettings() {
 
 //
 function updateAppSettings() {
+  const auto_login = document.getElementById("settings_autologin").checked;
+  let launch_to_tray = document.getElementById("settings_launchtotray").checked;
+  // launch to tray depends on auto login
+  if (!auto_login) {
+    launch_to_tray = false;
+    document.getElementById("settings_launchtotray").checked = false;
+  }
   const rSettings = {
-    auto_login: document.getElementById("settings_autologin").checked,
+    auto_login,
+    launch_to_tray,
     remember_me: document.getElementById("settings_rememberme").checked
   };
   ipc_send("save_app_settings", rSettings);

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -2019,6 +2019,13 @@ function open_settings(openSection) {
   );
   add_checkbox(
     section,
+    "Login automatically",
+    "settings_autologin",
+    settings.auto_login,
+    "updateAppSettings()"
+  );
+  add_checkbox(
+    section,
     "Launch on startup",
     "settings_startup",
     settings.startup
@@ -2663,6 +2670,7 @@ function updateUserSettings() {
 //
 function updateAppSettings() {
   const rSettings = {
+    auto_login: document.getElementById("settings_autologin").checked,
     remember_me: document.getElementById("settings_rememberme").checked
   };
   ipc_send("save_app_settings", rSettings);

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -236,19 +236,28 @@ ipc.on("set_db", function(event, arg) {
     delete arg.events;
     delete arg.events_format;
     delete arg.ranked_events;
-    canLogin = true;
     cardsDb.set(arg);
-    $(".authenticate").show();
-    $(".message_center").css("display", "none");
-    $(".init_loading").hide();
-    $(".button_simple_disabled").addClass("button_simple");
-    $("#signin_user").focus();
+    canLogin = true;
+    showLogin();
   } catch (e) {
     pop("Error parsing metadata", null);
     console.log("Error parsing metadata", e);
     return false;
   }
 });
+
+ipc.on("show_login", () => {
+  canLogin = true;
+  showLogin();
+});
+
+function showLogin() {
+  $(".authenticate").show();
+  $(".message_center").css("display", "none");
+  $(".init_loading").hide();
+  $(".button_simple_disabled").addClass("button_simple");
+  $("#signin_user").focus();
+}
 
 //
 ipc.on("set_player_data", (event, _data) => {


### PR DESCRIPTION
## Motivation
![image](https://user-images.githubusercontent.com/14894693/56085889-60e2d480-5e00-11e9-866e-b2c45ffc9129.png)

## Approach
- Refactor signals and handlers related to settings and config
  - `background` handles config persistence and resolution
    - new `rstore.settings` holds app config, new IPC signals and handlers for saving
    - all handlers that modify stores call `loadSettings` afterwards to propagate changes
      - eliminated `relay` concept entirely
    - `loadSettings` reads defaults, then user config, then app config
      - passes blended config on to IPC
  - `main`, `renderer`, and other windows can continue to use a unified `settings` downstream of IPC
- Add `auto_login` and `launch_to_tray` to app config
- Add checkboxes and new `setAppSettings` handler to Settings page
  - Launch to tray is only possible if Auto login is enabled
  - [ ] TODO make Auto login checkbox appear disabled when necessary
- Refactor startup bootstrapping logic
  - Display loading screen until _after_ `set_db` signal
  - Send new `auto_login` signal if enabled
  - Hide window if `launch_to_tray` enabled
    - Display window if any issue occurs in auth
  - Otherwise activate login form and show as before

## Other Refactors
- extract magic pw string "********" to `util.HIDDEN_PW`
- move "Remember Me" state into `rstore.settings`
- future config settings will auto-populate defaults (see comment below)


## Bonus Bugfixes
- Gracefully handle opening the History page with no data
- [x] Correctly move to offline mode when "Privacy > Online Sharing" is disabled



## Demo

### Auto Login Online
![auto-login-online](https://user-images.githubusercontent.com/14894693/56085899-81ab2a00-5e00-11e9-9d25-6124cb9cfaa0.gif)

### Launch to Tray
![launch-to-tray](https://user-images.githubusercontent.com/14894693/56085906-91c30980-5e00-11e9-91e7-2fecb8785f10.gif)

### Auto Login Offline
![auto-login-offline](https://user-images.githubusercontent.com/14894693/56085902-8a036500-5e00-11e9-89eb-8d50469d5d91.gif)

