### PR TITLE
Page Transitions

### DIFF
--- a/window_main/collection.js
+++ b/window_main/collection.js
@@ -16,6 +16,7 @@ global
   get_collection_export,
   get_collection_stats,
   get_set_scryfall,
+  hideLoadingBars,
   orderedColorCodesCommon,
   setsList,
   cardSize,
@@ -50,6 +51,7 @@ function openCollectionTab() {
     return 0;
   });
 
+  hideLoadingBars();
   document.getElementById("ux_1").innerHTML = "";
   let mainDiv = document.getElementById("ux_0");
   mainDiv.innerHTML = "";

--- a/window_main/decks.js
+++ b/window_main/decks.js
@@ -7,6 +7,7 @@ global
 	cards,
 	getDeckWinrate,
   getReadableFormat,
+  hideLoadingBars,
 	open_deck,
 	tags_colors,
 	ipc_send,
@@ -20,6 +21,7 @@ let filterTag = "All";
 function open_decks_tab() {
   if (sidebarActive == 0 && decks != null) {
     sort_decks();
+    hideLoadingBars();
     var mainDiv = document.getElementById("ux_0");
     mainDiv.classList.remove("flex_item");
     mainDiv.innerHTML = "";

--- a/window_main/economy.js
+++ b/window_main/economy.js
@@ -13,6 +13,7 @@ global
   get_card_image,
   get_set_scryfall,
   getReadableEvent,
+  hideLoadingBars,
   localDateFormat,
   setsList,
   shell
@@ -88,6 +89,7 @@ function getPrettyContext(context, full = true) {
 function openEconomyTab(loadMore) {
   var mainDiv = document.getElementById("ux_0");
   if (loadMore <= 0) {
+    hideLoadingBars();
     createEconomyUI(mainDiv);
     loadMore = 25;
   }

--- a/window_main/events.js
+++ b/window_main/events.js
@@ -11,6 +11,7 @@ globals
   addHover,
   compare_cards,
   getReadableEvent,
+  hideLoadingBars,
   createDivision,
   eventsHistory,
   compare_courses,
@@ -24,6 +25,7 @@ function openEventsTab(loadMore) {
     loadMore = 25;
     eventsHistory.courses.sort(compare_courses);
 
+    hideLoadingBars();
     mainDiv.classList.remove("flex_item");
     mainDiv.innerHTML = "";
 

--- a/window_main/explore.js
+++ b/window_main/explore.js
@@ -15,6 +15,7 @@ globals
   economyHistory,
   getWinrateClass,
   get_rank_index_16,
+  hideLoadingBars,
   createDivision,
   removeDuplicates,
   compare_cards,
@@ -43,8 +44,7 @@ const open_deck = require("./deck_details").open_deck;
 let raritySort = { c: "common", u: "uncommon", r: "rare", m: "mythic" };
 
 function openExploreTab() {
-  document.body.style.cursor = "auto";
-
+  hideLoadingBars();
   var mainDiv = document.getElementById("ux_0");
   var dateNow, d;
   ownedWildcards = {

--- a/window_main/history.js
+++ b/window_main/history.js
@@ -17,6 +17,7 @@ globals
   sort_decks,
   getReadableEvent,
   getWinrateClass,
+  hideLoadingBars,
   createDivision,
   playerData,
   tags_colors,
@@ -63,6 +64,7 @@ function open_history_tab(loadMore) {
   if (sidebarActive != 1 || decks == null) return;
 
   sort_decks();
+  hideLoadingBars();
   var mainDiv = document.getElementById("ux_0");
   var div, d;
   mainDiv.classList.add("flex_item");

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -916,13 +916,14 @@ $(document).ready(function() {
       });
 
       $(this).addClass("item_selected");
+      $("#ux_0").html("");
+      showLoadingBars();
 
       if ($(this).hasClass("ith")) {
         sidebarActive = -1;
         if (offlineMode) {
           showOfflineSplash();
         } else {
-          showLoadingBars();
           if (discordTag == null) {
             open_home_tab(null, true);
           } else {
@@ -933,17 +934,14 @@ $(document).ready(function() {
       }
       if ($(this).hasClass("it0")) {
         sidebarActive = 0;
-        $("#ux_0").html("");
         open_decks_tab();
       }
       if ($(this).hasClass("it1")) {
         sidebarActive = 1;
-        $("#ux_0").html("");
         ipc_send("request_history", 1);
       }
       if ($(this).hasClass("it2")) {
         sidebarActive = 2;
-        $("#ux_0").html("");
         ipc_send("request_events", 1);
       }
       if ($(this).hasClass("it3")) {

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -492,7 +492,6 @@ ipc.on("set_status", function(event, arg) {
 
 //
 ipc.on("set_home", function(event, arg) {
-  document.body.style.cursor = "auto";
   hideLoadingBars();
   deck_tags = arg.tags;
 
@@ -755,7 +754,6 @@ ipc.on("offline", function() {
 });
 
 function showOfflineSplash() {
-  document.body.style.cursor = "auto";
   $("#ux_0").html(
     '<div class="message_center" style="display: flex; position: fixed;"><div class="message_unlink"></div><div class="message_big red">Oops, you are offline!</div><div class="message_sub_16 white">You can <a class="signup_link">sign up</a> to access online features.</div></div>'
   );
@@ -927,7 +925,6 @@ $(document).ready(function() {
           if (discordTag == null) {
             open_home_tab(null, true);
           } else {
-            document.body.style.cursor = "progress";
             ipc_send("request_home", filteredWildcardsSet);
           }
         }
@@ -972,6 +969,7 @@ $(document).ready(function() {
 
 function showLoadingBars() {
   $$(".main_loading")[0].style.display = "block";
+  document.body.style.cursor = "progress";
 }
 
 //
@@ -979,6 +977,7 @@ ipc.on("show_loading", () => showLoadingBars());
 
 function hideLoadingBars() {
   $$(".main_loading")[0].style.display = "none";
+  document.body.style.cursor = "auto";
 }
 
 //

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -754,6 +754,7 @@ ipc.on("offline", function() {
 });
 
 function showOfflineSplash() {
+  hideLoadingBars();
   $("#ux_0").html(
     '<div class="message_center" style="display: flex; position: fixed;"><div class="message_unlink"></div><div class="message_big red">Oops, you are offline!</div><div class="message_sub_16 white">You can <a class="signup_link">sign up</a> to access online features.</div></div>'
   );
@@ -2001,6 +2002,7 @@ function add_checkbox(div, label, iid, def, func = "updateUserSettings()") {
 function open_settings(openSection) {
   lastSettingsSection = openSection;
   change_background("default");
+  hideLoadingBars();
   $("#ux_0").off();
   $("#history_column").off();
   $("#ux_0").html("");


### PR DESCRIPTION
### Motivation
- Occasionally, especially upon first visit, pages like "History" or "Economy" will take up to 3 seconds to load.
- Going to the home page shows the loading bar, but leaves the prior page's content visible during the AJAX request

### Approach
- Refactor routing logic in `renderer` so that page navigation always shows the loading bar and clears the main content container.
  - Minor tweaks to centralize cursor style logic as well
- Adds `hideLoadingBars` to the `openPageTab` functions immediately before they grab the main content container.