### PR TITLE
bugfix sample size math

### DIFF
--- a/window_background/background.js
+++ b/window_background/background.js
@@ -1662,40 +1662,32 @@ function forceDeckUpdate(removeUsed = true) {
     }
     let main = currentMatch.playerCardsLeft.mainboard;
     main.addProperty("chance", card =>
-      Math.round(
-        hypergeometricRange(
-          1,
-          Math.min(odds_sample_size, card.quantity),
-          cardsleft,
-          odds_sample_size,
-          card.quantity
-        ) * 100
-      )
+      getChance(card.quantity, cardsleft, odds_sample_size)
     );
 
-    typeLan = Math.min(odds_sample_size, main.countType("Land"));
-    typeCre = Math.min(odds_sample_size, main.countType("Creature"));
-    typeArt = Math.min(odds_sample_size, main.countType("Artifact"));
-    typeEnc = Math.min(odds_sample_size, main.countType("Enchantment"));
-    typeIns = Math.min(odds_sample_size, main.countType("Instant"));
-    typeSor = Math.min(odds_sample_size, main.countType("Sorcery"));
-    typePla = Math.min(odds_sample_size, main.countType("Planeswalker"));
+    typeLan = main.countType("Land");
+    typeCre = main.countType("Creature");
+    typeArt = main.countType("Artifact");
+    typeEnc = main.countType("Enchantment");
+    typeIns = main.countType("Instant");
+    typeSor = main.countType("Sorcery");
+    typePla = main.countType("Planeswalker");
 
     let chancesObj = {};
-    chancesObj.chanceCre = chanceType(typeCre, cardsleft, odds_sample_size);
-    chancesObj.chanceIns = chanceType(typeIns, cardsleft, odds_sample_size);
-    chancesObj.chanceSor = chanceType(typeSor, cardsleft, odds_sample_size);
-    chancesObj.chancePla = chanceType(typePla, cardsleft, odds_sample_size);
-    chancesObj.chanceArt = chanceType(typeArt, cardsleft, odds_sample_size);
-    chancesObj.chanceEnc = chanceType(typeEnc, cardsleft, odds_sample_size);
-    chancesObj.chanceLan = chanceType(typeLan, cardsleft, odds_sample_size);
+    chancesObj.chanceCre = getChance(typeCre, cardsleft, odds_sample_size);
+    chancesObj.chanceIns = getChance(typeIns, cardsleft, odds_sample_size);
+    chancesObj.chanceSor = getChance(typeSor, cardsleft, odds_sample_size);
+    chancesObj.chancePla = getChance(typePla, cardsleft, odds_sample_size);
+    chancesObj.chanceArt = getChance(typeArt, cardsleft, odds_sample_size);
+    chancesObj.chanceEnc = getChance(typeEnc, cardsleft, odds_sample_size);
+    chancesObj.chanceLan = getChance(typeLan, cardsleft, odds_sample_size);
 
     chancesObj.deckSize = decksize;
     chancesObj.cardsLeft = cardsleft;
     currentMatch.playerChances = chancesObj;
   } else {
     let main = currentMatch.playerCardsLeft.mainboard;
-    main.addProperty("chance", card => 1);
+    main.addProperty("chance", () => 1);
 
     let chancesObj = {};
     chancesObj.chanceCre = 0;
@@ -1709,18 +1701,15 @@ function forceDeckUpdate(removeUsed = true) {
   }
 }
 
