### PR TITLE
reverse log order

### DIFF
--- a/window_main/history.js
+++ b/window_main/history.js
@@ -145,7 +145,8 @@ function open_history_tab(loadMore) {
     actuallyLoaded - begin < filteredSampleSize;
     loadHistory++
   ) {
-    var match_id = matchesHistory.matches[loadHistory];
+    const revIndex = matchesHistory.matches.length - loadHistory - 1;
+    var match_id = matchesHistory.matches[revIndex];
     var match = matchesHistory[match_id];
 
     //console.log("match: ", match_id, match);
@@ -848,7 +849,7 @@ function sort_history() {
   });
 }
 
-function compare_matches(a, b) {
+function compare_matches(b, a) {
   if (a == undefined) return -1;
   if (b == undefined) return 1;
 


### PR DESCRIPTION
### Motivation
Our first load of the History page causes an expensive "worst-case scenario" sort of the matches history, flipping its order so that it can be displayed most-recent-first in the page. This optimization changes the final  ordering to closer to "in place" or "best-case scenario" and then tweaks the display code to iterate over it in reverse order instead.

Typical chart from performance recording of initial load of History page from clean start up:
![image](https://user-images.githubusercontent.com/14894693/57173645-109bd880-6de8-11e9-82e6-1750769d9543.png)
