### PR TITLE
Data scroller logic component

### DIFF
--- a/window_main/data-scroller.js
+++ b/window_main/data-scroller.js
@@ -1,0 +1,49 @@
+"use strict";
+/*
+globals
+  createDivision,
+  hideLoadingBars,
+  showLoadingBars
+  $
+*/
+
+class DataScroller {
+  constructor(container, renderData, loadAmount, maxDataIndex) {
+    this.container = container;
+    this.renderData = renderData;
+    this.loadAmount = loadAmount || 20;
+    this.maxDataIndex = maxDataIndex || 0;
+    this.renderRows = this.renderRows.bind(this);
+    return this;
+  }
+
+  render(loadMore) {
+    const d = createDivision(["list_fill"]);
+    this.container.appendChild(d);
+    this.loaded = 0;
+    this.dataIndex = 0;
+
+    this.renderRows(loadMore || this.loadAmount);
+
+    const jCont = $(this.container);
+    jCont.off();
+    jCont.on("scroll", () => {
+      const desiredHeight = Math.round(jCont.scrollTop() + jCont.innerHeight());
+      if (desiredHeight >= jCont[0].scrollHeight) {
+        this.renderRows(this.loadAmount);
+      }
+    });
+  }
+
+  renderRows(loadMore) {
+    showLoadingBars();
+    const loadEnd = this.loaded + loadMore;
+    while (this.loaded < loadEnd && this.dataIndex < this.maxDataIndex) {
+      this.loaded += this.renderData(this.container, this.dataIndex);
+      this.dataIndex++;
+    }
+    hideLoadingBars();
+  }
+}
+
+module.exports = DataScroller;

--- a/window_main/events.js
+++ b/window_main/events.js
@@ -1,72 +1,35 @@
 /*
 globals
+  addHover,
+  cardsDb,
+  compare_cards,
+  compare_courses,
+  createDivision,
+  currentId,
+  DataScroller,
+  eventsHistory,
+  get_deck_colors,
+  get_rank_index_16,
+  getReadableEvent,
   ipc_send,
   matchesHistory,
-  cardsDb,
   mana,
-  get_rank_index_16,
   timeSince,
-  toMMSS,
-  get_deck_colors,
-  addHover,
-  compare_cards,
-  getReadableEvent,
-  hideLoadingBars,
-  createDivision,
-  eventsHistory,
-  compare_courses,
-  loadEvents,
-  currentId
+  toMMSS
 */
 
-function openEventsTab(loadMore) {
-  var mainDiv = document.getElementById("ux_0");
-  if (loadMore <= 0) {
-    loadMore = 25;
-    eventsHistory.courses.sort(compare_courses);
-
-    hideLoadingBars();
-    mainDiv.classList.remove("flex_item");
-    mainDiv.innerHTML = "";
-
-    var d = createDivision(["list_fill"]);
-    mainDiv.appendChild(d);
-
-    loadEvents = 0;
-  }
-
-  //console.log("Load more: ", loadEvents, loadMore, loadEvents+loadMore);
-  for (
-    var loadEnd = loadEvents + loadMore;
-    loadEvents < loadEnd;
-    loadEvents++
-  ) {
-    var course_id = eventsHistory.courses[loadEvents];
-    var course = eventsHistory[course_id];
-
-    if (course == undefined || course.CourseDeck == undefined) {
-      continue;
-    }
-
-    var eventRow = createEventRow(course);
-    var divExp = createDivision([course.id + "exp", "list_event_expand"]);
-
-    mainDiv.appendChild(eventRow);
-    mainDiv.appendChild(divExp);
-
-    attachDeleteCourseButton(course);
-    addHover(course, divExp);
-  }
-
-  $(this).off();
-  $("#ux_0").on("scroll", function() {
-    if (
-      Math.round($(this).scrollTop() + $(this).innerHeight()) >=
-      $(this)[0].scrollHeight
-    ) {
-      openEventsTab(20);
-    }
-  });
+function openEventsTab() {
+  const mainDiv = document.getElementById("ux_0");
+  mainDiv.classList.remove("flex_item");
+  mainDiv.innerHTML = "";
+  const dataScroller = new DataScroller(
+    mainDiv,
+    renderData,
+    20,
+    eventsHistory.courses.length
+  );
+  eventsHistory.courses.sort(compare_courses);
+  dataScroller.render(25);
 
   $(".delete_item").hover(
     function() {
@@ -78,8 +41,26 @@ function openEventsTab(loadMore) {
       $(this).css("width", "4px");
     }
   );
+}
 
-  loadEvents = loadEnd;
+// return val = how many rows it rendered into container
+function renderData(container, index) {
+  var course_id = eventsHistory.courses[index];
+  var course = eventsHistory[course_id];
+
+  if (course === undefined || course.CourseDeck === undefined) {
+    return 0;
+  }
+
+  var eventRow = createEventRow(course);
+  var divExp = createDivision([course.id + "exp", "list_event_expand"]);
+
+  container.appendChild(eventRow);
+  container.appendChild(divExp);
+
+  attachDeleteCourseButton(course);
+  addHover(course, divExp);
+  return 1;
 }
 
 // converts a match index from a courses

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -52,6 +52,7 @@ require("time-elements");
 
 const FilterPanel = require("./FilterPanel.js");
 const StatsPanel = require("./StatsPanel.js");
+const DataScroller = require("./data-scroller.js");
 const open_home_tab = require("./home").open_home_tab;
 const tournamentOpen = require("./tournaments").tournamentOpen;
 const tournamentCreate = require("./tournaments").tournamentCreate;


### PR DESCRIPTION
### Motivation
This refactors the scrolling logic on the History, Events, and Economy pages.
  - All 3 pages should behave exactly the same way they do on `master`
  - Future bugs involving scrolling should be easier to fix
  - Building new lists of arbitrary data (potentially with filters or async calls) should be a little easier

### Approach
- Creates a new `DataScroller` logic component based on a generalization of the current scrolling logic in the pages.
- Refactors each page in roughly the same way:
  - split the `openFooTab(loadMore)` apart into an initial `openFooTab()` and a separate `renderData(container, index)` function.
  - use the new `DataScroller` with explicit `maxDataIndex` and `renderData` handshake
