### PR TITLE
crop deck images higher up

### DIFF
--- a/window_main/index.css
+++ b/window_main/index.css
@@ -432,7 +432,8 @@ span.top_nav_item_text {
     opacity: 0.66;
     background-image: url('');
     background-size: 200px;
-    background-position: center;
+    background-position-x: center;
+    background-position-y: -10px;
     -webkit-transition: .2s ease-out;
     transition: width opacity;
 }


### PR DESCRIPTION
<img width="358" alt="kaya-before" src="https://user-images.githubusercontent.com/14894693/56856872-48eb7480-6919-11e9-9653-a7d3e89ed5dd.png">
<img width="350" alt="kaya-after" src="https://user-images.githubusercontent.com/14894693/56856873-4be66500-6919-11e9-9fa1-c5b2f3ad1ca1.png">


Looks better for most images:
![image](https://user-images.githubusercontent.com/14894693/56856881-5f91cb80-6919-11e9-91fa-f4d862d75e8e.png)