-function chanceType(typeNumber, cardsleft, odds_sample_size) {
-  return (
-    Math.round(
-      hypergeometricRange(
-        1,
-        typeNumber,
-        cardsleft,
-        odds_sample_size,
-        typeNumber
-      ) * 1000
-    ) / 10
-  );
+function getChance(quantity, cardsleft, odds_sample_size) {
+  return Math.round(
+    hypergeometricRange(
+      1,
+      Math.min(odds_sample_size, quantity),
+      cardsleft,
+      odds_sample_size,
+      quantity
+    ) * 100);
 }
 
 //

--- a/window_background/background.js
+++ b/window_background/background.js
@@ -1662,7 +1662,15 @@ function forceDeckUpdate(removeUsed = true) {
     }
     let main = currentMatch.playerCardsLeft.mainboard;
     main.addProperty("chance", card =>
-      getChance(card.quantity, cardsleft, odds_sample_size)
+      Math.round(
+        hypergeometricRange(
+          1,
+          Math.min(odds_sample_size, card.quantity),
+          cardsleft,
+          odds_sample_size,
+          card.quantity
+        ) * 100
+      )
     );
 
     typeLan = main.countType("Land");
@@ -1674,13 +1682,13 @@ function forceDeckUpdate(removeUsed = true) {
     typePla = main.countType("Planeswalker");
 
     let chancesObj = {};
-    chancesObj.chanceCre = getChance(typeCre, cardsleft, odds_sample_size);
-    chancesObj.chanceIns = getChance(typeIns, cardsleft, odds_sample_size);
-    chancesObj.chanceSor = getChance(typeSor, cardsleft, odds_sample_size);
-    chancesObj.chancePla = getChance(typePla, cardsleft, odds_sample_size);
-    chancesObj.chanceArt = getChance(typeArt, cardsleft, odds_sample_size);
-    chancesObj.chanceEnc = getChance(typeEnc, cardsleft, odds_sample_size);
-    chancesObj.chanceLan = getChance(typeLan, cardsleft, odds_sample_size);
+    chancesObj.chanceCre = chanceType(typeCre, cardsleft, odds_sample_size);
+    chancesObj.chanceIns = chanceType(typeIns, cardsleft, odds_sample_size);
+    chancesObj.chanceSor = chanceType(typeSor, cardsleft, odds_sample_size);
+    chancesObj.chancePla = chanceType(typePla, cardsleft, odds_sample_size);
+    chancesObj.chanceArt = chanceType(typeArt, cardsleft, odds_sample_size);
+    chancesObj.chanceEnc = chanceType(typeEnc, cardsleft, odds_sample_size);
+    chancesObj.chanceLan = chanceType(typeLan, cardsleft, odds_sample_size);
 
     chancesObj.deckSize = decksize;
     chancesObj.cardsLeft = cardsleft;
@@ -1701,15 +1709,18 @@ function forceDeckUpdate(removeUsed = true) {
   }
 }
 
-function getChance(quantity, cardsleft, odds_sample_size) {
-  return Math.round(
-    hypergeometricRange(
-      1,
-      Math.min(odds_sample_size, quantity),
-      cardsleft,
-      odds_sample_size,
-      quantity
-    ) * 100);
+function chanceType(quantity, cardsleft, odds_sample_size) {
+  return (
+    Math.round(
+      hypergeometricRange(
+        1,
+        Math.min(odds_sample_size, quantity),
+        cardsleft,
+        odds_sample_size,
+        quantity
+      ) * 1000
+    ) / 10
+  );
 }
 
 //


### PR DESCRIPTION
## Motivation
We had a regression in our Sample Size panel when we [migrated to the new interpreter engine](https://github.com/Manuel-777/MTG-Arena-Tool/commit/89a29572a81e73152b8666712fe0b0fa2c0b4f26#diff-9179d37aa838679c9dd3c54d801755f9). I believe our current math always assumes you have exactly `odds_sample_size` (e.g. 1) creature/land/etc instead of using the count in the deck.

Fixes the other half of https://github.com/Manuel-777/MTG-Arena-Tool/issues/296

## Approach
Revert to old correct math. ~~Refactor to use a single helper method while I'm at it.~~

## Demo
<img width="367" alt="Annotation 2019-04-29 132658" src="https://user-images.githubusercontent.com/14894693/56924930-fb8b1680-6a82-11e9-966e-570168403897.png">
