### PR TITLE
Filterpalooza

### DIFF
--- a/shared/Aggregator.js
+++ b/shared/Aggregator.js
@@ -152,7 +152,7 @@ class Aggregator {
         this._eventIds.push(match.eventId);
         eventSet.add(match.eventId);
       }
-      if (match.playerDeck && !(match.playerDeck.id in deckMap)) {
+      if (match.playerDeck) {
         deckMap[match.playerDeck.id] = match.playerDeck;
       }
       // some of the data is wierd. Games which last years or have no data.

--- a/shared/Aggregator.js
+++ b/shared/Aggregator.js
@@ -7,16 +7,33 @@ globals
   getRecentDeckName,
   matchesHistory,
   orderedColorCodes,
-  orderedColorCodesCommon
+  orderedColorCodesCommon,
+  rankedEvents,
+  season_starts,
 */
 
 // Default filter values
 const DEFAULT_DECK = "All Decks";
 const DEFAULT_EVENT = "All Events";
 const DEFAULT_TAG = "All Tags";
+const DEFAULT_ARCH = "All Archetypes";
+// Ranked constants
+const RANKED_CONST = "Ranked Constructed";
+const RANKED_DRAFT = "Ranked Limited (Current)";
 // Draft-related constants
 const ALL_DRAFTS = "All Drafts";
 const DRAFT_REPLAYS = "Draft Replays";
+// Date constants
+const DATE_LAST_30 = "Last 30 Days";
+const DATE_SEASON = "Current Season";
+const DATE_ALL_TIME = "All Time";
+
+const now = new Date();
+const then = new Date();
+then.setDate(now.getDate() - 30);
+const DAYS_AGO_30 = then.toISOString();
+
+const CONSTRUCTED_EVENTS = ["Ladder", "Traditional_Ladder"];
 
 class Aggregator {
   constructor(filters) {
@@ -26,15 +43,22 @@ class Aggregator {
     this.updateFilters(filters);
   }
 
-  static getDefaultFilters() {
+  static getDefaultColorFilter() {
     const colorFilters = {};
     orderedColorCodesCommon.forEach(code => (colorFilters[code] = false));
+    return {...colorFilters};
+  }
+
+  static getDefaultFilters() {
     return {
       eventId: DEFAULT_EVENT,
       tag: DEFAULT_TAG,
-      colors: colorFilters,
+      colors: Aggregator.getDefaultColorFilter(),
       deckId: DEFAULT_DECK,
-      onlyCurrentDecks: false
+      onlyCurrentDecks: false,
+      arch: DEFAULT_ARCH,
+      oppColors: Aggregator.getDefaultColorFilter(),
+      date: DATE_ALL_TIME
     };
   }
 
@@ -61,13 +85,33 @@ class Aggregator {
         counts[deck.format] = (counts[deck.format] || 0) + 1;
       }
     });
-    let tagList = [...tagSet].filter(tag => tag && !formatSet.has(tag));
+    const tagList = [...tagSet].filter(tag => tag && !formatSet.has(tag));
     tagList.sort(); // alpha sort instead of counts for now
-    tagList = [DEFAULT_TAG, ...tagList];
-    let formatList = [...formatSet];
+    const formatList = [...formatSet];
     formatList.sort((a, b) => counts[b] - counts[a]);
 
-    return [...tagList, ...formatList];
+    return [DEFAULT_TAG, ...tagList, ...formatList];
+  }
+
+  _filterDeckByColors(deck, _colors) {
+    if (!deck) return true;
+
+    if (deck.colors instanceof Array) {
+      const deckColorCodes = deck.colors.map(i => orderedColorCodes[i - 1]);
+      for (const code in _colors) {
+        if (_colors[code]) {
+          if (!deckColorCodes.includes(code)) return false;
+        }
+      }
+    } else if (deck.colors instanceof Object) {
+      for (const code in _colors) {
+        if (_colors[code] && code in deck.colors) {
+          if (!deckColorCodes.includes(code)) return false;
+        }
+      }
+    }
+
+    return true;
   }
 
   filterDeck(deck) {
@@ -88,23 +132,11 @@ class Aggregator {
       }
     }
     const passesTagFilter =
-      tag === DEFAULT_TAG || deckTags.indexOf(tag) > -1;
+      tag === DEFAULT_TAG || deckTags.includes(tag);
     if (!passesTagFilter) return false;
 
-    if (deck.colors instanceof Array) {
-      const deckColorCodes = deck.colors.map(i => orderedColorCodes[i - 1]);
-      for (const code in colors) {
-        if (colors[code]) {
-          if (deckColorCodes.indexOf(code) === -1) return false;
-        }
-      }
-    } else if (deck.colors instanceof Object) {
-      for (const code in colors) {
-        if (colors[code] && code in deck.colors) {
-          if (!(deck.colors[code] > 0)) return false;
-        }
-      }
-    }
+    const passesColorFilter = this._filterDeckByColors(deck, colors);
+    if (!passesColorFilter) return false;
 
     if (onlyCurrentDecks) {
       return doesDeckStillExist(deck.id);
@@ -115,16 +147,42 @@ class Aggregator {
 
   filterMatch(match) {
     if (!match) return false;
-    const { eventId } = this.filters;
+    const { eventId, oppColors, arch, date } = this.filters;
 
     const passesEventFilter =
       (eventId === DEFAULT_EVENT && match.eventId !== "AIBotMatch") ||
-      eventId === match.eventId ||
+      (eventId === RANKED_CONST && CONSTRUCTED_EVENTS.includes(match.eventId)) ||
+      (eventId === RANKED_DRAFT && rankedEvents.includes(match.eventId)) ||
       (eventId === ALL_DRAFTS && Aggregator.isDraftMatch(match)) ||
-      (eventId === DRAFT_REPLAYS && match.type === "draft");
+      (eventId === DRAFT_REPLAYS && match.type === "draft") ||
+      eventId === match.eventId;
     if (!passesEventFilter) return false;
 
-    return this.filterDeck(match.playerDeck);
+    const passesPlayerDeckFilter = this.filterDeck(match.playerDeck);
+    if (!passesPlayerDeckFilter) return false;
+
+    const passesOppDeckFilter = this._filterDeckByColors(match.oppDeck, oppColors);
+    if (!passesOppDeckFilter) return false;
+
+    const matchTags = match.tags || ["Unknown"];
+    const passesArchFilter =
+      arch === DEFAULT_ARCH || (matchTags.length && arch === matchTags[0]);
+    if (!passesArchFilter) return false;
+
+    let dateFilter = null;
+    if (date === DATE_SEASON) {
+      dateFilter = season_starts;
+    } else if (date === DATE_LAST_30) {
+      dateFilter = DAYS_AGO_30;
+    } else {
+      dateFilter = date;
+    }
+    const passesDateFilter =
+      date === DATE_ALL_TIME ||
+      dateFilter === null ||
+      new Date (match.date) >= new Date(dateFilter);
+
+    return passesDateFilter;
   }
 
   updateFilters(filters = {}) {
@@ -141,6 +199,9 @@ class Aggregator {
     const eventSet = new Set();
     this._decks = [];
     const deckMap = {};
+    const deckWinrates = {};
+    const deckRecentWinrates = {};
+    const archSet = new Set();
     let wins = 0;
     let loss = 0;
     let winrate = 0;
@@ -160,11 +221,36 @@ class Aggregator {
         duration += match.duration;
       }
       if (match.player && match.opponent) {
+        const computeDeckWinrate = match.playerDeck && doesDeckStillExist(match.playerDeck.id);
+        let lastEdit, dId;
+        if (computeDeckWinrate) {
+          const currentDeck = getDeck(match.playerDeck.id);
+          lastEdit = currentDeck.lastUpdated;
+          dId = match.playerDeck.id
+          if (!(dId in deckWinrates)) {
+            deckWinrates[dId] = { wins: 0, losses: 0, winrate: 0 };
+          }
+          if (!(dId in deckRecentWinrates)) {
+            deckRecentWinrates[dId] = { wins: 0, losses: 0, winrate: 0 };
+          }
+        }
         if (match.player.win > match.opponent.win) {
           wins++;
+          if (computeDeckWinrate) {
+            deckWinrates[dId].wins++;
+            if (lastEdit && match.date > lastEdit) {
+              deckRecentWinrates[dId].wins++;
+            }
+          }
         }
         if (match.player.win < match.opponent.win) {
           loss++;
+          if (computeDeckWinrate) {
+            deckWinrates[dId].losses++;
+            if (lastEdit && match.date > lastEdit) {
+              deckRecentWinrates[dId].losses++;
+            }
+          }
         }
       }
       // color win/loss
@@ -195,6 +281,7 @@ class Aggregator {
         // tag win/loss
         if (match.tags !== undefined && match.tags.length > 0) {
           const tag = match.tags[0] || "Unknown";
+          archSet.add(tag);
           let added = -1;
           tagsWinrates.forEach((wr, index) => {
             if (wr.tag === tag) {
@@ -214,19 +301,36 @@ class Aggregator {
         }
       }
     });
-    if (wins + loss) {
-      winrate = Math.round((1 / (wins + loss)) * wins * 100) / 100;
-    }
-    colorsWinrates.sort(compare_winrates);
-    tagsWinrates.sort(compare_winrates);
     this._stats = {
-      total: winrate,
       wins,
       losses: loss,
       duration,
       colors: colorsWinrates,
       tags: tagsWinrates
     };
+    const finishStats = stats => {
+      const wins = stats.wins;
+      const loss = stats.losses;
+      const total = wins + loss;
+      let winrate = 0;
+      if (total) {
+        winrate = winrate = Math.round((wins / total) * 100) / 100;
+      }
+      stats.winrate = winrate;
+      stats.total = total;
+    };
+    finishStats(this._stats);
+    Object.values(deckWinrates).forEach(finishStats);
+    this.deckWinrates = deckWinrates;
+    Object.values(deckRecentWinrates).forEach(finishStats);
+    this.deckRecentWinrates = deckRecentWinrates;
+
+    colorsWinrates.sort(compare_winrates);
+    tagsWinrates.sort(compare_winrates);
+
+    const tagList = [...archSet];
+    tagList.sort();
+    this.archs = [DEFAULT_ARCH, ...tagList];
 
     for (const deckId in deckMap) {
       const deck = getDeck(deckId) || deckMap[deckId];
@@ -251,6 +355,8 @@ class Aggregator {
   get events() {
     return [
       DEFAULT_EVENT,
+      RANKED_CONST,
+      RANKED_DRAFT,
       ALL_DRAFTS,
       DRAFT_REPLAYS,
       ...this._eventIds
@@ -273,7 +379,13 @@ class Aggregator {
 Aggregator.DEFAULT_DECK = DEFAULT_DECK;
 Aggregator.DEFAULT_EVENT = DEFAULT_EVENT;
 Aggregator.DEFAULT_TAG = DEFAULT_TAG;
+Aggregator.DEFAULT_ARCH = DEFAULT_ARCH;
+Aggregator.RANKED_CONST = RANKED_CONST;
+Aggregator.RANKED_DRAFT = RANKED_DRAFT;
 Aggregator.ALL_DRAFTS = ALL_DRAFTS;
 Aggregator.DRAFT_REPLAYS = DRAFT_REPLAYS;
+Aggregator.DATE_LAST_30 = DATE_LAST_30;
+Aggregator.DATE_SEASON = DATE_SEASON;
+Aggregator.DATE_ALL_TIME = DATE_ALL_TIME;
 
 module.exports = Aggregator;

--- a/window_main/FilterPanel.js
+++ b/window_main/FilterPanel.js
@@ -13,7 +13,14 @@ globals
   orderedColorCodesCommon
 */
 
-const { DEFAULT_DECK, DEFAULT_TAG } = Aggregator;
+const {
+  DEFAULT_ARCH,
+  DEFAULT_DECK,
+  DEFAULT_TAG,
+  DATE_LAST_30,
+  DATE_ALL_TIME,
+  DATE_SEASON
+} = Aggregator;
 
 class FilterPanel {
   constructor(
@@ -23,12 +30,12 @@ class FilterPanel {
     events,
     tags,
     decks,
-    showManaFilter
+    showManaFilter,
+    archs,
+    showOppManaFilter
   ) {
     this.prefixId = prefixId;
     this.onFilterChange = onFilterChange;
-    const colorFilters = {};
-    orderedColorCodesCommon.forEach(code => (colorFilters[code] = false));
     this.filters = {
       ...Aggregator.getDefaultFilters(),
       ...filters
@@ -37,6 +44,8 @@ class FilterPanel {
     this.tags = tags || [];
     this.decks = decks || [];
     this.showManaFilter = showManaFilter || false;
+    this.archs = archs || [];
+    this.showOppManaFilter = showOppManaFilter || false;
     this.getTagString = this.getTagString.bind(this);
     this.getDeckString = this.getDeckString.bind(this);
     return this;
@@ -44,6 +53,7 @@ class FilterPanel {
 
   getTagString(tag) {
     if (tag === DEFAULT_TAG) return tag;
+    if (tag === DEFAULT_ARCH) return tag;
     const color = getTagColor(tag);
     const margins = "margin: 5px; margin-right: 30px;";
     const style = `background-color:${color}; color: black; padding-right: 12px; ${margins}`;
@@ -78,22 +88,8 @@ class FilterPanel {
   render() {
     const container = createDivision([this.prefixId + "_filter"]);
     container.style.display = "flex";
+    container.style.width = "100%";
     container.style.alignItems = "center";
-    // container.style.justifyContent = "space-between";
-
-    if (this.events.length) {
-      const eventSelect = createSelect(
-        container,
-        this.events,
-        this.filters.eventId,
-        filter => {
-          this.filters.eventId = filter;
-          this.onFilterChange({ eventId: filter }, this.filters);
-        },
-        this.prefixId + "_query_event",
-        getReadableEvent
-      );
-    }
 
     if (this.tags.length) {
       const tagSelect = createSelect(
@@ -138,9 +134,50 @@ class FilterPanel {
       container.appendChild(manas);
     }
 
+    const dateSelect = createSelect(
+      container,
+      [DATE_ALL_TIME, DATE_SEASON, DATE_LAST_30],
+      this.filters.date,
+      filter => {
+        this.filters.date = filter;
+        this.onFilterChange({ date: filter }, this.filters);
+      },
+      this.prefixId + "_query_date"
+    );
+    dateSelect.style.width = "180px";
+    dateSelect.style.alignSelf = "right";
+    dateSelect.style.marginLeft = "auto";
+
+    return container;
+  }
+
+  renderTheBeastThatShallNotBeNamed() {
+    const container = createDivision([this.prefixId + "_filter"]);
+    container.style.width = "100%";
+
+    const topRow = createDivision([this.prefixId + "_top_filter"]);
+    topRow.style.display = "flex";
+    topRow.style.alignItems = "center";
+    topRow.style.margin = "8px 0";
+    topRow.style.justifyContent = "space-between";
+
+    if (this.events.length) {
+      createSelect(
+        topRow,
+        this.events,
+        this.filters.eventId,
+        filter => {
+          this.filters.eventId = filter;
+          this.onFilterChange({ eventId: filter }, this.filters);
+        },
+        this.prefixId + "_query_event",
+        getReadableEvent
+      );
+    }
+
     if (this.decks.length) {
       const deckSelect = createSelect(
-        container,
+        topRow,
         this.decks.map(deck => deck.id),
         this.filters.deckId,
         filter => {
@@ -153,6 +190,127 @@ class FilterPanel {
       deckSelect.style.width = "300px";
     }
 
+    const dateSelect = createSelect(
+      topRow,
+      [DATE_ALL_TIME, DATE_SEASON, DATE_LAST_30],
+      this.filters.date,
+      filter => {
+        this.filters.date = filter;
+        this.onFilterChange({ date: filter }, this.filters);
+      },
+      this.prefixId + "_query_date"
+    );
+    dateSelect.style.width = "180px";
+
+    container.appendChild(topRow);
+
+    const bottomRow = createDivision([this.prefixId + "_bottom_filter"]);
+    bottomRow.style.display = "flex";
+    bottomRow.style.alignItems = "center";
+    bottomRow.style.margin = "8px 0";
+    bottomRow.style.justifyContent = "space-between";
+
+    const leftSide = createDivision([]);
+    leftSide.style.display = "flex";
+
+    if (this.tags.length) {
+      const tagSelect = createSelect(
+        leftSide,
+        this.tags,
+        this.filters.tag,
+        filter => {
+          this.filters.tag = filter;
+          this.onFilterChange({ tag: filter }, this.filters);
+        },
+        this.prefixId + "_query_tag",
+        this.getTagString
+      );
+      tagSelect.style.width = "180px";
+    }
+
+    if (this.showManaFilter) {
+      const manas = createDivision([this.prefixId + "_query_mana"]);
+      manas.style.display = "flex";
+      manas.style.margin = "auto 8px";
+      orderedColorCodesCommon.forEach(code => {
+        const filterClasses = ["mana_filter"];
+        if (!this.filters.colors[code]) {
+          filterClasses.push("mana_filter_on");
+        }
+        var manabutton = createDivision(filterClasses);
+        manabutton.style.backgroundImage = `url(../images/${code}20.png)`;
+        manabutton.style.width = "30px";
+        manabutton.addEventListener("click", () => {
+          if (manabutton.classList.contains("mana_filter_on")) {
+            manabutton.classList.remove("mana_filter_on");
+            this.filters.colors[code] = true;
+          } else {
+            manabutton.classList.add("mana_filter_on");
+            this.filters.colors[code] = false;
+          }
+          const colors = this.filters.colors;
+          this.onFilterChange({ colors }, this.filters);
+        });
+        manas.appendChild(manabutton);
+      });
+      leftSide.appendChild(manas);
+    }
+
+    bottomRow.appendChild(leftSide);
+
+    const vsLabel = createDivision(["vs_label", "white"], "VS");
+    vsLabel.style.margin = "0 8px";
+    bottomRow.appendChild(vsLabel);
+
+    const rightSide = createDivision([]);
+    rightSide.style.display = "flex";
+
+    if (this.showOppManaFilter) {
+      const manas = createDivision([this.prefixId + "_query_mana"]);
+      manas.style.display = "flex";
+      manas.style.margin = "auto 8px";
+      orderedColorCodesCommon.forEach(code => {
+        const filterClasses = ["mana_filter"];
+        if (!this.filters.oppColors[code]) {
+          filterClasses.push("mana_filter_on");
+        }
+        var manabutton = createDivision(filterClasses);
+        manabutton.style.backgroundImage = `url(../images/${code}20.png)`;
+        manabutton.style.width = "30px";
+        manabutton.addEventListener("click", () => {
+          if (manabutton.classList.contains("mana_filter_on")) {
+            manabutton.classList.remove("mana_filter_on");
+            this.filters.oppColors[code] = true;
+          } else {
+            manabutton.classList.add("mana_filter_on");
+            this.filters.oppColors[code] = false;
+          }
+          const oppColors = this.filters.oppColors;
+          this.onFilterChange({ oppColors }, this.filters);
+        });
+        manas.appendChild(manabutton);
+      });
+      rightSide.appendChild(manas);
+    }
+
+    if (this.archs.length) {
+      const archSelect = createSelect(
+        rightSide,
+        this.archs,
+        this.filters.arch,
+        filter => {
+          this.filters.arch = filter;
+          this.onFilterChange({ arch: filter }, this.filters);
+        },
+        this.prefixId + "_query_optag",
+        this.getTagString
+      );
+      archSelect.style.width = "180px";
+    }
+
+    bottomRow.appendChild(rightSide);
+
+    container.appendChild(bottomRow);
     return container;
   }
 }

--- a/window_main/StatsPanel.js
+++ b/window_main/StatsPanel.js
@@ -19,8 +19,8 @@ class StatsPanel {
   }
 
   render() {
-    const { total, wins, losses, duration, colors, tags } = this.stats;
-    const colClass = getWinrateClass(total);
+    const { winrate, wins, losses, duration, colors, tags } = this.stats;
+    const colClass = getWinrateClass(winrate);
 
     const container = createDivision([this.prefixId + "_winrate"]);
     const winrateContainer = createDivision([]);
@@ -29,7 +29,7 @@ class StatsPanel {
     const winrateLabel = createDivision(["list_deck_winrate"], "Overall:");
     winrateLabel.style.margin = "0 auto 0 0";
     winrateContainer.appendChild(winrateLabel);
-    const wrSpan = `<span class="${colClass}_bright">${formatPercent(total)}</span>`;
+    const wrSpan = `<span class="${colClass}_bright">${formatPercent(winrate)}</span>`;
     const winrateDiv = createDivision(
       ["list_deck_winrate"],
       `${wins}:${losses} (${wrSpan})`
@@ -88,10 +88,12 @@ class StatsPanel {
       winrates.forEach(cwr => {
         const winCol = createDivision(["mana_curve_column", "back_green"]);
         winCol.style.height = getStyleHeight(cwr.wins / _curveMax);
+        winCol.title = `${cwr.wins} matches won`;
         curve.appendChild(winCol);
 
         const lossCol = createDivision(["mana_curve_column", "back_red"]);
         lossCol.style.height = getStyleHeight(cwr.losses / _curveMax);
+        lossCol.title = `${cwr.losses} matches lost`;
         curve.appendChild(lossCol);
 
         const curveNumber = createDivision(["mana_curve_column_number"]);

--- a/window_main/history.js
+++ b/window_main/history.js
@@ -143,7 +143,7 @@ function open_history_tab(loadMore, _filters = {}) {
   if (loadHistory === 0) {
     let historyTop = createDivision(["history_top"]);
 
-    const eventFilter = { eventId: filters.eventId };
+    const eventFilter = { eventId: filters.eventId, date: filters.date };
     const matchesInEvent = new Aggregator(eventFilter);
 
     const handler = selected => {

--- a/window_main/history.js
+++ b/window_main/history.js
@@ -145,7 +145,8 @@ function open_history_tab(loadMore) {
     actuallyLoaded - begin < filteredSampleSize;
     loadHistory++
   ) {
-    var match_id = matchesHistory.matches[loadHistory];
+    const revIndex = matchesHistory.matches.length - loadHistory - 1;
+    var match_id = matchesHistory.matches[revIndex];
     var match = matchesHistory[match_id];
 
     //console.log("match: ", match_id, match);
@@ -849,20 +850,16 @@ function sort_history() {
 }
 
 function compare_matches(a, b) {
-  if (a == undefined) return -1;
-  if (b == undefined) return 1;
+  if (a === undefined) return 0;
+  if (b === undefined) return 0;
 
   a = matchesHistory[a];
   b = matchesHistory[b];
 
-  if (a == undefined) return -1;
-  if (b == undefined) return 1;
+  if (a === undefined) return 0;
+  if (b === undefined) return 0;
 
-  a = Date.parse(a.date);
-  b = Date.parse(b.date);
-  if (a < b) return 1;
-  if (a > b) return -1;
-  return 0;
+  return Date.parse(a.date) - Date.parse(b.date);
 }
 
 module.exports = { open_history_tab: open_history_tab };

--- a/window_main/index.css
+++ b/window_main/index.css
@@ -761,14 +761,14 @@ a:hover {
 
 .decks_top {
     display: flex;
-    height: 64px;
+    min-height: 64px;
     margin: 0 16px;
     justify-content: space-between;
 }
 
 .history_top {
     display: flex;
-    height: 64px;
+    min-height: 64px;
     margin-left: 16px;
     justify-content: space-between;
 }

--- a/window_main/index.html
+++ b/window_main/index.html
@@ -53,8 +53,12 @@
                     <div class="flex_item" style="margin-left: auto;">
                         <div class="top_status"></div>
                         <div class="top_status_pop"></div>
-                        <div class="top_constructed_rank"></div>
-                        <div class="top_limited_rank"></div>
+                        <div class="top_nav_item it7">
+                            <div class="top_constructed_rank"></div>
+                        </div>
+                        <div class="top_nav_item it8">
+                            <div class="top_limited_rank"></div>
+                        </div>
                         <div class="top_patreon"></div>
                         <div class="top_username"></div>
                         <div class="top_username_id"></div>

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -1,5 +1,6 @@
 /*
 global
+  Aggregator,
   setsList,
   cardsDb,
   makeId,
@@ -54,7 +55,7 @@ const tournamentCreate = require("./tournaments").tournamentCreate;
 const tournamentSetState = require("./tournaments").tournamentSetState;
 const open_deck = require("./deck_details").open_deck;
 const open_decks_tab = require("./decks").open_decks_tab;
-const open_history_tab = require("./history").open_history_tab;
+const { open_history_tab, setFilters } = require("./history");
 const openExploreTab = require("./explore").openExploreTab;
 const setExploreDecks = require("./explore").setExploreDecks;
 const updateExploreCheckbox = require("./explore").updateExploreCheckbox;
@@ -64,6 +65,8 @@ const expandEvent = require("./events").expandEvent;
 
 const open_economy_tab = require("./economy").open_economy_tab;
 const set_economy_history = require("./economy").set_economy_history;
+
+const { RANKED_CONST, RANKED_DRAFT, DATE_SEASON } = Aggregator;
 
 var orderedCardTypes = ["cre", "lan", "ins", "sor", "enc", "art", "pla"];
 var orderedCardTypesDesc = [
@@ -980,6 +983,30 @@ $(document).ready(function() {
       if ($(this).hasClass("it6")) {
         sidebarActive = 6;
         open_settings(lastSettingsSection);
+      }
+      if ($(this).hasClass("it7")) {
+        sidebarActive = 1;
+        setFilters({
+          ...Aggregator.getDefaultFilters(),
+          date: DATE_SEASON,
+          eventId: RANKED_CONST,
+          rankedMode: true
+        });
+        ipc_send("request_history", 1);
+        $(this).removeClass("item_selected");
+        $(".it1").addClass("item_selected");
+      }
+      if ($(this).hasClass("it8")) {
+        sidebarActive = 1;
+        setFilters({
+          ...Aggregator.getDefaultFilters(),
+          date: DATE_SEASON,
+          eventId: RANKED_DRAFT,
+          rankedMode: true
+        });
+        ipc_send("request_history", 1);
+        $(this).removeClass("item_selected");
+        $(".it1").addClass("item_selected");
       }
     } else {
       $(".moving_ux").animate({ left: "0px" }, 250, "easeInOutCubic");


### PR DESCRIPTION
## CANT STAHP WONT STAHP
- Optimize History page performance by mostly preserving `matchesHistory.matches` default order.
- Upgrade `Aggregator` to lvl 9000
    - compute filter-based deck winrates
    - rudimentary date filters: all time, current season, trailing 30 days
    - archetype filters
    - opponent deck color filters
    - new filter options for "Ranked Constructed" and "Ranked Limited (Current)"
- Upgrade `FilterPanel` to match `Aggregator` power level
    - I HEARD YOU LIKED DROPDOWNS
- History page equips all the new powerups!
    - Also shiny new `filters` plumbing to let us link directly to interesting "presets"
    - Restore Ranked Stats to former glory at top of panel, but
    - Hide Ranked Stats whenever filters make them irrelevant
- Deck page equips all the new powerups!
    - Deck winrates now respect fancy new filters!
    - Bonus bugfix: deck winrates now appear even if their record is 0:X
    - Winrates since last edit display detailed match stats in hover text
- Bonus feature: clicking on the ranked icons now jumps to their filtered presets on the history page (with the Ranked Stats visible)

## Decks
![decks-filters](https://user-images.githubusercontent.com/14894693/57184980-a717da80-6e78-11e9-9fc7-0bb717e31d8e.gif)

## History
![history-filters](https://user-images.githubusercontent.com/14894693/57185044-ae8bb380-6e79-11e9-9f8e-8dc09720f20e.gif)

## Ranked
![ranked-link](https://user-images.githubusercontent.com/14894693/57185096-0a563c80-6e7a-11e9-8e01-67c972a79388.gif)


