### PR TITLE
Aggregator Hardening and Consistent Event Order

### DIFF
--- a/shared/Aggregator.js
+++ b/shared/Aggregator.js
@@ -373,7 +373,13 @@ class Aggregator {
     }
     const aName = getRecentDeckName(a.id);
     const bName = getRecentDeckName(b.id);
-    return aName.localeCompare(bName);
+    if (aName) {
+      return aName.localeCompare(bName);
+    }
+    // a is invalid, sort b first
+    if (bName) return 1;
+    // neither valid, leave in place
+    return 0;
   }
 
   compareEvents(a, b) {
@@ -384,7 +390,13 @@ class Aggregator {
     }
     const aName = getReadableEvent(a);
     const bName = getReadableEvent(b);
-    return aName.localeCompare(bName);
+    if (aName) {
+      return aName.localeCompare(bName);
+    }
+    // a is invalid, sort b first
+    if (bName) return 1;
+    // neither valid, leave in place
+    return 0;
   }
 
   get matches() {

--- a/shared/Aggregator.js
+++ b/shared/Aggregator.js
@@ -223,7 +223,7 @@ class Aggregator {
           eventLastPlayed[match.eventId] = match.date;
         }
       }
-      if (match.playerDeck) {
+      if (match.playerDeck && match.playerDeck.id) {
         const id = match.playerDeck.id;
         let deckIsMoreRecent = true;
         if (id in deckLastPlayed) {

--- a/shared/Aggregator.js
+++ b/shared/Aggregator.js
@@ -4,6 +4,7 @@ globals
   compare_decks,
   doesDeckStillExist,
   getDeck,
+  getReadableEvent,
   getRecentDeckName,
   matchesHistory,
   orderedColorCodes,
@@ -41,6 +42,7 @@ class Aggregator {
     this.filterMatch = this.filterMatch.bind(this);
     this.updateFilters = this.updateFilters.bind(this);
     this.compareDecks = this.compareDecks.bind(this);
+    this.compareEvents = this.compareEvents.bind(this);
     this.updateFilters(filters);
   }
 
@@ -198,7 +200,7 @@ class Aggregator {
       .filter(this.filterMatch);
 
     this._eventIds = [];
-    const eventSet = new Set();
+    const eventLastPlayed = {};
     this._decks = [];
     const deckMap = {};
     const deckLastPlayed = {};
@@ -212,9 +214,14 @@ class Aggregator {
     const colorsWinrates = [];
     const tagsWinrates = [];
     this._matches.forEach(match => {
-      if (match.eventId && !eventSet.has(match.eventId)) {
-        this._eventIds.push(match.eventId);
-        eventSet.add(match.eventId);
+      if (match.eventId) {
+        let eventIsMoreRecent = true;
+        if (match.eventId in eventLastPlayed) {
+          eventIsMoreRecent = match.date > eventLastPlayed[match.eventId];
+        } 
+        if (eventIsMoreRecent) {
+          eventLastPlayed[match.eventId] = match.date;
+        }
       }
       if (match.playerDeck) {
         const id = match.playerDeck.id;
@@ -313,7 +320,9 @@ class Aggregator {
       }
     });
     this.deckLastPlayed = deckLastPlayed;
-    this._eventIds.reverse();
+    this.eventLastPlayed = eventLastPlayed;
+    this._eventIds = [...Object.keys(eventLastPlayed)];
+    this._eventIds.sort(this.compareEvents);
     this._stats = {
       wins,
       losses: loss,
@@ -364,6 +373,17 @@ class Aggregator {
     }
     const aName = getRecentDeckName(a.id);
     const bName = getRecentDeckName(b.id);
+    return aName.localeCompare(bName);
+  }
+
+  compareEvents(a, b) {
+    const aDate = this.eventLastPlayed[a];
+    const bDate = this.eventLastPlayed[b];
+    if (aDate && bDate && aDate !== bDate) {
+      return new Date(bDate) - new Date(aDate);
+    }
+    const aName = getReadableEvent(a);
+    const bName = getReadableEvent(b);
     return aName.localeCompare(bName);
   }
 


### PR DESCRIPTION
### Consistent Event Order
@AnnanFay mentioned that the ordering of events in the event list filter moves around. I referenced the problem in https://github.com/Manuel-777/MTG-Arena-Tool/pull/319, but forgot to include this commit, which has the actual fix. This follows the same approach as the updated deck ordering code.
https://discordapp.com/channels/463844727654187020/506793351786266624/575015352325373954


### Aggregator Hardening
https://discordapp.com/channels/463844727654187020/506793351786266624/575198818291810304
![image](https://user-images.githubusercontent.com/14894693/57326852-44b21a80-70c2-11e9-8125-cb9cc69cb656.png)

This is probably not related to multiple trackers, race conditions, or file locks.  We used to rely on `history.sort_history` to find partially complete match data and fill in fake deck data. Since we now instantiate the singleton earlier (right after a "set_decks" or a "set_matches"), I don't want to rely on local display code doing data normalization.

This PR adds some hardening to the directly affected `updateFilters`, `compareDecks`, and `compareEvents` functions in the Aggregator.

### TODO
[ ] Make sure this actually solves @AnnanFay's problem