### PR TITLE
Deck Format Tags

### DIFF
--- a/shared/util.js
+++ b/shared/util.js
@@ -618,6 +618,23 @@ const enums = {
 var setsList = cardsDb.get("sets");
 var eventsList = cardsDb.get("events");
 var eventsToFormat = cardsDb.get("events_format");
+const formats = {
+  Standard: "Standard",
+  TraditionalStandard: "Traditional Standard",
+  Draft: "Draft",
+  Sealed: "Sealed",
+  Pauper: "Pauper",
+  Singleton: "Singleton",
+  Cascade: "Cascade",
+  Pandemonium: "Pandemonium",
+  NoInstants: "No Instants",
+  DirectGame: "Direct Game",
+  precon: "Preconstructed",
+  Ravnica: "Ravnica Block",
+  Ixalan: "Ixalan Block",
+  GRN: "Ravnica Constructed",
+  XLN: "Ixalan Constructed"
+};
 var rankedEvents = cardsDb.get("ranked_events");
 var renderer = 0;
 var rarities = ["common", "uncommon", "rare", "mythic"];
@@ -1150,12 +1167,19 @@ function getReadableEvent(arg) {
   return arg;
 }
 
+//
+function getReadableFormat(format) {
+  if (format in formats) {
+    return formats[format];
+  }
+  return format || "Unknown";
+}
+
 function getReadableQuest(questCode) {
   // FIXME: Can we get a human readable quest name?
   // For now lets just use a small portion of the ID.
   return `#${questCode.substring(0, 6)}`
 }
-
 
 //
 function getEventId(arg) {

--- a/window_background/background.js
+++ b/window_background/background.js
@@ -258,17 +258,6 @@ var wcMythic = 0;
 
 var lastDeckUpdate = new Date();
 
-let formats = {
-  Standard: "Standard",
-  TraditionalStandard: "Traditional Standard",
-  Pauper: "Pauper",
-  Singleton: "Singleton",
-  NoInstants: "No Instants",
-  Ravnica: "Ravnica Constructed",
-  XLN: "Ixalan Constructed",
-  Pandemonium: "Pandemonium"
-};
-
 // Begin of IPC messages recievers
 function ipc_send(method, arg, to = windowRenderer) {
   if (method == "ipc_log") {

--- a/window_background/labels.js
+++ b/window_background/labels.js
@@ -259,9 +259,6 @@ function onLabelInDeckGetDeckLists(entry, json) {
     let deckId = deck.id;
     deck.tags = decks_tags[deckId];
     if (!deck.tags) deck.tags = [];
-    if (deck.tags.indexOf(formats[deck.format]) == -1) {
-      deck.tags.push(formats[deck.format]);
-    }
 
     decks[deckId] = deck;
     if (decks["index"].indexOf(deckId) == -1) {

--- a/window_main/decks.js
+++ b/window_main/decks.js
@@ -15,6 +15,20 @@ global
 
 let filterTag = "All";
 
+const formats = {
+  precon: "Preconstructed",
+  Standard: "Standard",
+  Sealed: "Sealed",
+  Draft: "Draft",
+  TraditionalStandard: "Traditional Standard",
+  Pauper: "Pauper",
+  Singleton: "Singleton",
+  NoInstants: "No Instants",
+  Ravnica: "Ravnica Constructed",
+  XLN: "Ixalan Constructed",
+  Pandemonium: "Pandemonium"
+};
+
 //
 function open_decks_tab() {
   if (sidebarActive == 0 && decks != null) {

--- a/window_main/decks.js
+++ b/window_main/decks.js
@@ -6,6 +6,7 @@ global
 	sort_decks,
 	cards,
 	getDeckWinrate,
+  getReadableFormat,
 	open_deck,
 	tags_colors,
 	ipc_send,
@@ -14,28 +15,6 @@ global
 */
 
 let filterTag = "All";
-
-const formats = {
-  precon: "Preconstructed",
-  Standard: "Standard",
-  Sealed: "Sealed",
-  Draft: "Draft",
-  TraditionalStandard: "Traditional Standard",
-  Pauper: "Pauper",
-  Singleton: "Singleton",
-  NoInstants: "No Instants",
-  Ravnica: "Ravnica Constructed",
-  XLN: "Ixalan Constructed",
-  Pandemonium: "Pandemonium"
-};
-
-//
-function getReadableFormat(format) {
-  if (format in formats) {
-    return formats[format];
-  }
-  return format || "Unknown";
-}
 
 //
 function open_decks_tab() {


### PR DESCRIPTION
### Motivation
- I want to see my Sealed and Draft decks auto-tagged with formats the same way my Constructed decks are.
- I am confused when I attempt to remove a "Standard" tag and it magically reappears later.

### Approach
- Since we are already capturing `deck.format`, let's explicitly use it in the display code instead of depending on auto-tagging.
- Update `formats` constant, move to `util`, create new `getReadableFormat` helper
- Add all formats to Decks page explicitly as tag-aliases
  - Hook up to existing tag display and colorizing logic
    - Style slightly differently, do not let users remove them
  - Sort formats in filter by count of decks in format
- Remove initial `deck.tags` population based on `deck.format` during import (we shouldn't need it any more and it didn't work for limited).


### Demo
![image](https://user-images.githubusercontent.com/14894693/56983830-7d3d7b80-6b39-11e9-8ed1-b4c7296cd91a.png)

