### PR TITLE
bugfix StatsPanel bars for all locales

### DIFF
--- a/window_main/StatsPanel.js
+++ b/window_main/StatsPanel.js
@@ -80,17 +80,19 @@ class StatsPanel {
       container.appendChild(chartTitle);
     }
 
+    const getStyleHeight = frac => Math.round(frac * 100) + "%";
+
     const appendChart = (winrates, _curveMax, showTags) => {
       const curve = createDivision(["mana_curve"]);
       const numbers = createDivision(["mana_curve_costs"]);
 
       winrates.forEach(cwr => {
         const winCol = createDivision(["mana_curve_column", "back_green"]);
-        winCol.style.height = formatPercent(cwr.wins / _curveMax);
+        winCol.style.height = getStyleHeight(cwr.wins / _curveMax);
         curve.appendChild(winCol);
 
         const lossCol = createDivision(["mana_curve_column", "back_red"]);
-        lossCol.style.height = formatPercent(cwr.losses / _curveMax);
+        lossCol.style.height = getStyleHeight(cwr.losses / _curveMax);
         curve.appendChild(lossCol);
 
         const curveNumber = createDivision(["mana_curve_column_number"]);


### PR DESCRIPTION
I naively used `formatPercent` to create the bar heights, breaking the code for certain browser locales. This should fix the problem.

![image](https://user-images.githubusercontent.com/14894693/57172854-aa5c8900-6dda-11e9-93fa-bd1796a11708.png)
