### PR TITLE
Events Filters and Stats

### DIFF
--- a/shared/Aggregator.js
+++ b/shared/Aggregator.js
@@ -46,6 +46,10 @@ class Aggregator {
     this.updateFilters(filters);
   }
 
+  static createAllMatches() {
+    return new Aggregator({ date: DATE_ALL_TIME });
+  }
+
   static getDefaultColorFilter() {
     const colorFilters = {};
     orderedColorCodesCommon.forEach(code => (colorFilters[code] = false));
@@ -61,7 +65,7 @@ class Aggregator {
       onlyCurrentDecks: false,
       arch: DEFAULT_ARCH,
       oppColors: Aggregator.getDefaultColorFilter(),
-      date: DATE_ALL_TIME
+      date: DATE_LAST_30
     };
   }
 

--- a/window_main/economy.js
+++ b/window_main/economy.js
@@ -94,7 +94,10 @@ function openEconomyTab() {
 
 // return val = how many rows it rendered into container
 function renderData(container, index) {
-  let economyId = economyHistory.changes[index];
+  // for performance reasons, we leave changes order mostly alone
+  // to display most-recent-first, we use a reverse index
+  const revIndex = economyHistory.changes.length - index - 1;
+  let economyId = economyHistory.changes[revIndex];
   let change = economyHistory[economyId];
 
   if (change == undefined) return;
@@ -771,20 +774,16 @@ function createEconomyUI(mainDiv) {
 // If two IDs are specified then events are retrieved from `economyHistory`
 function compare_economy(a, b) {
   /* global economyHistory */
-  if (a == undefined) return -1;
-  if (b == undefined) return 1;
+  if (a === undefined) return 0;
+  if (b === undefined) return 0;
 
   a = economyHistory[a];
   b = economyHistory[b];
 
-  if (a == undefined) return -1;
-  if (b == undefined) return 1;
+  if (a === undefined) return 0;
+  if (b === undefined) return 0;
 
-  a = Date.parse(a.date);
-  b = Date.parse(b.date);
-  if (a < b) return 1;
-  if (a > b) return -1;
-  return 0;
+  return Date.parse(a.date) - Date.parse(b.date);
 }
 
 module.exports = {

--- a/window_main/events.js
+++ b/window_main/events.js
@@ -23,7 +23,7 @@ globals
 */
 
 let filters = Aggregator.getDefaultFilters();
-filters.onlyEvents = true;
+filters.eventId = Aggregator.ALL_EVENT_TRACKS;
 let filteredMatches;
 
 function openEventsTab(_filters) {
@@ -50,7 +50,6 @@ function openEventsTab(_filters) {
     allMatches.trackEvents
   );
 
-  console.log(allMatches);
   const eventsTopFilter = filterPanel.render();
   eventsTop.appendChild(eventsTopFilter);
 

--- a/window_main/events.js
+++ b/window_main/events.js
@@ -45,7 +45,10 @@ function openEventsTab() {
 
 // return val = how many rows it rendered into container
 function renderData(container, index) {
-  var course_id = eventsHistory.courses[index];
+  // for performance reasons, we leave events order mostly alone
+  // to display most-recent-first, we use a reverse index
+  const revIndex = eventsHistory.courses.length - index - 1;
+  var course_id = eventsHistory.courses[revIndex];
   var course = eventsHistory[course_id];
 
   if (course === undefined || course.CourseDeck === undefined) {

--- a/window_main/events.js
+++ b/window_main/events.js
@@ -1,6 +1,8 @@
 /*
 globals
   addHover,
+  Aggregator,
+  allMatches,
   cardsDb,
   compare_cards,
   compare_courses,
@@ -8,35 +10,76 @@ globals
   currentId,
   DataScroller,
   eventsHistory,
+  FilterPanel,
   get_deck_colors,
   get_rank_index_16,
   getReadableEvent,
   ipc_send,
   matchesHistory,
   mana,
+  StatsPanel,
   timeSince,
   toMMSS
 */
 
-function openEventsTab() {
+let filters = Aggregator.getDefaultFilters();
+filters.onlyEvents = true;
+let filteredMatches;
+
+function openEventsTab(_filters) {
   const mainDiv = document.getElementById("ux_0");
   mainDiv.classList.remove("flex_item");
   mainDiv.innerHTML = "";
+  const d = createDivision(["list_fill"]);
+  mainDiv.appendChild(d);
+
+  eventsHistory.courses.sort(compare_courses);
+  filters = { ...filters, ..._filters };
+  filteredMatches = new Aggregator(filters);
+
+  const eventsTop = createDivision(["events_top"]);
+  eventsTop.style.display = "flex";
+  eventsTop.style.width = "100%";
+  eventsTop.style.alignItems = "center";
+  eventsTop.style.justifyContent = "space-between";
+
+  const filterPanel = new FilterPanel(
+    "events_top",
+    selected => openEventsTab(selected),
+    filters,
+    allMatches.trackEvents
+  );
+
+  console.log(allMatches);
+  const eventsTopFilter = filterPanel.render();
+  eventsTop.appendChild(eventsTopFilter);
+
+  const partialStats = {
+    ...filteredMatches.stats,
+    colors: [],
+    tags: []
+  };
+  const statsPanel = new StatsPanel("events_top", partialStats);
+  const eventsTopWinrate = statsPanel.render();
+  eventsTopWinrate.style.width = "300px";
+  eventsTopWinrate.style.marginRight = "16px";
+  eventsTop.appendChild(eventsTopWinrate);
+
+  mainDiv.appendChild(eventsTop);
   const dataScroller = new DataScroller(
     mainDiv,
     renderData,
     20,
     eventsHistory.courses.length
   );
-  eventsHistory.courses.sort(compare_courses);
   dataScroller.render(25);
 
   $(".delete_item").hover(
-    function() {
+    () => {
       // in
       $(this).css("width", "32px");
     },
-    function() {
+    () => {
       // out
       $(this).css("width", "4px");
     }
@@ -52,6 +95,12 @@ function renderData(container, index) {
   var course = eventsHistory[course_id];
 
   if (course === undefined || course.CourseDeck === undefined) {
+    return 0;
+  }
+
+  if (!filteredMatches) return 0;
+  if (!filteredMatches.filterDate(course.date)) return 0;
+  if (!filteredMatches.filterEvent(course.InternalEventName)) {
     return 0;
   }
 

--- a/window_main/history.js
+++ b/window_main/history.js
@@ -158,6 +158,8 @@ function open_history_tab(_deprecated, _filters = {}) {
 
 // return val = how many rows it rendered into container
 function renderData(container, index) {
+  // for performance reasons, we leave matches order mostly alone
+  // to display most-recent-first, we use a reverse index
   const revIndex = matchesHistory.matches.length - index - 1;
   var match_id = matchesHistory.matches[revIndex];
   var match = matchesHistory[match_id];

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -3060,18 +3060,14 @@ function compare_changes_inner(a, b) {
 
 //
 function compare_courses(a, b) {
-  if (a == undefined) return -1;
-  if (b == undefined) return 1;
+  if (a === undefined) return 0;
+  if (b === undefined) return 0;
 
   a = eventsHistory[a];
   b = eventsHistory[b];
 
-  if (a == undefined) return -1;
-  if (b == undefined) return 1;
+  if (a === undefined) return 0;
+  if (b === undefined) return 0;
 
-  a = Date.parse(a.date);
-  b = Date.parse(b.date);
-  if (a < b) return 1;
-  if (a > b) return -1;
-  return 0;
+  return Date.parse(a.date) - Date.parse(b.date);
 }

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -362,7 +362,7 @@ ipc.on("set_decks", function(event, arg) {
     delete arg.index;
     decks = Object.values(arg);
     if (matchesHistory.length) {
-      allMatches = new Aggregator();
+      allMatches = Aggregator.createAllMatches();
     }
   }
   open_decks_tab();
@@ -385,7 +385,7 @@ ipc.on("set_history", function(event, arg) {
     try {
       matchesHistory = JSON.parse(arg);
       if (decks) {
-        allMatches = new Aggregator();
+        allMatches = Aggregator.createAllMatches();
       }
     } catch (e) {
       console.log("Error parsing JSON:", arg);
@@ -401,7 +401,7 @@ ipc.on("set_history_data", function(event, arg) {
   if (arg != null) {
     matchesHistory = JSON.parse(arg);
     if (decks) {
-      allMatches = new Aggregator();
+      allMatches = Aggregator.createAllMatches();
     }
   }
 });


### PR DESCRIPTION
This PR depends on #327 because I never wanted to think about `loadMore` again.

### Motivation
This is the 3rd and final installment of the "Saga of Filters and Charts" trilogy. Here we upgrade the Events page to take advantage of the same common components we use in the Decks and History page.
- Users can now filter to events of a certain type
- Users can now filter to events within a certain time period
- Users now see a summary of the winrate and duration for all currently visible events
https://discordapp.com/channels/463844727654187020/506793351786266624/575505606652461078
![image](https://user-images.githubusercontent.com/14894693/57481610-5678f680-7257-11e9-8c95-b1b666db5de0.png)
^ for @AnnanFay 

### Demo
![image](https://user-images.githubusercontent.com/14894693/57481352-c5098480-7256-11e9-940d-a11c41770b7a.png)

### Additional Stuff
- Performance optimizations for the Event page and Economy page similar to the History page: we now leave the order mostly alone and display it from the reverse end.
- Move default time window to last 30 days
