### PR TITLE
Add count mode filter to collection stats

### DIFF
--- a/shared/util.js
+++ b/shared/util.js
@@ -1370,13 +1370,22 @@ function get_set_code(set) {
 
 //
 class CountStats {
-  constructor(owned = 0, total = 0, unique = 0, complete = 0, wanted = 0, uniqueWanted = 0) {
+  constructor(
+    owned = 0,
+    total = 0,
+    unique = 0,
+    complete = 0,
+    wanted = 0,
+    uniqueWanted = 0,
+    uniqueOwned = 0
+  ) {
     this.owned = owned;
     this.total = total;
     this.unique = unique;
     this.complete = complete; // all 4 copies of a card
     this.wanted = wanted;
     this.uniqueWanted = uniqueWanted;
+    this.uniqueOwned = uniqueOwned;
   }
 
   get percentage() {
@@ -1409,7 +1418,9 @@ class SetStats {
       acc.owned += c.owned;
       acc.total += c.total;
       acc.unique += c.unique;
+      acc.complete += c.complete;
       acc.wanted += c.wanted;
+      acc.uniqueOwned += c.uniqueOwned;
       return acc;
     });
   }
@@ -1418,8 +1429,7 @@ class SetStats {
 //
 function get_collection_stats() {
   const stats = {
-    complete: new SetStats("complete"),
-    singles: new SetStats("singles")
+    complete: new SetStats("complete")
   };
 
   for (var set in setsList) {
@@ -1440,23 +1450,21 @@ function get_collection_stats() {
         // add to totals
         stats[card.set][card.rarity].total += 4;
         stats.complete[card.rarity].total += 4;
-        stats.singles[card.rarity].total += 1;
         stats[card.set][card.rarity].unique += 1;
         stats.complete[card.rarity].unique += 1;
-        stats.singles[card.rarity].unique += 1;
 
         // add cards we own
         if (cards[grpId] !== undefined) {
           var owned = cards[grpId];
           stats[card.set][card.rarity].owned += owned;
           stats.complete[card.rarity].owned += owned;
-          stats.singles[card.rarity].owned += 1;
+          stats[card.set][card.rarity].uniqueOwned += 1;
+          stats.complete[card.rarity].uniqueOwned += 1;
 
           // count complete sets we own
           if (owned == 4) {
             stats[card.set][card.rarity].complete += 1;
             stats.complete[card.rarity].complete += 1;
-            stats.singles[card.rarity].complete += 1;
           }
         }
 
@@ -1465,12 +1473,10 @@ function get_collection_stats() {
         let wanted = Math.max(...deckWantedCounts);
         stats[card.set][card.rarity].wanted += wanted;
         stats.complete[card.rarity].wanted += wanted;
-        stats.singles[card.rarity].wanted += Math.min(1, wanted);
 
         // count unique cards we know we want across decks
         stats[card.set][card.rarity].uniqueWanted += Math.min(1, wanted);
         stats.complete[card.rarity].uniqueWanted += Math.min(1, wanted);
-        stats.singles[card.rarity].uniqueWanted += Math.min(1, wanted);
       }
     }
   });


### PR DESCRIPTION
### Motivation
The goal here was to expose more of the underlying counts that we do for collection statistics, specifically to let users think about either singletons or complete sets of 4 cards by-set and by-rarity. This may be related to https://github.com/Manuel-777/MTG-Arena-Tool/issues/267

### Demo
![stats-count-modes](https://user-images.githubusercontent.com/14894693/56541217-f4fb1d00-651f-11e9-9ce3-1ab3e0df44bf.gif)

### Other Notes
- Moved the total collection set to the top of the list
- Deleted the now redundant "singleton" collection
- cleaned up the old aggregation math related to singletons
