### PR TITLE
Backports and Bugfixes

### DIFF
--- a/shared/cards-list.js
+++ b/shared/cards-list.js
@@ -15,6 +15,7 @@ class CardsList {
     if (!list) list = [];
     this._list = list.map(obj => {
       return {
+        ...obj,
         quantity: obj.quantity || 1,
         id: obj.id || obj,
         measurable: true

--- a/window_main/economy.js
+++ b/window_main/economy.js
@@ -232,7 +232,11 @@ function createDayHeader(change) {
   const icva = tx.cloneNode(true);
   icva.innerHTML = "Vault:";
   const vatx = tx.cloneNode(true);
-  const deltaPercent = dayList[daysago].vaultProgress / 100.0;
+  const rawDelta = dayList[daysago].vaultProgress;
+  // Assume vault can only be redeemed once per day
+  // Rely on modulo arithmetic to derive pure vault gain
+  const delta = rawDelta < 0 ? rawDelta + 100 : rawDelta;
+  const deltaPercent = delta / 100.0;
   vatx.innerHTML = deltaPercent.toLocaleString([], {
     style: "percent",
     maximumSignificantDigits: 2

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -1470,8 +1470,8 @@ function open_draft(id, tileGrpid, set) {
   var pi = Math.floor(((draftPosition - 1) / 2) % packSize);
   var key = "pack_" + pa + "pick_" + pi;
 
-  var pack = draft[key].pack;
-  var pick = draft[key].pick;
+  var pack = (draft[key] && draft[key].pack) || [];
+  var pick = (draft[key] && draft[key].pick) || "";
 
   var top = $(
     '<div class="decklist_top"><div class="button back"></div><div class="deck_name">' +

--- a/window_overlay/index.css
+++ b/window_overlay/index.css
@@ -82,6 +82,10 @@ body {
     z-index: 50;
 }
 
+.overlay_clock_spacer {
+    min-height: 64px;
+}
+
 .overlay_clock_container {
     -webkit-app-region: drag;
     position: relative;

--- a/window_overlay/index.html
+++ b/window_overlay/index.html
@@ -48,6 +48,8 @@
                 <div class="draft_next"></div>
             </div>
 
+            <div class="overlay_clock_spacer" />
+
             <div class="overlay_clock_container click-on">
                 <div class="clock_prev"></div>
                 <div class="clock_turn"></div>

--- a/window_overlay/overlay.js
+++ b/window_overlay/overlay.js
@@ -628,7 +628,11 @@ function setDraft(_packN = -1, _pickN = -1) {
   }
   $(".overlay_decklist").html("");
   $(".overlay_deckcolors").html("");
-  $(".overlay_deckname").html("Pack " + (packN + 1) + " - Pick " + (pickN + 1));
+  let title = "Pack " + (packN + 1) + " - Pick " + (pickN + 1);
+  if (packN === currentDraft.packNumber && pickN === currentDraft.pickNumber) {
+    title += " - Current";
+  }
+  $(".overlay_deckname").html(title);
 
   let colors;
   if (draftMode == 0) {

--- a/window_overlay/overlay.js
+++ b/window_overlay/overlay.js
@@ -809,7 +809,10 @@ $(document).ready(function() {
       packN = 0;
     }
 
-    if (pickN == currentDraft.pickNumber && packN == currentDraft.packNumber) {
+    if (
+      packN > currentDraft.packNumber ||
+      (pickN == currentDraft.pickNumber && packN == currentDraft.packNumber)
+    ) {
       setDraft();
     } else {
       setDraft(packN, pickN);

--- a/window_overlay/overlay.js
+++ b/window_overlay/overlay.js
@@ -2,7 +2,10 @@
 global
   addCardTile,
   cardsDb,
+  compare_cards,
+  compare_chances,
   compare_draft_cards,
+  CardsList,
   Deck,
   draftRanks,
   get_ids_colors,
@@ -307,7 +310,6 @@ ipc.on("set_match", (event, arg) => {
   currentMatch = JSON.parse(arg);
 
   currentMatch.oppCards = new Deck(currentMatch.oppCards);
-  currentMatch.oppCards.sortMainboard(compare_cards);
 
   let tempMain = currentMatch.playerCardsLeft.mainDeck;
   currentMatch.playerCardsLeft = new Deck(currentMatch.playerCardsLeft);
@@ -447,7 +449,17 @@ function updateView() {
   }
 
   if (!deckToDraw) return;
-  deckToDraw.mainboard.get().forEach(card => {
+
+  let sortFunc = compare_cards;
+  if (deckMode === 2) {
+    sortFunc = compare_chances;
+  }
+
+  const mainCards = new CardsList(deckToDraw.mainboard.get());
+  mainCards.removeDuplicates();
+  mainCards.get().sort(sortFunc);
+
+  mainCards.get().forEach(card => {
     var grpId = card.id;
     if (deckMode == 2) {
       addCardTile(
@@ -463,7 +475,11 @@ function updateView() {
   if (showSideboard && deckToDraw.sideboard.count() > 0) {
     deckListDiv.append('<div class="card_tile_separator">Sideboard</div>');
 
-    deckToDraw.sideboard.get().forEach(function(card) {
+    const sideCards = new CardsList(deckToDraw.sideboard.get());
+    sideCards.removeDuplicates();
+    sideCards.get().sort(sortFunc);
+
+    sideCards.get().forEach(function(card) {
       var grpId = card.id;
       if (deckMode == 2) {
         addCardTile(grpId, "a", "0%", deckListDiv);

--- a/window_overlay/overlay.js
+++ b/window_overlay/overlay.js
@@ -240,6 +240,7 @@ ipc.on("set_settings", function(event, settings) {
   $(".overlay_deckcolors").css("display", "");
   $(".overlay_separator").css("display", "");
   $(".overlay_decklist").css("display", "");
+  $(".overlay_clock_spacer").css("display", "");
   $(".overlay_clock_container").css("display", "");
   $(".overlay_deck_container").attr("style", "");
   $(".overlay_draft_container").attr("style", "");
@@ -264,6 +265,7 @@ ipc.on("set_settings", function(event, settings) {
     hideDiv(".overlay_draft_container");
   }
   if (!settings.overlay_clock || overlayMode == 1) {
+    hideDiv(".overlay_clock_spacer");
     hideDiv(".overlay_clock_container");
   }
 });

--- a/window_overlay/overlay.js
+++ b/window_overlay/overlay.js
@@ -196,6 +196,7 @@ ipc.on("action_log", function(event, arg) {
   if (arg.seat == -99) {
     actionLog = [];
   }
+  actionLog.sort(compare_logs);
   //console.log(arg.seat, arg.str);
 });
 
@@ -353,18 +354,7 @@ function updateView() {
   if (deckMode == 4) {
     $(".overlay_deckname").html("Action Log");
 
-    let defaultIndex = 0;
-    let sortedLog = [];
-    actionLog.forEach(log => {
-      const newLog = { ...log, defaultIndex };
-      defaultIndex++;
-      sortedLog.push(newLog);
-    });
-    sortedLog.sort(
-      (a, b) => b.time - a.time || b.defaultIndex - a.defaultIndex
-    );
-
-    sortedLog.forEach(function(log) {
+    actionLog.forEach(function(log) {
       var d = new Date(log.time);
       var hh = ("0" + d.getHours()).slice(-2);
       var mm = ("0" + d.getMinutes()).slice(-2);

--- a/window_overlay/overlay.js
+++ b/window_overlay/overlay.js
@@ -196,7 +196,6 @@ ipc.on("action_log", function(event, arg) {
   if (arg.seat == -99) {
     actionLog = [];
   }
-  actionLog.sort(compare_logs);
   //console.log(arg.seat, arg.str);
 });
 
@@ -354,7 +353,18 @@ function updateView() {
   if (deckMode == 4) {
     $(".overlay_deckname").html("Action Log");
 
-    actionLog.forEach(function(log) {
+    let defaultIndex = 0;
+    let sortedLog = [];
+    actionLog.forEach(log => {
+      const newLog = { ...log, defaultIndex };
+      defaultIndex++;
+      sortedLog.push(newLog);
+    });
+    sortedLog.sort(
+      (a, b) => b.time - a.time || b.defaultIndex - a.defaultIndex
+    );
+
+    sortedLog.forEach(function(log) {
       var d = new Date(log.time);
       var hh = ("0" + d.getHours()).slice(-2);
       var mm = ("0" + d.getMinutes()).slice(-2);

--- a/window_overlay/overlay.js
+++ b/window_overlay/overlay.js
@@ -781,7 +781,7 @@ $(document).ready(function() {
   //
   $(".draft_prev").click(function() {
     pickN -= 1;
-    let packSize = packSizes[currentDraft.set] || 13;
+    let packSize = packSizes[currentDraft.set] || 14;
 
     if (pickN < 0) {
       pickN = packSize;
@@ -797,7 +797,7 @@ $(document).ready(function() {
   //
   $(".draft_next").click(function() {
     pickN += 1;
-    let packSize = packSizes[currentDraft.set] || 13;
+    let packSize = packSizes[currentDraft.set] || 14;
 
     if (pickN > packSize) {
       pickN = 0;


### PR DESCRIPTION
## Random Backports and Bugfixes
This is a handful of backports from the current build in https://github.com/lusbenjamin/MTG-Arena-Tool/tree/create-react-app


### Overlay
  - Added a "Current" to the title for the current pack/pick in draft mode.
  - I believe the default for maximum pack size should be `15 - 1 = 14`, not sure why it was `13` before
  - In some odd edge cases, the draft mode next pick toggle can go beyond the 3rd pack. I fixed the boundary logic to catch those cases.
  - When the main content requires scroll, the final bit can be blocked by the floating clock. I added a spacing `div` before the clock to fix this.
  - Implements sorting and deduplication using the new object utilities. ([we had a feature regression here](https://github.com/lusbenjamin/MTG-Arena-Tool/commit/89a29572a81e73152b8666712fe0b0fa2c0b4f26#diff-1435c8c1268f77062c3d0894c22de331L398))
![image](https://user-images.githubusercontent.com/14894693/56856607-0de64280-6913-11e9-820a-2064e0f9f61d.png)


### Action Log
  - ~~Added a stabilizing `defaultIndex` to keep log entries with duplicate times from jumping around~~
  - ~~Reversed log order so recent entries always appear at the top~~

### Economy Page
  - Opening your vault will now only display your positive Vault progress in the daily summary bar
![image](https://user-images.githubusercontent.com/14894693/56831353-ac907780-681d-11e9-87e1-eac84826e1c9.png)


### History Page
  - Bugfix for https://github.com/Manuel-777/MTG-Arena-Tool/issues/283 - Opening a draft replay with partially complete pack/pick data will now fail gracefully
