### PR TITLE
bugfix decks page drilldown when filters active

### DIFF
--- a/window_main/decks.js
+++ b/window_main/decks.js
@@ -23,7 +23,6 @@ global
   StatsPanel
 */
 
-const { DEFAULT_TAG } = Aggregator;
 let filters = Aggregator.getDefaultFilters();
 filters.onlyCurrentDecks = true;
 
@@ -259,7 +258,6 @@ function open_decks_tab() {
       });
 
       $("." + deck.id).on("click", function() {
-        var deck = decks[index];
         open_deck(deck, 2);
         $(".moving_ux").animate({ left: "-100%" }, 250, "easeInOutCubic");
       });


### PR DESCRIPTION
### Motivation
When a filter is active, clicking on a deck will open up the incorrect deck details page. (You will see the Nth deck as if you clicked in the same location with no filters active.) I believe I introduced this bug back when I put filters on the page. 🤕 

This bugfix makes the page have the correct behavior.