### PR TITLE
Bugfix save_user_settings

### DIFF
--- a/window_background/background.js
+++ b/window_background/background.js
@@ -389,8 +389,10 @@ ipc.on("overlayBounds", function(event, obj) {
 //
 ipc.on("save_user_settings", function(event, settings) {
   ipc_send("show_loading");
-  loadSettings(settings);
-  store.set("settings", settings);
+  const oldSettings = store.get("settings");
+  const updated = { ...oldSettings, ...settings };
+  loadSettings(updated);
+  store.set("settings", updated);
   ipc_send("hide_loading");
 });
 


### PR DESCRIPTION
This is the correct way to save @Manuel-777 from the recurring Ghitu Lavarunner. Please disregard any mention of "subtle bugs in production" that I mentioned on Discord earlier. Production code is fine. I was just crazy earlier. `save_app_settings` does everything correctly, only `save_user_settings` was wrong. There were no bugs with `save_user_settings` until I recently attempted to call it outside of the Settings page area.

