### PR TITLE
Filter Layout V2

### DIFF
--- a/shared/Aggregator.js
+++ b/shared/Aggregator.js
@@ -204,7 +204,7 @@ class Aggregator {
     const deckLastPlayed = {};
     const deckWinrates = {};
     const deckRecentWinrates = {};
-    const archSet = new Set();
+    const archCounts = {};
     let wins = 0;
     let loss = 0;
     let winrate = 0;
@@ -292,7 +292,7 @@ class Aggregator {
         // tag win/loss
         if (match.tags !== undefined && match.tags.length > 0) {
           const tag = match.tags[0] || "Unknown";
-          archSet.add(tag);
+          archCounts[tag] = (archCounts[tag] || 0) + 1;
           let added = -1;
           tagsWinrates.forEach((wr, index) => {
             if (wr.tag === tag) {
@@ -341,9 +341,10 @@ class Aggregator {
     colorsWinrates.sort(compare_winrates);
     tagsWinrates.sort(compare_winrates);
 
-    const tagList = [...archSet];
-    tagList.sort();
-    this.archs = [DEFAULT_ARCH, ...tagList];
+    this.archCounts = archCounts;
+    const archList = [...Object.keys(archCounts)];
+    archList.sort();
+    this.archs = [DEFAULT_ARCH, ...archList];
 
     for (const deckId in deckMap) {
       const deck = getDeck(deckId) || deckMap[deckId];

--- a/shared/Aggregator.js
+++ b/shared/Aggregator.js
@@ -97,19 +97,20 @@ class Aggregator {
   _filterDeckByColors(deck, _colors) {
     if (!deck) return true;
 
+    // All decks pass when no colors are selected
+    if (Object.values(_colors).every(val => val === false)) return true;
+
+    // Normalize deck colors into matching data format
+    let deckColorCodes = Aggregator.getDefaultColorFilter();
     if (deck.colors instanceof Array) {
-      const deckColorCodes = deck.colors.map(i => orderedColorCodes[i - 1]);
-      for (const code in _colors) {
-        if (_colors[code]) {
-          if (!deckColorCodes.includes(code)) return false;
-        }
-      }
+      deck.colors.forEach(i => (deckColorCodes[orderedColorCodes[i - 1]] = true));
     } else if (deck.colors instanceof Object) {
-      for (const code in _colors) {
-        if (_colors[code] && code in deck.colors) {
-          if (!deckColorCodes.includes(code)) return false;
-        }
-      }
+      deckColorCodes = deck.colors;
+    }
+
+    // If at least one color is selected, deck must match exactly
+    for (const code in _colors) {
+      if (_colors[code] !== deckColorCodes[code]) return false;
     }
 
     return true;

--- a/window_main/FilterPanel.js
+++ b/window_main/FilterPanel.js
@@ -218,12 +218,6 @@ class FilterPanel {
 
     const showColumnC = this.archs.length || this.showOppManaFilter;
     if (showColumnC) {
-      const vsLabel = createDivision(["vs_label", "white"], "VS");
-      vsLabel.style.width = "40px";
-      vsLabel.style.margin = "0 8px";
-      vsLabel.style.textAlign = "center";
-      container.appendChild(vsLabel);
-
       const columnC = createDivision([]);
 
       if (this.archs.length) {
@@ -273,10 +267,7 @@ class FilterPanel {
       }
       container.appendChild(columnC);
     } else {
-      // spacers
-      const vsSpacer = createDivision([]);
-      vsSpacer.style.width = "40px";
-      container.appendChild(vsSpacer);
+      // spacer
       const opSpacer = createDivision([]);
       opSpacer.style.width = "180px";
       container.appendChild(opSpacer);

--- a/window_main/FilterPanel.js
+++ b/window_main/FilterPanel.js
@@ -100,52 +100,11 @@ class FilterPanel {
     container.style.display = "flex";
     container.style.width = "100%";
     container.style.alignItems = "center";
+    container.style.justifyContent = "space-between";
 
-    if (this.tags.length) {
-      const tagSelect = createSelect(
-        container,
-        this.tags,
-        this.filters.tag,
-        filter => {
-          this.filters.tag = filter;
-          this.onFilterChange({ tag: filter }, this.filters);
-        },
-        this.prefixId + "_query_tag",
-        this.getTagString
-      );
-      tagSelect.style.width = "180px";
-    }
-
-    if (this.showManaFilter) {
-      const manas = createDivision([this.prefixId + "_query_mana"]);
-      manas.style.display = "flex";
-      manas.style.margin = "auto 8px";
-      orderedColorCodesCommon.forEach(code => {
-        const filterClasses = ["mana_filter"];
-        if (!this.filters.colors[code]) {
-          filterClasses.push("mana_filter_on");
-        }
-        var manabutton = createDivision(filterClasses);
-        manabutton.style.backgroundImage = `url(../images/${code}20.png)`;
-        manabutton.style.width = "30px";
-        manabutton.addEventListener("click", () => {
-          if (manabutton.classList.contains("mana_filter_on")) {
-            manabutton.classList.remove("mana_filter_on");
-            this.filters.colors[code] = true;
-          } else {
-            manabutton.classList.add("mana_filter_on");
-            this.filters.colors[code] = false;
-          }
-          const colors = this.filters.colors;
-          this.onFilterChange({ colors }, this.filters);
-        });
-        manas.appendChild(manabutton);
-      });
-      container.appendChild(manas);
-    }
-
+    const columnA = createDivision([]);
     const dateSelect = createSelect(
-      container,
+      columnA,
       [DATE_ALL_TIME, DATE_SEASON, DATE_LAST_30],
       this.filters.date,
       filter => {
@@ -154,26 +113,10 @@ class FilterPanel {
       },
       this.prefixId + "_query_date"
     );
-    dateSelect.style.width = "180px";
-    dateSelect.style.alignSelf = "right";
-    dateSelect.style.marginLeft = "auto";
-
-    return container;
-  }
-
-  renderTheBeastThatShallNotBeNamed() {
-    const container = createDivision([this.prefixId + "_filter"]);
-    container.style.width = "100%";
-
-    const topRow = createDivision([this.prefixId + "_top_filter"]);
-    topRow.style.display = "flex";
-    topRow.style.alignItems = "center";
-    topRow.style.margin = "8px 0";
-    topRow.style.justifyContent = "space-between";
-
+    dateSelect.style.marginBottom = "8px";
     if (this.events.length) {
-      createSelect(
-        topRow,
+      const eventSelect = createSelect(
+        columnA,
         this.events,
         this.filters.eventId,
         filter => {
@@ -183,144 +126,156 @@ class FilterPanel {
         this.prefixId + "_query_event",
         getReadableEvent
       );
+      eventSelect.style.marginBottom = "8px";
     }
+    container.appendChild(columnA);
 
-    if (this.decks.length) {
-      const deckSelect = createSelect(
-        topRow,
-        this.decks.map(deck => deck.id),
-        this.filters.deckId,
-        filter => {
-          this.filters.deckId = filter;
-          this.onFilterChange({ deckId: filter }, this.filters);
-        },
-        this.prefixId + "_query_deck",
-        this.getDeckString
-      );
-      deckSelect.style.width = "300px";
-    }
+    const showColumnB = this.tags.length || this.showManaFilter;
+    if (showColumnB) {
+      const columnB = createDivision([]);
 
-    const dateSelect = createSelect(
-      topRow,
-      [DATE_ALL_TIME, DATE_SEASON, DATE_LAST_30],
-      this.filters.date,
-      filter => {
-        this.filters.date = filter;
-        this.onFilterChange({ date: filter }, this.filters);
-      },
-      this.prefixId + "_query_date"
-    );
-    dateSelect.style.width = "180px";
+      if (this.tags.length || this.decks.length) {
+        const deckFiltersCont = createDivision([]);
+        deckFiltersCont.style.display = "flex";
+        deckFiltersCont.style.width = "100%";
+        deckFiltersCont.style.alignItems = "center";
+        deckFiltersCont.style.justifyContent = "space-between";
+        deckFiltersCont.style.marginBottom = "8px";
 
-    container.appendChild(topRow);
-
-    const bottomRow = createDivision([this.prefixId + "_bottom_filter"]);
-    bottomRow.style.display = "flex";
-    bottomRow.style.alignItems = "center";
-    bottomRow.style.margin = "8px 0";
-    bottomRow.style.justifyContent = "space-between";
-
-    const leftSide = createDivision([]);
-    leftSide.style.display = "flex";
-
-    if (this.tags.length) {
-      const tagSelect = createSelect(
-        leftSide,
-        this.tags,
-        this.filters.tag,
-        filter => {
-          this.filters.tag = filter;
-          this.onFilterChange({ tag: filter }, this.filters);
-        },
-        this.prefixId + "_query_tag",
-        this.getTagString
-      );
-      tagSelect.style.width = "180px";
-    }
-
-    if (this.showManaFilter) {
-      const manas = createDivision([this.prefixId + "_query_mana"]);
-      manas.style.display = "flex";
-      manas.style.margin = "auto 8px";
-      orderedColorCodesCommon.forEach(code => {
-        const filterClasses = ["mana_filter"];
-        if (!this.filters.colors[code]) {
-          filterClasses.push("mana_filter_on");
+        if (this.tags.length) {
+          const tagSelect = createSelect(
+            deckFiltersCont,
+            this.tags,
+            this.filters.tag,
+            filter => {
+              this.filters.tag = filter;
+              this.onFilterChange({ tag: filter }, this.filters);
+            },
+            this.prefixId + "_query_tag",
+            this.getTagString
+          );
+          tagSelect.style.width = "180px";
         }
-        var manabutton = createDivision(filterClasses);
-        manabutton.style.backgroundImage = `url(../images/${code}20.png)`;
-        manabutton.style.width = "30px";
-        manabutton.addEventListener("click", () => {
-          if (manabutton.classList.contains("mana_filter_on")) {
-            manabutton.classList.remove("mana_filter_on");
-            this.filters.colors[code] = true;
-          } else {
-            manabutton.classList.add("mana_filter_on");
-            this.filters.colors[code] = false;
-          }
-          const colors = this.filters.colors;
-          this.onFilterChange({ colors }, this.filters);
-        });
-        manas.appendChild(manabutton);
-      });
-      leftSide.appendChild(manas);
-    }
-
-    bottomRow.appendChild(leftSide);
-
-    const vsLabel = createDivision(["vs_label", "white"], "VS");
-    vsLabel.style.margin = "0 8px";
-    bottomRow.appendChild(vsLabel);
-
-    const rightSide = createDivision([]);
-    rightSide.style.display = "flex";
-
-    if (this.showOppManaFilter) {
-      const manas = createDivision([this.prefixId + "_query_mana"]);
-      manas.style.display = "flex";
-      manas.style.margin = "auto 8px";
-      orderedColorCodesCommon.forEach(code => {
-        const filterClasses = ["mana_filter"];
-        if (!this.filters.oppColors[code]) {
-          filterClasses.push("mana_filter_on");
+        if (this.decks.length) {
+          const deckSelect = createSelect(
+            deckFiltersCont,
+            this.decks.map(deck => deck.id),
+            this.filters.deckId,
+            filter => {
+              this.filters.deckId = filter;
+              this.onFilterChange({ deckId: filter }, this.filters);
+            },
+            this.prefixId + "_query_deck",
+            this.getDeckString
+          );
+          deckSelect.style.width = "180px";
+        } else {
+          const deckSpacer = createDivision([]);
+          deckSpacer.style.width = "180px";
+          deckFiltersCont.appendChild(deckSpacer);
         }
-        var manabutton = createDivision(filterClasses);
-        manabutton.style.backgroundImage = `url(../images/${code}20.png)`;
-        manabutton.style.width = "30px";
-        manabutton.addEventListener("click", () => {
-          if (manabutton.classList.contains("mana_filter_on")) {
-            manabutton.classList.remove("mana_filter_on");
-            this.filters.oppColors[code] = true;
-          } else {
-            manabutton.classList.add("mana_filter_on");
-            this.filters.oppColors[code] = false;
+
+        columnB.appendChild(deckFiltersCont);
+      }
+
+      if (this.showManaFilter) {
+        const manas = createDivision([this.prefixId + "_query_mana"]);
+        manas.style.display = "flex";
+        manas.style.margin = "8px";
+        manas.style.width = "150px";
+        manas.style.height = "32px";
+        orderedColorCodesCommon.forEach(code => {
+          const filterClasses = ["mana_filter"];
+          if (!this.filters.colors[code]) {
+            filterClasses.push("mana_filter_on");
           }
-          const oppColors = this.filters.oppColors;
-          this.onFilterChange({ oppColors }, this.filters);
+          var manabutton = createDivision(filterClasses);
+          manabutton.style.backgroundImage = `url(../images/${code}20.png)`;
+          manabutton.style.width = "30px";
+          manabutton.addEventListener("click", () => {
+            if (manabutton.classList.contains("mana_filter_on")) {
+              manabutton.classList.remove("mana_filter_on");
+              this.filters.colors[code] = true;
+            } else {
+              manabutton.classList.add("mana_filter_on");
+              this.filters.colors[code] = false;
+            }
+            const colors = this.filters.colors;
+            this.onFilterChange({ colors }, this.filters);
+          });
+          manas.appendChild(manabutton);
         });
-        manas.appendChild(manabutton);
-      });
-      rightSide.appendChild(manas);
+        columnB.appendChild(manas);
+      }
+      container.appendChild(columnB);
     }
 
-    if (this.archs.length) {
-      const archSelect = createSelect(
-        rightSide,
-        this.archs,
-        this.filters.arch,
-        filter => {
-          this.filters.arch = filter;
-          this.onFilterChange({ arch: filter }, this.filters);
-        },
-        this.prefixId + "_query_optag",
-        this.getTagString
-      );
-      archSelect.style.width = "180px";
+    const showColumnC = this.archs.length || this.showOppManaFilter;
+    if (showColumnC) {
+      const vsLabel = createDivision(["vs_label", "white"], "VS");
+      vsLabel.style.width = "40px";
+      vsLabel.style.margin = "0 8px";
+      vsLabel.style.textAlign = "center";
+      container.appendChild(vsLabel);
+
+      const columnC = createDivision([]);
+
+      if (this.archs.length) {
+        const archSelect = createSelect(
+          columnC,
+          this.archs,
+          this.filters.arch,
+          filter => {
+            this.filters.arch = filter;
+            this.onFilterChange({ arch: filter }, this.filters);
+          },
+          this.prefixId + "_query_optag",
+          this.getTagString
+        );
+        archSelect.style.width = "180px";
+        archSelect.style.marginBottom = "8px";
+      }
+
+      if (this.showOppManaFilter) {
+        const manas = createDivision([this.prefixId + "_query_mana"]);
+        manas.style.display = "flex";
+        manas.style.margin = "8px";
+        manas.style.width = "150px";
+        manas.style.height = "32px";
+        orderedColorCodesCommon.forEach(code => {
+          const filterClasses = ["mana_filter"];
+          if (!this.filters.oppColors[code]) {
+            filterClasses.push("mana_filter_on");
+          }
+          var manabutton = createDivision(filterClasses);
+          manabutton.style.backgroundImage = `url(../images/${code}20.png)`;
+          manabutton.style.width = "30px";
+          manabutton.addEventListener("click", () => {
+            if (manabutton.classList.contains("mana_filter_on")) {
+              manabutton.classList.remove("mana_filter_on");
+              this.filters.oppColors[code] = true;
+            } else {
+              manabutton.classList.add("mana_filter_on");
+              this.filters.oppColors[code] = false;
+            }
+            const oppColors = this.filters.oppColors;
+            this.onFilterChange({ oppColors }, this.filters);
+          });
+          manas.appendChild(manabutton);
+        });
+        columnC.appendChild(manas);
+      }
+      container.appendChild(columnC);
+    } else {
+      // spacers
+      const vsSpacer = createDivision([]);
+      vsSpacer.style.width = "40px";
+      container.appendChild(vsSpacer);
+      const opSpacer = createDivision([]);
+      opSpacer.style.width = "180px";
+      container.appendChild(opSpacer);
     }
 
-    bottomRow.appendChild(rightSide);
-
-    container.appendChild(bottomRow);
     return container;
   }
 }

--- a/window_main/FilterPanel.js
+++ b/window_main/FilterPanel.js
@@ -32,7 +32,8 @@ class FilterPanel {
     decks,
     showManaFilter,
     archs,
-    showOppManaFilter
+    showOppManaFilter,
+    archCounts
   ) {
     this.prefixId = prefixId;
     this.onFilterChange = onFilterChange;
@@ -46,18 +47,23 @@ class FilterPanel {
     this.showManaFilter = showManaFilter || false;
     this.archs = archs || [];
     this.showOppManaFilter = showOppManaFilter || false;
+    this.archCounts = archCounts;
     this.getTagString = this.getTagString.bind(this);
     this.getDeckString = this.getDeckString.bind(this);
     return this;
   }
 
-  getTagString(tag) {
+  getTagString(tag, showCount = false) {
     if (tag === DEFAULT_TAG) return tag;
     if (tag === DEFAULT_ARCH) return tag;
     const color = getTagColor(tag);
     const margins = "margin: 5px; margin-right: 30px;";
-    const style = `background-color:${color}; color: black; padding-right: 12px; ${margins}`;
-    return `<div class="deck_tag" style="${style}">${getReadableFormat(tag)}</div>`;
+    const style = `white-space: nowrap; background-color:${color}; color: black; padding-right: 12px; ${margins}`;
+    let tagString = getReadableFormat(tag);
+    if (showCount && tag in this.archCounts) {
+      tagString += ` (${this.archCounts[tag]})`;
+    }
+    return `<div class="deck_tag" style="${style}">${tagString}</div>`;
   }
 
   getDeckString(deckId) {
@@ -230,7 +236,7 @@ class FilterPanel {
             this.onFilterChange({ arch: filter }, this.filters);
           },
           this.prefixId + "_query_optag",
-          this.getTagString
+          tag => this.getTagString(tag, true)
         );
         archSelect.style.width = "180px";
         archSelect.style.marginBottom = "8px";

--- a/window_main/FilterPanel.js
+++ b/window_main/FilterPanel.js
@@ -66,23 +66,33 @@ class FilterPanel {
     if (matches.length === 0) return deckId;
     const deck = matches[0];
 
-    let deckName = deck.name;
-    if (doesDeckStillExist(deckId)) {
-      deckName = getRecentDeckName(deckId);
+    const deckExists = doesDeckStillExist(deckId);
+
+    let deckName = deckExists ? getRecentDeckName(deckId) : deck.name;
+    let maxChars = 10;
+    if (deckExists && deck.colors) {
+      maxChars = 16 - 2 * deck.colors.length;
+    }
+
+    if (deckName.length > maxChars) {
+      deckName = `<abbr title="${deckName}">${deckName.slice(0, maxChars)}...</abbr>`;
+    }
+
+    if (deckExists) {
+      let colorsString = "";
+      if (deck.colors) {
+        deck.colors.forEach(color => {
+          colorsString += `<div class="mana_s16 mana_${
+            orderedColorCodes[color - 1]
+          }"></div>`;
+        });
+      }
+      deckName += `<div class="flex_item">${colorsString}</div>`;
     } else {
       deckName += "<small><i> (deleted)</i></small>";
     }
 
-    let colorsString = "";
-    if (deck.colors) {
-      deck.colors.forEach(color => {
-        colorsString += `<div class="mana_s16 mana_${
-          orderedColorCodes[color - 1]
-        }"></div>`;
-      });
-    }
-
-    return `${deckName}<div class="flex_item">${colorsString}</div>`;
+    return deckName;
   }
 
   render() {

--- a/window_main/decks.js
+++ b/window_main/decks.js
@@ -1,6 +1,7 @@
 /*
 global
   Aggregator,
+  allMatches,
 	cardsDb,
   createDivision,
 	decks,
@@ -71,7 +72,14 @@ function open_decks_tab() {
     decks_top.classList.add("decks_top");
 
     const handler = selected => {
-      if (selected.tag) {
+      if (selected.eventId) {
+        // clear all dependent filters
+        filters = {
+          ...Aggregator.getDefaultFilters(),
+          date: filters.date, // independent filter
+          ...selected
+        };
+      } else if (selected.tag) {
         // tag resets colors
         filters = {
           ...filters,
@@ -87,8 +95,8 @@ function open_decks_tab() {
     const filterPanel = new FilterPanel(
       "decks_top",
       handler,
-      aggregator.filters,
-      [],
+      filters,
+      allMatches.events,
       tags,
       [],
       true
@@ -99,7 +107,13 @@ function open_decks_tab() {
     wrap_l.appendChild(decks_top);
 
     sort_decks(aggregator.compareDecks);
-    decks.filter(aggregator.filterDeck).forEach(function(deck, index) {
+
+    const isDeckVisible = deck =>
+      aggregator.filterDeck(deck) &&
+      (filters.eventId === Aggregator.DEFAULT_EVENT ||
+        aggregator.deckLastPlayed[deck.id]);
+
+    decks.filter(isDeckVisible).forEach(deck => {
       var tileGrpid = deck.deckTileId;
 
       if (cardsDb.get(tileGrpid).set == undefined) {

--- a/window_main/decks.js
+++ b/window_main/decks.js
@@ -72,21 +72,16 @@ function open_decks_tab() {
     decks_top.classList.add("decks_top");
 
     const handler = selected => {
-      if (selected.eventId) {
+      if (selected.eventId || selected.date) {
         // clear all dependent filters
         filters = {
           ...Aggregator.getDefaultFilters(),
-          date: filters.date, // independent filter
-          ...selected
-        };
-      } else if (selected.tag) {
-        // tag resets colors
-        filters = {
-          ...filters,
-          colors: Aggregator.getDefaultColorFilter(),
+          date: filters.date,
+          eventId: filters.eventId,
           ...selected
         };
       } else {
+        // default case
         filters = { ...filters, ...selected };
       }
       open_decks_tab();

--- a/window_main/history.js
+++ b/window_main/history.js
@@ -2,6 +2,7 @@
 globals
   addHover,
   Aggregator,
+  allMatches,
   cardsDb,
   compare_cards,
   compare_decks,
@@ -85,7 +86,6 @@ function setFilters(_filters = {}) {
 function open_history_tab(loadMore, _filters = {}) {
   if (sidebarActive != 1 || decks == null) return;
 
-  let allMatches;
   hideLoadingBars();
   var mainDiv = document.getElementById("ux_0");
   var div, d;
@@ -93,7 +93,6 @@ function open_history_tab(loadMore, _filters = {}) {
   if (loadMore <= 0) {
     loadMore = 25;
     sort_history();
-    allMatches = new Aggregator();
     mainDiv.innerHTML = "";
     loadHistory = 0;
 
@@ -172,7 +171,7 @@ function open_history_tab(loadMore, _filters = {}) {
       matchesInEvent.archs,
       true
     );
-    const historyTopFilter = filterPanel.renderTheBeastThatShallNotBeNamed();
+    const historyTopFilter = filterPanel.render();
     historyTop.appendChild(historyTopFilter);
     historyColumn.appendChild(historyTop);
   }

--- a/window_main/history.js
+++ b/window_main/history.js
@@ -169,7 +169,8 @@ function open_history_tab(loadMore, _filters = {}) {
       matchesInEvent.decks,
       true,
       matchesInEvent.archs,
-      true
+      true,
+      matchesInEvent.archCounts
     );
     const historyTopFilter = filterPanel.render();
     historyTop.appendChild(historyTopFilter);

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -96,6 +96,7 @@ let ipc = electron.ipcRenderer;
 let decks = null;
 let changes = null;
 let matchesHistory = [];
+let allMatches = null;
 let eventsHistory = [];
 
 let explore = null;
@@ -359,6 +360,9 @@ ipc.on("set_decks", function(event, arg) {
   if (arg != null) {
     delete arg.index;
     decks = Object.values(arg);
+    if (matchesHistory.length) {
+      allMatches = new Aggregator();
+    }
   }
   open_decks_tab();
 });
@@ -379,6 +383,9 @@ ipc.on("set_history", function(event, arg) {
   if (arg != null) {
     try {
       matchesHistory = JSON.parse(arg);
+      if (decks) {
+        allMatches = new Aggregator();
+      }
     } catch (e) {
       console.log("Error parsing JSON:", arg);
       return false;
@@ -392,6 +399,9 @@ ipc.on("set_history", function(event, arg) {
 ipc.on("set_history_data", function(event, arg) {
   if (arg != null) {
     matchesHistory = JSON.parse(arg);
+    if (decks) {
+      allMatches = new Aggregator();
+    }
   }
 });
 


### PR DESCRIPTION
## Motivation
Following a great design brainstorming session with @AnnanFay and @Manuel-777, the goal is to reorganize the filters to be more intuitive.
  - Filters should be in consistent locations on the Decks page and the History page
  - Filters that depend on other filters should be to the right of the one they depend on.
  - Deck names just took up too much space
  - Archetypes should show sample size

## History Page
![image](https://user-images.githubusercontent.com/14894693/57266067-4b438200-702f-11e9-8c75-50fd5cf48ce8.png)

Here is a demo of the new deck name abbreviations:
![image](https://user-images.githubusercontent.com/14894693/57266088-657d6000-702f-11e9-8eab-78041a02194d.png)


## Deck Page
![image](https://user-images.githubusercontent.com/14894693/57266113-85148880-702f-11e9-916d-17bae118bbaf.png)


## Additional Logic
- To make the Deck page have a consistent layout, I added the Events filter dropdown. So of course I had to make it work on the Deck page, too. ;)
- Color filters now either expect all colors to be off or the deck to exactly match the color filter settings.
- Optimized performance by moving `allMatches` aggregation into a global singleton.
- Aggregator now counts archetype sample size and FilterPanel now displays it
- Several updates to dependency logic between filters