### PR TITLE
Bugfix Explore Page scroll handler

### DIFF
--- a/window_main/explore.js
+++ b/window_main/explore.js
@@ -100,7 +100,7 @@ function openExploreTab() {
   mainDiv.appendChild(d);
 
   $(this).off();
-  mainDiv.addEventListener("scroll", () => {
+  $(this).on("scroll", () => {
     if (Math.round(mainDiv.scrollTop + mainDiv.offsetHeight) >= mainDiv.scrollHeight) {
       queryExplore(filterSkip);
     }


### PR DESCRIPTION
### Motivation
Each visit to the Explore page will create and register a new scroll event listener that will never ever get removed. These will cause lots of spam `get_explore` requests whenever you scroll another page!

I believe we introduced this bug here: https://github.com/Manuel-777/MTG-Arena-Tool/commit/982c45f23f5d29ee4dee1877a07c7256e3f532b6#diff-abc8d139e33fdb5e8f5413d2ef2c6caaL99

https://discordapp.com/channels/463844727654187020/506793351786266624/576166746692517895
![image](https://user-images.githubusercontent.com/14894693/57490552-7831a800-726e-11e9-99b7-f007594b15a8.png)
