### PR TITLE
Remove allmatches singleton

### DIFF
--- a/window_main/decks.js
+++ b/window_main/decks.js
@@ -1,7 +1,6 @@
 /*
 global
   Aggregator,
-  allMatches,
 	cardsDb,
   createDivision,
 	decks,
@@ -36,6 +35,7 @@ function open_decks_tab() {
     var mainDiv = document.getElementById("ux_0");
     mainDiv.classList.add("flex_item");
     mainDiv.innerHTML = "";
+    const allMatches = new Aggregator();
 
     const wrap_r = createDivision(["wrapper_column", "sidebar_column_l"]);
     wrap_r.style.width = sidebarSize+"px";

--- a/window_main/history.js
+++ b/window_main/history.js
@@ -2,7 +2,6 @@
 globals
   addHover,
   Aggregator,
-  allMatches,
   cardsDb,
   compare_cards,
   compare_decks,
@@ -72,6 +71,7 @@ function setFilters(selected = {}) {
 function open_history_tab(loadMore, _filters = {}) {
   if (sidebarActive != 1 || decks == null) return;
 
+  let allMatches;
   hideLoadingBars();
   var mainDiv = document.getElementById("ux_0");
   var div, d;
@@ -79,6 +79,7 @@ function open_history_tab(loadMore, _filters = {}) {
   if (loadMore <= 0) {
     loadMore = 25;
     sort_history();
+    allMatches = new Aggregator();
     mainDiv.innerHTML = "";
     loadHistory = 0;
 

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -96,7 +96,6 @@ let ipc = electron.ipcRenderer;
 let decks = null;
 let changes = null;
 let matchesHistory = [];
-let allMatches = null;
 let eventsHistory = [];
 
 let explore = null;
@@ -360,9 +359,6 @@ ipc.on("set_decks", function(event, arg) {
   if (arg != null) {
     delete arg.index;
     decks = Object.values(arg);
-    if (matchesHistory.length) {
-      allMatches = new Aggregator();
-    }
   }
   open_decks_tab();
 });
@@ -383,9 +379,6 @@ ipc.on("set_history", function(event, arg) {
   if (arg != null) {
     try {
       matchesHistory = JSON.parse(arg);
-      if (decks) {
-        allMatches = new Aggregator();
-      }
     } catch (e) {
       console.log("Error parsing JSON:", arg);
       return false;
@@ -399,9 +392,6 @@ ipc.on("set_history", function(event, arg) {
 ipc.on("set_history_data", function(event, arg) {
   if (arg != null) {
     matchesHistory = JSON.parse(arg);
-    if (decks) {
-      allMatches = new Aggregator();
-    }
   }
 });
 


### PR DESCRIPTION
### Motivation
![image](https://user-images.githubusercontent.com/14894693/57311252-1f141980-70a0-11e9-8fe5-fcf611358f0a.png)

### Approach
This removes the global singleton aggregation of all match data `allMatches` that snuck its way into https://github.com/Manuel-777/MTG-Arena-Tool/pull/320. The History page has reverted back to maintaining its own copy, and now the Decks page maintains one as well (necessary for the event filter dropdown).