### PR TITLE
Travis jest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "MTG-Arena-Tool",
-  "version": "2.2.28",
+  "version": "2.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -19,6 +19,118 @@
         "@babel/highlight": "^7.0.0"
       }
     },
+    "@babel/core": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.4.4.tgz",
+      "integrity": "sha512-lQgGX3FPRgbz2SKmhMtYgJvVzGZrmjaF4apZ2bLwofAKiSjxU0drPh4S/VasyYXwaTs+A1gvQ45BN8SQJzHsQQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.4.4",
+        "@babel/helpers": "^7.4.4",
+        "@babel/parser": "^7.4.4",
+        "@babel/template": "^7.4.4",
+        "@babel/traverse": "^7.4.4",
+        "@babel/types": "^7.4.4",
+        "convert-source-map": "^1.1.0",
+        "debug": "^4.1.0",
+        "json5": "^2.1.0",
+        "lodash": "^4.17.11",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.4.tgz",
+      "integrity": "sha512-53UOLK6TVNqKxf7RUh8NE851EHRxOOeVXKbK2bivdb+iziMyk03Sr4eaE9OELCbyZAAafAKPDwF2TPUES5QbxQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.4.4",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.11",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+      "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
+      "dev": true
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+      "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.4.4"
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.4.4.tgz",
+      "integrity": "sha512-igczbR/0SeuPR8RFfC7tGrbdTbFL3QTvH6D+Z6zNxnTe//GyqmtHmDkzrqDmyZ3eSwPqB/LhyKoU5DXsp+Vp2A==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.4.4",
+        "@babel/traverse": "^7.4.4",
+        "@babel/types": "^7.4.4"
+      }
+    },
     "@babel/highlight": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
@@ -30,10 +142,391 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@babel/parser": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.4.tgz",
+      "integrity": "sha512-5pCS4mOsL+ANsFZGdvNLybx4wtqAZJ0MJjMHxvzI3bvIsz6sQvzW8XX92EYIkiPtIvcfG3Aj+Ir5VNyjnZhP7w==",
+      "dev": true
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
+      "integrity": "sha512-t0JKGgqk2We+9may3t0xDdmneaXmyxq0xieYcKHxIsrJO64n1OiMWNUtc5gQK1PA0NpdCRrtZp4z+IUaKugrSA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+      "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.4.4",
+        "@babel/types": "^7.4.4"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.4.tgz",
+      "integrity": "sha512-Gw6qqkw/e6AGzlyj9KnkabJX7VcubqPtkUQVAwkc0wUMldr3A/hezNB3Rc5eIvId95iSGkGIOe5hh1kMKf951A==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.4.4",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.4.4",
+        "@babel/parser": "^7.4.4",
+        "@babel/types": "^7.4.4",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
+      "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.11",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@cnakazawa/watch": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.3.tgz",
+      "integrity": "sha512-r5160ogAvGyHsal38Kux7YYtodEKOj89RGb28ht1jh3SJb08VwRwAKKJL0bGb04Zd/3r9FL3BFIc3bBidYffCA==",
+      "dev": true,
+      "requires": {
+        "exec-sh": "^0.3.2",
+        "minimist": "^1.2.0"
+      }
+    },
+    "@jest/console": {
+      "version": "24.7.1",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.7.1.tgz",
+      "integrity": "sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==",
+      "dev": true,
+      "requires": {
+        "@jest/source-map": "^24.3.0",
+        "chalk": "^2.0.1",
+        "slash": "^2.0.0"
+      }
+    },
+    "@jest/core": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-24.8.0.tgz",
+      "integrity": "sha512-R9rhAJwCBQzaRnrRgAdVfnglUuATXdwTRsYqs6NMdVcAl5euG8LtWDe+fVkN27YfKVBW61IojVsXKaOmSnqd/A==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^24.7.1",
+        "@jest/reporters": "^24.8.0",
+        "@jest/test-result": "^24.8.0",
+        "@jest/transform": "^24.8.0",
+        "@jest/types": "^24.8.0",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.1",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.1.15",
+        "jest-changed-files": "^24.8.0",
+        "jest-config": "^24.8.0",
+        "jest-haste-map": "^24.8.0",
+        "jest-message-util": "^24.8.0",
+        "jest-regex-util": "^24.3.0",
+        "jest-resolve-dependencies": "^24.8.0",
+        "jest-runner": "^24.8.0",
+        "jest-runtime": "^24.8.0",
+        "jest-snapshot": "^24.8.0",
+        "jest-util": "^24.8.0",
+        "jest-validate": "^24.8.0",
+        "jest-watcher": "^24.8.0",
+        "micromatch": "^3.1.10",
+        "p-each-series": "^1.0.0",
+        "pirates": "^4.0.1",
+        "realpath-native": "^1.1.0",
+        "rimraf": "^2.5.4",
+        "strip-ansi": "^5.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "4.1.15",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+          "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "@jest/environment": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.8.0.tgz",
+      "integrity": "sha512-vlGt2HLg7qM+vtBrSkjDxk9K0YtRBi7HfRFaDxoRtyi+DyVChzhF20duvpdAnKVBV6W5tym8jm0U9EfXbDk1tw==",
+      "dev": true,
+      "requires": {
+        "@jest/fake-timers": "^24.8.0",
+        "@jest/transform": "^24.8.0",
+        "@jest/types": "^24.8.0",
+        "jest-mock": "^24.8.0"
+      }
+    },
+    "@jest/fake-timers": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.8.0.tgz",
+      "integrity": "sha512-2M4d5MufVXwi6VzZhJ9f5S/wU4ud2ck0kxPof1Iz3zWx6Y+V2eJrES9jEktB6O3o/oEyk+il/uNu9PvASjWXQw==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.8.0",
+        "jest-message-util": "^24.8.0",
+        "jest-mock": "^24.8.0"
+      }
+    },
+    "@jest/reporters": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-24.8.0.tgz",
+      "integrity": "sha512-eZ9TyUYpyIIXfYCrw0UHUWUvE35vx5I92HGMgS93Pv7du+GHIzl+/vh8Qj9MCWFK/4TqyttVBPakWMOfZRIfxw==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^24.8.0",
+        "@jest/test-result": "^24.8.0",
+        "@jest/transform": "^24.8.0",
+        "@jest/types": "^24.8.0",
+        "chalk": "^2.0.1",
+        "exit": "^0.1.2",
+        "glob": "^7.1.2",
+        "istanbul-lib-coverage": "^2.0.2",
+        "istanbul-lib-instrument": "^3.0.1",
+        "istanbul-lib-report": "^2.0.4",
+        "istanbul-lib-source-maps": "^3.0.1",
+        "istanbul-reports": "^2.1.1",
+        "jest-haste-map": "^24.8.0",
+        "jest-resolve": "^24.8.0",
+        "jest-runtime": "^24.8.0",
+        "jest-util": "^24.8.0",
+        "jest-worker": "^24.6.0",
+        "node-notifier": "^5.2.1",
+        "slash": "^2.0.0",
+        "source-map": "^0.6.0",
+        "string-length": "^2.0.0"
+      }
+    },
+    "@jest/source-map": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.3.0.tgz",
+      "integrity": "sha512-zALZt1t2ou8le/crCeeiRYzvdnTzaIlpOWaet45lNSqNJUnXbppUUFR4ZUAlzgDmKee4Q5P/tKXypI1RiHwgag==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.1.15",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.15",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+          "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+          "dev": true
+        }
+      }
+    },
+    "@jest/test-result": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.8.0.tgz",
+      "integrity": "sha512-+YdLlxwizlfqkFDh7Mc7ONPQAhA4YylU1s529vVM1rsf67vGZH/2GGm5uO8QzPeVyaVMobCQ7FTxl38QrKRlng==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^24.7.1",
+        "@jest/types": "^24.8.0",
+        "@types/istanbul-lib-coverage": "^2.0.0"
+      }
+    },
+    "@jest/test-sequencer": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-24.8.0.tgz",
+      "integrity": "sha512-OzL/2yHyPdCHXEzhoBuq37CE99nkme15eHkAzXRVqthreWZamEMA0WoetwstsQBCXABhczpK03JNbc4L01vvLg==",
+      "dev": true,
+      "requires": {
+        "@jest/test-result": "^24.8.0",
+        "jest-haste-map": "^24.8.0",
+        "jest-runner": "^24.8.0",
+        "jest-runtime": "^24.8.0"
+      }
+    },
+    "@jest/transform": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.8.0.tgz",
+      "integrity": "sha512-xBMfFUP7TortCs0O+Xtez2W7Zu1PLH9bvJgtraN1CDST6LBM/eTOZ9SfwS/lvV8yOfcDpFmwf9bq5cYbXvqsvA==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.1.0",
+        "@jest/types": "^24.8.0",
+        "babel-plugin-istanbul": "^5.1.0",
+        "chalk": "^2.0.1",
+        "convert-source-map": "^1.4.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "graceful-fs": "^4.1.15",
+        "jest-haste-map": "^24.8.0",
+        "jest-regex-util": "^24.3.0",
+        "jest-util": "^24.8.0",
+        "micromatch": "^3.1.10",
+        "realpath-native": "^1.1.0",
+        "slash": "^2.0.0",
+        "source-map": "^0.6.1",
+        "write-file-atomic": "2.4.1"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.15",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+          "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+          "dev": true
+        },
+        "write-file-atomic": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
+          "integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.2"
+          }
+        }
+      }
+    },
+    "@jest/types": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.8.0.tgz",
+      "integrity": "sha512-g17UxVr2YfBtaMUxn9u/4+siG1ptg9IGYAYwvpwn61nBg779RXnjE/m7CxYcIzEt0AbHZZAHSEZNhkE2WxURVg==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^1.1.1",
+        "@types/yargs": "^12.0.9"
+      }
+    },
+    "@types/babel__core": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.1.tgz",
+      "integrity": "sha512-+hjBtgcFPYyCTo0A15+nxrCVJL7aC6Acg87TXd5OW3QhHswdrOLoles+ldL2Uk8q++7yIfl4tURtztccdeeyOw==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "@types/babel__generator": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.0.2.tgz",
+      "integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__template": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
+      "integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@types/babel__traverse": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.6.tgz",
+      "integrity": "sha512-XYVgHF2sQ0YblLRMLNPB3CkFMewzFmlDsH/TneZFHUXDlABQgh88uOxuez7ZcXxayLFrqLwtDH1t+FmlFwNZxw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.3.0"
+      }
+    },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+      "integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==",
+      "dev": true
+    },
+    "@types/istanbul-lib-report": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
+      "integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "@types/istanbul-reports": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
+      "integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "*",
+        "@types/istanbul-lib-report": "*"
+      }
+    },
     "@types/node": {
       "version": "8.10.48",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.48.tgz",
       "integrity": "sha512-c35YEBTkL4rzXY2ucpSKy+UYHjUBIIkuJbWYbsGIrKLEWU5dgJMmLkkIb3qeC3O3Tpb1ZQCwecscvJTDjDjkRw==",
+      "dev": true
+    },
+    "@types/stack-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
+      "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
+      "dev": true
+    },
+    "@types/yargs": {
+      "version": "12.0.12",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.12.tgz",
+      "integrity": "sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw==",
+      "dev": true
+    },
+    "abab": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
+      "integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
       "dev": true
     },
     "acorn": {
@@ -42,10 +535,26 @@
       "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
       "dev": true
     },
+    "acorn-globals": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.2.tgz",
+      "integrity": "sha512-BbzvZhVtZP+Bs1J1HcwrQe8ycfO0wStkSGxuul3He3GkHOIZ6eTqOkPuw9IP1X3+IkOo4wiJmwkobzXYz4wewQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "^6.0.1",
+        "acorn-walk": "^6.0.1"
+      }
+    },
     "acorn-jsx": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
       "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+      "dev": true
+    },
+    "acorn-walk": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
+      "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
       "dev": true
     },
     "adm-zip": {
@@ -133,6 +642,16 @@
         "color-convert": "^1.9.0"
       }
     },
+    "anymatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+      "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+      "dev": true,
+      "requires": {
+        "micromatch": "^3.1.4",
+        "normalize-path": "^2.1.1"
+      }
+    },
     "app-builder-bin": {
       "version": "2.6.6",
       "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-2.6.6.tgz",
@@ -202,10 +721,40 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "arr-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+      "dev": true
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "arr-union": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
+    },
+    "array-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+      "dev": true
+    },
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "array-unique": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
     "asn1": {
@@ -220,6 +769,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "assign-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+      "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
     },
     "astral-regex": {
       "version": "1.0.0",
@@ -248,10 +803,22 @@
       "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
       "dev": true
     },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+      "dev": true
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -263,11 +830,169 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
+    "babel-jest": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-24.8.0.tgz",
+      "integrity": "sha512-+5/kaZt4I9efoXzPlZASyK/lN9qdRKmmUav9smVc0ruPQD7IsfucQ87gpOE8mn2jbDuS6M/YOW6n3v9ZoIfgnw==",
+      "dev": true,
+      "requires": {
+        "@jest/transform": "^24.8.0",
+        "@jest/types": "^24.8.0",
+        "@types/babel__core": "^7.1.0",
+        "babel-plugin-istanbul": "^5.1.0",
+        "babel-preset-jest": "^24.6.0",
+        "chalk": "^2.4.2",
+        "slash": "^2.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
+      }
+    },
+    "babel-plugin-istanbul": {
+      "version": "5.1.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.4.tgz",
+      "integrity": "sha512-dySz4VJMH+dpndj0wjJ8JPs/7i1TdSPb1nRrn56/92pKOF9VKC1FMFJmMXjzlGGusnCAqujP6PBCiKq0sVA+YQ==",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0",
+        "istanbul-lib-instrument": "^3.3.0",
+        "test-exclude": "^5.2.3"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        }
+      }
+    },
+    "babel-plugin-jest-hoist": {
+      "version": "24.6.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-24.6.0.tgz",
+      "integrity": "sha512-3pKNH6hMt9SbOv0F3WVmy5CWQ4uogS3k0GY5XLyQHJ9EGpAT9XWkFd2ZiXXtkwFHdAHa5j7w7kfxSP5lAIwu7w==",
+      "dev": true,
+      "requires": {
+        "@types/babel__traverse": "^7.0.6"
+      }
+    },
+    "babel-preset-jest": {
+      "version": "24.6.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-24.6.0.tgz",
+      "integrity": "sha512-pdZqLEdmy1ZK5kyRUfvBb2IfTPb2BUvIJczlPspS8fWmBQslNNDBqVfh7BW5leOVJMDZKzjD8XEyABTk6gQ5yw==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+        "babel-plugin-jest-hoist": "^24.6.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "base": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "dev": true,
+      "requires": {
+        "cache-base": "^1.0.1",
+        "class-utils": "^0.3.5",
+        "component-emitter": "^1.2.1",
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.1",
+        "mixin-deep": "^1.2.0",
+        "pascalcase": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
     },
     "base64-js": {
       "version": "1.3.0",
@@ -358,6 +1083,67 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+      "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+      "dev": true,
+      "requires": {
+        "arr-flatten": "^1.1.0",
+        "array-unique": "^0.3.2",
+        "extend-shallow": "^2.0.1",
+        "fill-range": "^4.0.0",
+        "isobject": "^3.0.1",
+        "repeat-element": "^1.1.2",
+        "snapdragon": "^0.8.1",
+        "snapdragon-node": "^2.0.1",
+        "split-string": "^3.0.2",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "browser-process-hrtime": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
+      "integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
+      "dev": true
+    },
+    "browser-resolve": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+      "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+      "dev": true,
+      "requires": {
+        "resolve": "1.1.7"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+          "dev": true
+        }
+      }
+    },
+    "bser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
+      "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+      "dev": true,
+      "requires": {
+        "node-int64": "^0.4.0"
       }
     },
     "buffer-alloc": {
@@ -474,6 +1260,23 @@
         }
       }
     },
+    "cache-base": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "dev": true,
+      "requires": {
+        "collection-visit": "^1.0.0",
+        "component-emitter": "^1.2.1",
+        "get-value": "^2.0.6",
+        "has-value": "^1.0.0",
+        "isobject": "^3.0.1",
+        "set-value": "^2.0.0",
+        "to-object-path": "^0.3.0",
+        "union-value": "^1.0.0",
+        "unset-value": "^1.0.0"
+      }
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -494,6 +1297,15 @@
       "requires": {
         "camelcase": "^2.0.0",
         "map-obj": "^1.0.0"
+      }
+    },
+    "capture-exit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
+      "integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
+      "dev": true,
+      "requires": {
+        "rsvp": "^4.8.4"
       }
     },
     "capture-stack-trace": {
@@ -569,6 +1381,29 @@
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
       "dev": true
     },
+    "class-utils": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "define-property": "^0.2.5",
+        "isobject": "^3.0.0",
+        "static-extend": "^0.1.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
     "clean-stack": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.1.0.tgz",
@@ -639,11 +1474,27 @@
         }
       }
     },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
+    },
+    "collection-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+      "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+      "dev": true,
+      "requires": {
+        "map-visit": "^1.0.0",
+        "object-visit": "^1.0.0"
+      }
     },
     "color-convert": {
       "version": "1.9.3",
@@ -667,6 +1518,13 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "commander": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "dev": true,
+      "optional": true
+    },
     "compare-version": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
@@ -677,6 +1535,12 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.0.11.tgz",
       "integrity": "sha512-6IArJLApNtdg1P1dFtn3dnyzoZBEF0MwMnrfF1exSBRpZYoy4yieMkpZhQDC0uwctw48vii0CFVyHfpgZ/DfGw=="
+    },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -754,6 +1618,21 @@
         "xdg-basedir": "^3.0.0"
       }
     },
+    "convert-source-map": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "copy-descriptor": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+      "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+      "dev": true
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -785,6 +1664,21 @@
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
       "dev": true
     },
+    "cssom": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
+      "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
+      "dev": true
+    },
+    "cssstyle": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.2.tgz",
+      "integrity": "sha512-43wY3kl1CVQSvL7wUY1qXkxVGkStjpkDmVjiIKX8R97uhajy8Bybay78uOtqvh7Q5GK75dNPfW0geWjE6qQQow==",
+      "dev": true,
+      "requires": {
+        "cssom": "0.3.x"
+      }
+    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -800,6 +1694,30 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
         "assert-plus": "^1.0.0"
+      }
+    },
+    "data-urls": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+      "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+      "dev": true,
+      "requires": {
+        "abab": "^2.0.0",
+        "whatwg-mimetype": "^2.2.0",
+        "whatwg-url": "^7.0.0"
+      },
+      "dependencies": {
+        "whatwg-url": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
+          "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        }
       }
     },
     "date-fns": {
@@ -826,6 +1744,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.1.1.tgz",
       "integrity": "sha512-vEEgyk1fWVEnv7lPjkNedAIjzxQDue5Iw4FeX4UkNUDSVyD/jZTD0Bw2kAO7k6iyyJRAhM9oxxI0D1ET6k0Mmg=="
     },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -838,10 +1762,80 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      },
+      "dependencies": {
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
+        }
+      }
+    },
+    "define-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "dev": true,
+      "requires": {
+        "is-descriptor": "^1.0.2",
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "detect-newline": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+      "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+      "dev": true
+    },
+    "diff-sequences": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.3.0.tgz",
+      "integrity": "sha512-xLqpez+Zj9GKSnPWS0WZw1igGocZ+uua8+y+5dDNTT934N3QuY1sp2LkHzwiaYQGz60hMq0pjAshdeXm5VUOEw==",
+      "dev": true
     },
     "dmg-builder": {
       "version": "6.6.1",
@@ -866,6 +1860,15 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
+      }
+    },
+    "domexception": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+      "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+      "dev": true,
+      "requires": {
+        "webidl-conversions": "^4.0.2"
       }
     },
     "dot-prop": {
@@ -1197,6 +2200,39 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "es-abstract": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
+      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-keys": "^1.0.12"
+      },
+      "dependencies": {
+        "object-keys": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+          "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+          "dev": true
+        }
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
     "escape-latex": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.2.0.tgz",
@@ -1207,6 +2243,27 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
+    },
+    "escodegen": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
+      "integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
+      "dev": true,
+      "requires": {
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+          "dev": true
+        }
+      }
     },
     "eslint": {
       "version": "5.16.0",
@@ -1407,6 +2464,12 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "exec-sh": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.2.tgz",
+      "integrity": "sha512-9sLAvzhI5nc8TpuQUh4ahMdCrWT00wPWz7j47/emR5+2qEfoZP5zzUXvx+vdx+H6ohhnsYC31iX04QLYJK8zTg==",
+      "dev": true
+    },
     "execa": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
@@ -1422,10 +2485,86 @@
         "strip-eof": "^1.0.0"
       }
     },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "expand-brackets": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+      "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+      "dev": true,
+      "requires": {
+        "debug": "^2.3.3",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "posix-character-classes": "^0.1.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
+    "expect": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-24.8.0.tgz",
+      "integrity": "sha512-/zYvP8iMDrzaaxHVa724eJBCKqSHmO0FA7EDkBiRHxg6OipmMn1fN+C8T9L9K8yr7UONkOifu6+LLH+z76CnaA==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.8.0",
+        "ansi-styles": "^3.2.0",
+        "jest-get-type": "^24.8.0",
+        "jest-matcher-utils": "^24.8.0",
+        "jest-message-util": "^24.8.0",
+        "jest-regex-util": "^24.3.0"
+      }
+    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "extend-shallow": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+      "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+      "dev": true,
+      "requires": {
+        "assign-symbols": "^1.0.0",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
     },
     "external-editor": {
       "version": "3.0.3",
@@ -1436,6 +2575,71 @@
         "chardet": "^0.7.0",
         "iconv-lite": "^0.4.24",
         "tmp": "^0.0.33"
+      }
+    },
+    "extglob": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+      "dev": true,
+      "requires": {
+        "array-unique": "^0.3.2",
+        "define-property": "^1.0.0",
+        "expand-brackets": "^2.1.4",
+        "extend-shallow": "^2.0.1",
+        "fragment-cache": "^0.2.1",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
       }
     },
     "extract-zip": {
@@ -1477,6 +2681,15 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fb-watchman": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+      "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+      "dev": true,
+      "requires": {
+        "bser": "^2.0.0"
+      }
+    },
     "fd-slicer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
@@ -1504,6 +2717,29 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "fill-range": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+      "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1",
+        "to-regex-range": "^2.1.0"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
@@ -1529,6 +2765,12 @@
       "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
       "dev": true
     },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -1548,6 +2790,15 @@
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.12.tgz",
       "integrity": "sha512-8Z1K0VTG4hzYY7kA/1sj4/r1/RWLBD3xwReT/RCrUCbzPszjNQCCsy3ktkU/eaEqX3MYa4pY37a52eiBlPMlhA=="
+    },
+    "fragment-cache": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+      "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+      "dev": true,
+      "requires": {
+        "map-cache": "^0.2.2"
+      }
     },
     "fs-extra": {
       "version": "4.0.3",
@@ -1587,6 +2838,541 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "^2.12.1",
+        "node-pre-gyp": "^0.12.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "debug": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "fs-minipass": {
+          "version": "1.2.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "ignore-walk": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimatch": "^3.0.4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "minipass": {
+          "version": "2.3.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minipass": "^2.2.1"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "needle": {
+          "version": "2.3.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "^4.1.0",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1",
+            "osenv": "^0.1.4"
+          }
+        },
+        "npm-bundled": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "npm-packlist": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sax": {
+          "version": "1.2.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "semver": {
+          "version": "5.7.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "4.4.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "^1.0.2 || 2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "bundled": true,
+          "dev": true
+        }
+      }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
@@ -1609,6 +3395,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "dev": true
+    },
+    "get-value": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+      "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
     "getpass": {
@@ -1677,10 +3469,28 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
+    "growly": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
+      "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
+      "dev": true
+    },
     "gunzip-file": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/gunzip-file/-/gunzip-file-0.1.1.tgz",
       "integrity": "sha1-KbOjzIpqWM5VOBK8CxPwoLs6XuI="
+    },
+    "handlebars": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "dev": true,
+      "requires": {
+        "neo-async": "^2.6.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
+      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -1696,11 +3506,58 @@
         "har-schema": "^2.0.0"
       }
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
+    "has-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+      "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+      "dev": true,
+      "requires": {
+        "get-value": "^2.0.6",
+        "has-values": "^1.0.0",
+        "isobject": "^3.0.0"
+      }
+    },
+    "has-values": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+      "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
     },
     "hosted-git-info": {
       "version": "2.7.1",
@@ -1712,6 +3569,15 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/howler/-/howler-2.1.2.tgz",
       "integrity": "sha512-oKrTFaVXsDRoB/jik7cEpWKTj7VieoiuzMYJ7E/EU5ayvmpRhumCv3YQ3823zi9VTJkSWAhbryHnlZAionGAJg=="
+    },
+    "html-encoding-sniffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
+      "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
+      "dev": true,
+      "requires": {
+        "whatwg-encoding": "^1.0.1"
+      }
     },
     "http-signature": {
       "version": "1.2.0",
@@ -1753,6 +3619,16 @@
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-2.1.0.tgz",
       "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
       "dev": true
+    },
+    "import-local": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+      "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
+      "dev": true,
+      "requires": {
+        "pkg-dir": "^3.0.0",
+        "resolve-cwd": "^2.0.0"
+      }
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -1873,16 +3749,57 @@
         }
       }
     },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "invert-kv": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
       "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
       "dev": true
     },
+    "is-accessor-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
       "dev": true
     },
     "is-ci": {
@@ -1893,6 +3810,57 @@
       "requires": {
         "ci-info": "^2.0.0"
       }
+    },
+    "is-data-descriptor": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
+    "is-descriptor": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "dev": true,
+      "requires": {
+        "is-accessor-descriptor": "^0.1.6",
+        "is-data-descriptor": "^0.1.4",
+        "kind-of": "^5.0.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -1912,6 +3880,12 @@
         "number-is-nan": "^1.0.0"
       }
     },
+    "is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "dev": true
+    },
     "is-installed-globally": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
@@ -1928,6 +3902,26 @@
       "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
       "dev": true
     },
+    "is-number": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+      "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
@@ -1942,6 +3936,15 @@
         "path-is-inside": "^1.0.1"
       }
     },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
@@ -1953,6 +3956,15 @@
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
       "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1"
+      }
     },
     "is-retry-allowed": {
       "version": "1.1.0",
@@ -1966,6 +3978,15 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -1975,6 +3996,18 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
+    "is-wsl": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
       "dev": true
     },
     "isarray": {
@@ -1995,15 +4028,899 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
+    "istanbul-lib-coverage": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+      "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
+      "dev": true
+    },
+    "istanbul-lib-instrument": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+      "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
+      "dev": true,
+      "requires": {
+        "@babel/generator": "^7.4.0",
+        "@babel/parser": "^7.4.3",
+        "@babel/template": "^7.4.0",
+        "@babel/traverse": "^7.4.3",
+        "@babel/types": "^7.4.0",
+        "istanbul-lib-coverage": "^2.0.5",
+        "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
+          "integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==",
+          "dev": true
+        }
+      }
+    },
+    "istanbul-lib-report": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz",
+      "integrity": "sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==",
+      "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "^2.0.5",
+        "make-dir": "^2.1.0",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "make-dir": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+          "dev": true,
+          "requires": {
+            "pify": "^4.0.1",
+            "semver": "^5.6.0"
+          }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-lib-source-maps": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz",
+      "integrity": "sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^2.0.5",
+        "make-dir": "^2.1.0",
+        "rimraf": "^2.6.3",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "make-dir": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+          "dev": true,
+          "requires": {
+            "pify": "^4.0.1",
+            "semver": "^5.6.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        }
+      }
+    },
+    "istanbul-reports": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.4.tgz",
+      "integrity": "sha512-QCHGyZEK0bfi9GR215QSm+NJwFKEShbtc7tfbUdLAEzn3kKhLDDZqvljn8rPZM9v8CEOhzL1nlYoO4r1ryl67w==",
+      "dev": true,
+      "requires": {
+        "handlebars": "^4.1.2"
+      }
+    },
     "javascript-natural-sort": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
       "integrity": "sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k="
+    },
+    "jest": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-24.8.0.tgz",
+      "integrity": "sha512-o0HM90RKFRNWmAWvlyV8i5jGZ97pFwkeVoGvPW1EtLTgJc2+jcuqcbbqcSZLE/3f2S5pt0y2ZBETuhpWNl1Reg==",
+      "dev": true,
+      "requires": {
+        "import-local": "^2.0.0",
+        "jest-cli": "^24.8.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "get-caller-file": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "jest-cli": {
+          "version": "24.8.0",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-24.8.0.tgz",
+          "integrity": "sha512-+p6J00jSMPQ116ZLlHJJvdf8wbjNbZdeSX9ptfHX06/MSNaXmKihQzx5vQcw0q2G6JsdVkUIdWbOWtSnaYs3yA==",
+          "dev": true,
+          "requires": {
+            "@jest/core": "^24.8.0",
+            "@jest/test-result": "^24.8.0",
+            "@jest/types": "^24.8.0",
+            "chalk": "^2.0.1",
+            "exit": "^0.1.2",
+            "import-local": "^2.0.0",
+            "is-ci": "^2.0.0",
+            "jest-config": "^24.8.0",
+            "jest-util": "^24.8.0",
+            "jest-validate": "^24.8.0",
+            "prompts": "^2.0.1",
+            "realpath-native": "^1.1.0",
+            "yargs": "^12.0.2"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "yargs": {
+          "version": "12.0.5",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
+    "jest-changed-files": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-24.8.0.tgz",
+      "integrity": "sha512-qgANC1Yrivsq+UrLXsvJefBKVoCsKB0Hv+mBb6NMjjZ90wwxCDmU3hsCXBya30cH+LnPYjwgcU65i6yJ5Nfuug==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.8.0",
+        "execa": "^1.0.0",
+        "throat": "^4.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
+      }
+    },
+    "jest-config": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-24.8.0.tgz",
+      "integrity": "sha512-Czl3Nn2uEzVGsOeaewGWoDPD8GStxCpAe0zOYs2x2l0fZAgPbCr3uwUkgNKV3LwE13VXythM946cd5rdGkkBZw==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.1.0",
+        "@jest/test-sequencer": "^24.8.0",
+        "@jest/types": "^24.8.0",
+        "babel-jest": "^24.8.0",
+        "chalk": "^2.0.1",
+        "glob": "^7.1.1",
+        "jest-environment-jsdom": "^24.8.0",
+        "jest-environment-node": "^24.8.0",
+        "jest-get-type": "^24.8.0",
+        "jest-jasmine2": "^24.8.0",
+        "jest-regex-util": "^24.3.0",
+        "jest-resolve": "^24.8.0",
+        "jest-util": "^24.8.0",
+        "jest-validate": "^24.8.0",
+        "micromatch": "^3.1.10",
+        "pretty-format": "^24.8.0",
+        "realpath-native": "^1.1.0"
+      }
+    },
+    "jest-diff": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.8.0.tgz",
+      "integrity": "sha512-wxetCEl49zUpJ/bvUmIFjd/o52J+yWcoc5ZyPq4/W1LUKGEhRYDIbP1KcF6t+PvqNrGAFk4/JhtxDq/Nnzs66g==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1",
+        "diff-sequences": "^24.3.0",
+        "jest-get-type": "^24.8.0",
+        "pretty-format": "^24.8.0"
+      }
+    },
+    "jest-docblock": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-24.3.0.tgz",
+      "integrity": "sha512-nlANmF9Yq1dufhFlKG9rasfQlrY7wINJbo3q01tu56Jv5eBU5jirylhF2O5ZBnLxzOVBGRDz/9NAwNyBtG4Nyg==",
+      "dev": true,
+      "requires": {
+        "detect-newline": "^2.1.0"
+      }
+    },
+    "jest-each": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-24.8.0.tgz",
+      "integrity": "sha512-NrwK9gaL5+XgrgoCsd9svsoWdVkK4gnvyhcpzd6m487tXHqIdYeykgq3MKI1u4I+5Zf0tofr70at9dWJDeb+BA==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.8.0",
+        "chalk": "^2.0.1",
+        "jest-get-type": "^24.8.0",
+        "jest-util": "^24.8.0",
+        "pretty-format": "^24.8.0"
+      }
+    },
+    "jest-environment-jsdom": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-24.8.0.tgz",
+      "integrity": "sha512-qbvgLmR7PpwjoFjM/sbuqHJt/NCkviuq9vus9NBn/76hhSidO+Z6Bn9tU8friecegbJL8gzZQEMZBQlFWDCwAQ==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^24.8.0",
+        "@jest/fake-timers": "^24.8.0",
+        "@jest/types": "^24.8.0",
+        "jest-mock": "^24.8.0",
+        "jest-util": "^24.8.0",
+        "jsdom": "^11.5.1"
+      }
+    },
+    "jest-environment-node": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.8.0.tgz",
+      "integrity": "sha512-vIGUEScd1cdDgR6sqn2M08sJTRLQp6Dk/eIkCeO4PFHxZMOgy+uYLPMC4ix3PEfM5Au/x3uQ/5Tl0DpXXZsJ/Q==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^24.8.0",
+        "@jest/fake-timers": "^24.8.0",
+        "@jest/types": "^24.8.0",
+        "jest-mock": "^24.8.0",
+        "jest-util": "^24.8.0"
+      }
+    },
+    "jest-get-type": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.8.0.tgz",
+      "integrity": "sha512-RR4fo8jEmMD9zSz2nLbs2j0zvPpk/KCEz3a62jJWbd2ayNo0cb+KFRxPHVhE4ZmgGJEQp0fosmNz84IfqM8cMQ==",
+      "dev": true
+    },
+    "jest-haste-map": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.8.0.tgz",
+      "integrity": "sha512-ZBPRGHdPt1rHajWelXdqygIDpJx8u3xOoLyUBWRW28r3tagrgoepPrzAozW7kW9HrQfhvmiv1tncsxqHJO1onQ==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.8.0",
+        "anymatch": "^2.0.0",
+        "fb-watchman": "^2.0.0",
+        "fsevents": "^1.2.7",
+        "graceful-fs": "^4.1.15",
+        "invariant": "^2.2.4",
+        "jest-serializer": "^24.4.0",
+        "jest-util": "^24.8.0",
+        "jest-worker": "^24.6.0",
+        "micromatch": "^3.1.10",
+        "sane": "^4.0.3",
+        "walker": "^1.0.7"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.15",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+          "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+          "dev": true
+        }
+      }
+    },
+    "jest-jasmine2": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-24.8.0.tgz",
+      "integrity": "sha512-cEky88npEE5LKd5jPpTdDCLvKkdyklnaRycBXL6GNmpxe41F0WN44+i7lpQKa/hcbXaQ+rc9RMaM4dsebrYong==",
+      "dev": true,
+      "requires": {
+        "@babel/traverse": "^7.1.0",
+        "@jest/environment": "^24.8.0",
+        "@jest/test-result": "^24.8.0",
+        "@jest/types": "^24.8.0",
+        "chalk": "^2.0.1",
+        "co": "^4.6.0",
+        "expect": "^24.8.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^24.8.0",
+        "jest-matcher-utils": "^24.8.0",
+        "jest-message-util": "^24.8.0",
+        "jest-runtime": "^24.8.0",
+        "jest-snapshot": "^24.8.0",
+        "jest-util": "^24.8.0",
+        "pretty-format": "^24.8.0",
+        "throat": "^4.0.0"
+      }
+    },
+    "jest-leak-detector": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.8.0.tgz",
+      "integrity": "sha512-cG0yRSK8A831LN8lIHxI3AblB40uhv0z+SsQdW3GoMMVcK+sJwrIIyax5tu3eHHNJ8Fu6IMDpnLda2jhn2pD/g==",
+      "dev": true,
+      "requires": {
+        "pretty-format": "^24.8.0"
+      }
+    },
+    "jest-matcher-utils": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-24.8.0.tgz",
+      "integrity": "sha512-lex1yASY51FvUuHgm0GOVj7DCYEouWSlIYmCW7APSqB9v8mXmKSn5+sWVF0MhuASG0bnYY106/49JU1FZNl5hw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1",
+        "jest-diff": "^24.8.0",
+        "jest-get-type": "^24.8.0",
+        "pretty-format": "^24.8.0"
+      }
+    },
+    "jest-message-util": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.8.0.tgz",
+      "integrity": "sha512-p2k71rf/b6ns8btdB0uVdljWo9h0ovpnEe05ZKWceQGfXYr4KkzgKo3PBi8wdnd9OtNh46VpNIJynUn/3MKm1g==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@jest/test-result": "^24.8.0",
+        "@jest/types": "^24.8.0",
+        "@types/stack-utils": "^1.0.1",
+        "chalk": "^2.0.1",
+        "micromatch": "^3.1.10",
+        "slash": "^2.0.0",
+        "stack-utils": "^1.0.1"
+      }
+    },
+    "jest-mock": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.8.0.tgz",
+      "integrity": "sha512-6kWugwjGjJw+ZkK4mDa0Df3sDlUTsV47MSrT0nGQ0RBWJbpODDQ8MHDVtGtUYBne3IwZUhtB7elxHspU79WH3A==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.8.0"
+      }
+    },
+    "jest-pnp-resolver": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
+      "integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==",
+      "dev": true
+    },
+    "jest-regex-util": {
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.3.0.tgz",
+      "integrity": "sha512-tXQR1NEOyGlfylyEjg1ImtScwMq8Oh3iJbGTjN7p0J23EuVX1MA8rwU69K4sLbCmwzgCUbVkm0FkSF9TdzOhtg==",
+      "dev": true
+    },
+    "jest-resolve": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-24.8.0.tgz",
+      "integrity": "sha512-+hjSzi1PoRvnuOICoYd5V/KpIQmkAsfjFO71458hQ2Whi/yf1GDeBOFj8Gxw4LrApHsVJvn5fmjcPdmoUHaVKw==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.8.0",
+        "browser-resolve": "^1.11.3",
+        "chalk": "^2.0.1",
+        "jest-pnp-resolver": "^1.2.1",
+        "realpath-native": "^1.1.0"
+      }
+    },
+    "jest-resolve-dependencies": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-24.8.0.tgz",
+      "integrity": "sha512-hyK1qfIf/krV+fSNyhyJeq3elVMhK9Eijlwy+j5jqmZ9QsxwKBiP6qukQxaHtK8k6zql/KYWwCTQ+fDGTIJauw==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.8.0",
+        "jest-regex-util": "^24.3.0",
+        "jest-snapshot": "^24.8.0"
+      }
+    },
+    "jest-runner": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-24.8.0.tgz",
+      "integrity": "sha512-utFqC5BaA3JmznbissSs95X1ZF+d+4WuOWwpM9+Ak356YtMhHE/GXUondZdcyAAOTBEsRGAgH/0TwLzfI9h7ow==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^24.7.1",
+        "@jest/environment": "^24.8.0",
+        "@jest/test-result": "^24.8.0",
+        "@jest/types": "^24.8.0",
+        "chalk": "^2.4.2",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.1.15",
+        "jest-config": "^24.8.0",
+        "jest-docblock": "^24.3.0",
+        "jest-haste-map": "^24.8.0",
+        "jest-jasmine2": "^24.8.0",
+        "jest-leak-detector": "^24.8.0",
+        "jest-message-util": "^24.8.0",
+        "jest-resolve": "^24.8.0",
+        "jest-runtime": "^24.8.0",
+        "jest-util": "^24.8.0",
+        "jest-worker": "^24.6.0",
+        "source-map-support": "^0.5.6",
+        "throat": "^4.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.15",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+          "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+          "dev": true
+        }
+      }
+    },
+    "jest-runtime": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-24.8.0.tgz",
+      "integrity": "sha512-Mq0aIXhvO/3bX44ccT+czU1/57IgOMyy80oM0XR/nyD5zgBcesF84BPabZi39pJVA6UXw+fY2Q1N+4BiVUBWOA==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^24.7.1",
+        "@jest/environment": "^24.8.0",
+        "@jest/source-map": "^24.3.0",
+        "@jest/transform": "^24.8.0",
+        "@jest/types": "^24.8.0",
+        "@types/yargs": "^12.0.2",
+        "chalk": "^2.0.1",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.1.15",
+        "jest-config": "^24.8.0",
+        "jest-haste-map": "^24.8.0",
+        "jest-message-util": "^24.8.0",
+        "jest-mock": "^24.8.0",
+        "jest-regex-util": "^24.3.0",
+        "jest-resolve": "^24.8.0",
+        "jest-snapshot": "^24.8.0",
+        "jest-util": "^24.8.0",
+        "jest-validate": "^24.8.0",
+        "realpath-native": "^1.1.0",
+        "slash": "^2.0.0",
+        "strip-bom": "^3.0.0",
+        "yargs": "^12.0.2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "get-caller-file": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "4.1.15",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+          "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "12.0.5",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
+    "jest-serializer": {
+      "version": "24.4.0",
+      "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.4.0.tgz",
+      "integrity": "sha512-k//0DtglVstc1fv+GY/VHDIjrtNjdYvYjMlbLUed4kxrE92sIUewOi5Hj3vrpB8CXfkJntRPDRjCrCvUhBdL8Q==",
+      "dev": true
+    },
+    "jest-snapshot": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-24.8.0.tgz",
+      "integrity": "sha512-5ehtWoc8oU9/cAPe6fez6QofVJLBKyqkY2+TlKTOf0VllBB/mqUNdARdcjlZrs9F1Cv+/HKoCS/BknT0+tmfPg==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0",
+        "@jest/types": "^24.8.0",
+        "chalk": "^2.0.1",
+        "expect": "^24.8.0",
+        "jest-diff": "^24.8.0",
+        "jest-matcher-utils": "^24.8.0",
+        "jest-message-util": "^24.8.0",
+        "jest-resolve": "^24.8.0",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^24.8.0",
+        "semver": "^5.5.0"
+      }
+    },
+    "jest-util": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.8.0.tgz",
+      "integrity": "sha512-DYZeE+XyAnbNt0BG1OQqKy/4GVLPtzwGx5tsnDrFcax36rVE3lTA5fbvgmbVPUZf9w77AJ8otqR4VBbfFJkUZA==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^24.7.1",
+        "@jest/fake-timers": "^24.8.0",
+        "@jest/source-map": "^24.3.0",
+        "@jest/test-result": "^24.8.0",
+        "@jest/types": "^24.8.0",
+        "callsites": "^3.0.0",
+        "chalk": "^2.0.1",
+        "graceful-fs": "^4.1.15",
+        "is-ci": "^2.0.0",
+        "mkdirp": "^0.5.1",
+        "slash": "^2.0.0",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.15",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+          "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+          "dev": true
+        }
+      }
+    },
+    "jest-validate": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-24.8.0.tgz",
+      "integrity": "sha512-+/N7VOEMW1Vzsrk3UWBDYTExTPwf68tavEPKDnJzrC6UlHtUDU/fuEdXqFoHzv9XnQ+zW6X3qMZhJ3YexfeLDA==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.8.0",
+        "camelcase": "^5.0.0",
+        "chalk": "^2.0.1",
+        "jest-get-type": "^24.8.0",
+        "leven": "^2.1.0",
+        "pretty-format": "^24.8.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        }
+      }
+    },
+    "jest-watcher": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-24.8.0.tgz",
+      "integrity": "sha512-SBjwHt5NedQoVu54M5GEx7cl7IGEFFznvd/HNT8ier7cCAx/Qgu9ZMlaTQkvK22G1YOpcWBLQPFSImmxdn3DAw==",
+      "dev": true,
+      "requires": {
+        "@jest/test-result": "^24.8.0",
+        "@jest/types": "^24.8.0",
+        "@types/yargs": "^12.0.9",
+        "ansi-escapes": "^3.0.0",
+        "chalk": "^2.0.1",
+        "jest-util": "^24.8.0",
+        "string-length": "^2.0.0"
+      }
+    },
+    "jest-worker": {
+      "version": "24.6.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.6.0.tgz",
+      "integrity": "sha512-jDwgW5W9qGNvpI1tNnvajh0a5IE/PuGLFmHk6aR/BZFz8tSgGw17GsDPXAJ6p91IvYDjOw8GpFbvvZGAK+DPQQ==",
+      "dev": true,
+      "requires": {
+        "merge-stream": "^1.0.1",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
     },
     "js-sha1": {
       "version": "0.6.0",
@@ -2029,6 +4946,60 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "jsdom": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
+      "integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
+      "dev": true,
+      "requires": {
+        "abab": "^2.0.0",
+        "acorn": "^5.5.3",
+        "acorn-globals": "^4.1.0",
+        "array-equal": "^1.0.0",
+        "cssom": ">= 0.3.2 < 0.4.0",
+        "cssstyle": "^1.0.0",
+        "data-urls": "^1.0.0",
+        "domexception": "^1.0.1",
+        "escodegen": "^1.9.1",
+        "html-encoding-sniffer": "^1.0.2",
+        "left-pad": "^1.3.0",
+        "nwsapi": "^2.0.7",
+        "parse5": "4.0.0",
+        "pn": "^1.1.0",
+        "request": "^2.87.0",
+        "request-promise-native": "^1.0.5",
+        "sax": "^1.2.4",
+        "symbol-tree": "^3.2.2",
+        "tough-cookie": "^2.3.4",
+        "w3c-hr-time": "^1.0.1",
+        "webidl-conversions": "^4.0.2",
+        "whatwg-encoding": "^1.0.3",
+        "whatwg-mimetype": "^2.1.0",
+        "whatwg-url": "^6.4.1",
+        "ws": "^5.2.0",
+        "xml-name-validator": "^3.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.7.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+          "dev": true
+        }
+      }
+    },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
+    "json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
@@ -2089,6 +5060,18 @@
       "resolved": "https://registry.npmjs.org/keyboardevents-areequal/-/keyboardevents-areequal-0.2.2.tgz",
       "integrity": "sha512-Nv+Kr33T0mEjxR500q+I6IWisOQ0lK1GGOncV0kWE6n4KFmpcu7RUX5/2B0EUtX51Cb0HjZ9VJsSY3u4cBa0kw=="
     },
+    "kind-of": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+      "dev": true
+    },
+    "kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "dev": true
+    },
     "latest-version": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
@@ -2111,6 +5094,18 @@
       "requires": {
         "invert-kv": "^2.0.0"
       }
+    },
+    "left-pad": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+      "dev": true
+    },
+    "leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "dev": true
     },
     "levn": {
       "version": "0.3.0",
@@ -2173,10 +5168,25 @@
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+      "dev": true
+    },
     "lodash.transform": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.transform/-/lodash.transform-4.6.0.tgz",
       "integrity": "sha1-EjBkIvYzJK7YSD0/ODMrX2cFR6A="
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
     },
     "loud-rejection": {
       "version": "1.6.0",
@@ -2212,6 +5222,15 @@
         "pify": "^3.0.0"
       }
     },
+    "makeerror": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
+      "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
+      "dev": true,
+      "requires": {
+        "tmpl": "1.0.x"
+      }
+    },
     "map-age-cleaner": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
@@ -2221,11 +5240,26 @@
         "p-defer": "^1.0.0"
       }
     },
+    "map-cache": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+      "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+      "dev": true
+    },
     "map-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "dev": true
+    },
+    "map-visit": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+      "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+      "dev": true,
+      "requires": {
+        "object-visit": "^1.0.0"
+      }
     },
     "mathjs": {
       "version": "5.9.0",
@@ -2279,6 +5313,68 @@
         "trim-newlines": "^1.0.0"
       }
     },
+    "merge-stream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+      "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "micromatch": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "braces": "^2.3.1",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "extglob": "^2.0.4",
+        "fragment-cache": "^0.2.1",
+        "kind-of": "^6.0.2",
+        "nanomatch": "^1.2.9",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.2"
+      }
+    },
     "mime": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.2.tgz",
@@ -2319,6 +5415,27 @@
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
+    "mixin-deep": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -2352,10 +5469,42 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
+    "nan": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+      "dev": true,
+      "optional": true
+    },
+    "nanomatch": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "dev": true,
+      "requires": {
+        "arr-diff": "^4.0.0",
+        "array-unique": "^0.3.2",
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "fragment-cache": "^0.2.1",
+        "is-windows": "^1.0.2",
+        "kind-of": "^6.0.2",
+        "object.pick": "^1.3.0",
+        "regex-not": "^1.0.0",
+        "snapdragon": "^0.8.1",
+        "to-regex": "^3.0.1"
+      }
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "neo-async": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
     },
     "new-github-issue-url": {
@@ -2369,6 +5518,31 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=",
+      "dev": true
+    },
+    "node-modules-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+      "dev": true
+    },
+    "node-notifier": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.4.0.tgz",
+      "integrity": "sha512-SUDEb+o71XR5lXSTyivXd9J7fCloE3SyP4lSgt3lU2oSANiox+SxlNRGPjDKrwU1YN3ix2KN/VGGCg0t01rttQ==",
+      "dev": true,
+      "requires": {
+        "growly": "^1.3.0",
+        "is-wsl": "^1.1.0",
+        "semver": "^5.5.0",
+        "shellwords": "^0.1.1",
+        "which": "^1.3.0"
+      }
+    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -2379,6 +5553,15 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "dev": true,
+      "requires": {
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "npm": {
@@ -5442,6 +8625,12 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
+    "nwsapi": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.4.tgz",
+      "integrity": "sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw==",
+      "dev": true
+    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -5453,11 +8642,70 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
+    "object-copy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+      "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+      "dev": true,
+      "requires": {
+        "copy-descriptor": "^0.1.0",
+        "define-property": "^0.2.5",
+        "kind-of": "^3.0.3"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
     "object-keys": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
       "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
       "dev": true
+    },
+    "object-visit": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+      "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.0"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -5475,6 +8723,30 @@
       "dev": true,
       "requires": {
         "mimic-fn": "^1.0.0"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
       }
     },
     "optionator": {
@@ -5558,6 +8830,15 @@
       "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
       "dev": true
     },
+    "p-each-series": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
+      "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
+      "dev": true,
+      "requires": {
+        "p-reduce": "^1.0.0"
+      }
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -5585,6 +8866,12 @@
       "requires": {
         "p-limit": "^1.1.0"
       }
+    },
+    "p-reduce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
+      "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
+      "dev": true
     },
     "p-try": {
       "version": "1.0.0",
@@ -5642,6 +8929,18 @@
       "requires": {
         "error-ex": "^1.2.0"
       }
+    },
+    "parse5": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+      "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+      "dev": true
+    },
+    "pascalcase": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+      "dev": true
     },
     "path-exists": {
       "version": "3.0.0",
@@ -5722,6 +9021,69 @@
         "pinkie": "^2.0.0"
       }
     },
+    "pirates": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
+      "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
+      "dev": true,
+      "requires": {
+        "node-modules-regexp": "^1.0.0"
+      }
+    },
+    "pkg-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        }
+      }
+    },
     "pkg-up": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
@@ -5740,6 +9102,18 @@
         "xmlbuilder": "^9.0.7",
         "xmldom": "0.1.x"
       }
+    },
+    "pn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+      "dev": true
+    },
+    "posix-character-classes": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+      "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+      "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -5778,6 +9152,26 @@
         "meow": "^3.1.0"
       }
     },
+    "pretty-format": {
+      "version": "24.8.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.8.0.tgz",
+      "integrity": "sha512-P952T7dkrDEplsR+TuY7q3VXDae5Sr7zmQb12JU/NDQa/3CH7/QW0yvqLcGN6jL+zQFKaoJcPc+yJxMTGmosqw==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.8.0",
+        "ansi-regex": "^4.0.0",
+        "ansi-styles": "^3.2.0",
+        "react-is": "^16.8.4"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        }
+      }
+    },
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
@@ -5798,6 +9192,16 @@
       "requires": {
         "speedometer": "~0.1.2",
         "through2": "~0.2.3"
+      }
+    },
+    "prompts": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.0.4.tgz",
+      "integrity": "sha512-HTzM3UWp/99A0gk51gAegwo1QRYA7xjcZufMNe33rCclFszUYAuHe1fIN/3ZmiHeGPkUsNaRyQm1hHOfM0PKxA==",
+      "dev": true,
+      "requires": {
+        "kleur": "^3.0.2",
+        "sisteransi": "^1.0.0"
       }
     },
     "pseudomap": {
@@ -5850,6 +9254,12 @@
         "minimist": "^1.2.0",
         "strip-json-comments": "~2.0.1"
       }
+    },
+    "react-is": {
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+      "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
+      "dev": true
     },
     "read-config-file": {
       "version": "3.2.2",
@@ -5922,6 +9332,15 @@
         "string_decoder": "~0.10.x"
       }
     },
+    "realpath-native": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.1.0.tgz",
+      "integrity": "sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==",
+      "dev": true,
+      "requires": {
+        "util.promisify": "^1.0.0"
+      }
+    },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -5930,6 +9349,16 @@
       "requires": {
         "indent-string": "^2.1.0",
         "strip-indent": "^1.0.1"
+      }
+    },
+    "regex-not": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.2",
+        "safe-regex": "^1.1.0"
       }
     },
     "regexpp": {
@@ -5956,6 +9385,24 @@
       "requires": {
         "rc": "^1.0.1"
       }
+    },
+    "remove-trailing-separator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+      "dev": true
+    },
+    "repeat-element": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
+      "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
     },
     "repeating": {
       "version": "2.0.1",
@@ -6015,6 +9462,26 @@
         }
       }
     },
+    "request-promise-core": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+      "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.11"
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
+      "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
+      "dev": true,
+      "requires": {
+        "request-promise-core": "1.1.2",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -6036,10 +9503,33 @@
         "path-parse": "^1.0.6"
       }
     },
+    "resolve-cwd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^3.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "dev": true
+        }
+      }
+    },
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
       "dev": true
     },
     "restore-cursor": {
@@ -6052,6 +9542,12 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
     "rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -6060,6 +9556,12 @@
       "requires": {
         "glob": "^7.1.3"
       }
+    },
+    "rsvp": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.4.tgz",
+      "integrity": "sha512-6FomvYPfs+Jy9TfXmBpBuMWNH94SgCsZmJKcanySzgNNP6LjWxBvyLTa9KaMfDDM5oxRfrKDB0r/qeRsLwnBfA==",
+      "dev": true
     },
     "run-async": {
       "version": "2.3.0",
@@ -6084,10 +9586,75 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
+    "safe-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+      "dev": true,
+      "requires": {
+        "ret": "~0.1.10"
+      }
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sane": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
+      "integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
+      "dev": true,
+      "requires": {
+        "@cnakazawa/watch": "^1.0.3",
+        "anymatch": "^2.0.0",
+        "capture-exit": "^2.0.0",
+        "exec-sh": "^0.3.2",
+        "execa": "^1.0.0",
+        "fb-watchman": "^2.0.0",
+        "micromatch": "^3.1.4",
+        "minimist": "^1.1.1",
+        "walker": "~1.0.5"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        }
+      }
     },
     "sanitize-filename": {
       "version": "1.6.1",
@@ -6128,6 +9695,29 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
+    "set-value": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        }
+      }
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -6143,6 +9733,12 @@
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
+    "shellwords": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+      "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
+      "dev": true
+    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -6156,6 +9752,18 @@
       "requires": {
         "string-width": "^1.0.1"
       }
+    },
+    "sisteransi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.0.tgz",
+      "integrity": "sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ==",
+      "dev": true
+    },
+    "slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true
     },
     "slice-ansi": {
       "version": "2.1.0",
@@ -6176,10 +9784,136 @@
         }
       }
     },
+    "snapdragon": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "dev": true,
+      "requires": {
+        "base": "^0.11.1",
+        "debug": "^2.2.0",
+        "define-property": "^0.2.5",
+        "extend-shallow": "^2.0.1",
+        "map-cache": "^0.2.2",
+        "source-map": "^0.5.6",
+        "source-map-resolve": "^0.5.0",
+        "use": "^3.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        }
+      }
+    },
+    "snapdragon-node": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^1.0.0",
+        "isobject": "^3.0.0",
+        "snapdragon-util": "^3.0.1"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+          "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^1.0.0"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        }
+      }
+    },
+    "snapdragon-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.2.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
+    "source-map-resolve": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "dev": true,
+      "requires": {
+        "atob": "^2.1.1",
+        "decode-uri-component": "^0.2.0",
+        "resolve-url": "^0.2.1",
+        "source-map-url": "^0.4.0",
+        "urix": "^0.1.0"
+      }
     },
     "source-map-support": {
       "version": "0.5.10",
@@ -6189,6 +9923,12 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "source-map-url": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
     },
     "spdx-correct": {
       "version": "3.1.0",
@@ -6228,6 +9968,15 @@
       "integrity": "sha1-mHbb0qFp0xFUAtSObqYynIgWpQ0=",
       "dev": true
     },
+    "split-string": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^3.0.0"
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -6249,11 +9998,71 @@
         "tweetnacl": "~0.14.0"
       }
     },
+    "stack-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
+      "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
+      "dev": true
+    },
     "stat-mode": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.3.0.tgz",
       "integrity": "sha512-QjMLR0A3WwFY2aZdV0okfFEJB5TRjkggXZjxP3A1RsWsNHNu3YPv8btmtc6iCFZ0Rul3FE93OYogvhOUClU+ng==",
       "dev": true
+    },
+    "static-extend": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+      "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+      "dev": true,
+      "requires": {
+        "define-property": "^0.2.5",
+        "object-copy": "^0.1.0"
+      },
+      "dependencies": {
+        "define-property": {
+          "version": "0.2.5",
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+          "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+          "dev": true,
+          "requires": {
+            "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
+    },
+    "string-length": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
+      "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
+      "dev": true,
+      "requires": {
+        "astral-regex": "^1.0.0",
+        "strip-ansi": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
     },
     "string-width": {
       "version": "1.0.2",
@@ -6334,6 +10143,12 @@
         "has-flag": "^3.0.0"
       }
     },
+    "symbol-tree": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+      "dev": true
+    },
     "table": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/table/-/table-5.2.3.tgz",
@@ -6400,10 +10215,131 @@
         "execa": "^0.7.0"
       }
     },
+    "test-exclude": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
+      "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3",
+        "minimatch": "^3.0.4",
+        "read-pkg-up": "^4.0.0",
+        "require-main-filename": "^2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+          "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0",
+            "read-pkg": "^3.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
+      }
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "throat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
+      "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
       "dev": true
     },
     "throttleit": {
@@ -6453,6 +10389,60 @@
         "os-tmpdir": "~1.0.2"
       }
     },
+    "tmpl": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
+      "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
+      "dev": true
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "dev": true,
+          "requires": {
+            "is-buffer": "^1.1.5"
+          }
+        }
+      }
+    },
+    "to-regex": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "dev": true,
+      "requires": {
+        "define-property": "^2.0.2",
+        "extend-shallow": "^3.0.2",
+        "regex-not": "^1.0.2",
+        "safe-regex": "^1.1.0"
+      }
+    },
+    "to-regex-range": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+      "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+      "dev": true,
+      "requires": {
+        "is-number": "^3.0.0",
+        "repeat-string": "^1.6.1"
+      }
+    },
     "tough-cookie": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
@@ -6469,10 +10459,25 @@
         }
       }
     },
+    "tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "dev": true
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
     "truncate-utf8-bytes": {
@@ -6523,6 +10528,52 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "uglify-js": {
+      "version": "3.5.12",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.12.tgz",
+      "integrity": "sha512-KeQesOpPiZNgVwJj8Ge3P4JYbQHUdZzpx6Fahy6eKAYRSV4zhVmLXoC+JtOeYxcHCHTve8RG1ZGdTvpeOUM26Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "commander": "~2.20.0",
+        "source-map": "~0.6.1"
+      }
+    },
+    "union-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "dev": true,
+      "requires": {
+        "arr-union": "^3.1.0",
+        "get-value": "^2.0.6",
+        "is-extendable": "^0.1.1",
+        "set-value": "^0.4.3"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "dev": true,
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "set-value": {
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.1",
+            "to-object-path": "^0.3.0"
+          }
+        }
+      }
+    },
     "unique-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
@@ -6536,6 +10587,52 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+    },
+    "unset-value": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+      "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+      "dev": true,
+      "requires": {
+        "has-value": "^0.3.1",
+        "isobject": "^3.0.0"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "dev": true
+        }
+      }
     },
     "unzip-response": {
       "version": "2.0.1",
@@ -6586,6 +10683,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
+    },
     "url-parse-lax": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
@@ -6594,6 +10697,12 @@
       "requires": {
         "prepend-http": "^1.0.1"
       }
+    },
+    "use": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "dev": true
     },
     "utf8-byte-length": {
       "version": "1.0.4",
@@ -6606,6 +10715,16 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
+    },
+    "util.promisify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+      "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "object.getownpropertydescriptors": "^2.0.3"
+      }
     },
     "uuid": {
       "version": "3.3.2",
@@ -6630,6 +10749,56 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "w3c-hr-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+      "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+      "dev": true,
+      "requires": {
+        "browser-process-hrtime": "^0.1.2"
+      }
+    },
+    "walker": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
+      "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
+      "dev": true,
+      "requires": {
+        "makeerror": "1.0.x"
+      }
+    },
+    "webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
+    },
+    "whatwg-encoding": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+      "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.24"
+      }
+    },
+    "whatwg-mimetype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+      "dev": true,
+      "requires": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
       }
     },
     "which": {
@@ -6730,10 +10899,25 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "ws": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+      "dev": true,
+      "requires": {
+        "async-limiter": "~1.0.0"
+      }
+    },
     "xdg-basedir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+      "dev": true
+    },
+    "xml-name-validator": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
     },
     "xmlbuilder": {

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "eslint": "^5.16.0",
     "eslint-config-prettier": "^4.2.0",
     "eslint-plugin-prettier": "^3.0.1",
+    "jest": "^24.8.0",
     "prettier": "1.16.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "main": "main.js",
   "build": {
     "appId": "com.github.manuel777.mtgatool",
+    "files": ["!**/__tests__/**"],
     "win": {
       "target": "NSIS",
       "icon": "icon.ico",

--- a/package.json
+++ b/package.json
@@ -50,8 +50,10 @@
   "scripts": {
     "start": "electron .",
     "postinstall": "install-app-deps",
-    "test": "npx eslint . --quiet",
-    "predist": "npx eslint . --quiet",
+    "lint": "npx eslint . --quiet",
+    "pretest": "npm run lint",
+    "test": "npx jest",
+    "predist": "npm test",
     "dist": "build --x64",
     "version": "node -p \"require('./package.json').version\""
   },

--- a/window_background/arena-log-decoder/__tests__/arena-log-decoder-spec.js
+++ b/window_background/arena-log-decoder/__tests__/arena-log-decoder-spec.js
@@ -14,7 +14,7 @@ describe("arena-log-decoder", () => {
       const decoder = new ArenaLogDecoder();
       const logEntries = [];
       decoder.append(text, logEntry => logEntries.push(logEntry));
-      expect(logEntries.length).toEqual(8154);
+      expect(logEntries.length).toEqual(63);
     });
 
     it("finds the same log entries when reading the file in arbitrary chunks", () => {

--- a/window_background/arena-log-decoder/__tests__/output_log.txt
+++ b/window_background/arena-log-decoder/__tests__/output_log.txt
@@ -1,0 +1,21755 @@
+
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+<== FrontDoor.ConnectionDetails(0)
+{
+  "sessionId": "56bf6e39-3865-4451-a06a-c48a8a876957",
+  "isQueued": "False"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+==> Log.Info(1):
+{
+  "jsonrpc": "2.0",
+  "method": "Log.Info",
+  "params": {
+    "messageName": "Client.SceneChange",
+    "humanContext": "Client changed scenes to Splash, duration 00:00:00.0199463",
+    "payloadObject": {
+      "fromSceneName": "None",
+      "toSceneName": "Splash",
+      "timestamp": "2019-05-13T17:09:53.5460997Z",
+      "duration": "00:00:00.0199463",
+      "initiator": "System",
+      "context": "Startup",
+      "playerId": "annon"
+    },
+    "transactionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "id": "1"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+==> Log.Info(2):
+{
+  "jsonrpc": "2.0",
+  "method": "Log.Info",
+  "params": {
+    "messageName": "Client.PerformanceReport",
+    "humanContext": "Session Performance Analysis",
+    "payloadObject": {
+      "FrameRateAverage": 57,
+      "FrameRateMinimum": 48,
+      "FrameRateDeviation": 3,
+      "FirstFrameRateFrame": 105,
+      "LastFrameRateFrame": 2421,
+      "FrameRateOddities": [
+        {
+          "Frame": 533,
+          "Value": 49,
+          "Deviation": -8
+        },
+        {
+          "Frame": 1584,
+          "Value": 48,
+          "Deviation": -9
+        }
+      ],
+      "TotalMemoryAverage": 300,
+      "TotalMemoryMaximum": 346,
+      "TotalMemoryDeviation": 53,
+      "FirstTotalMemorySampleFrame": 105,
+      "LastTotalMemorySampleFrame": 2421,
+      "TotalMemoryOddities": [],
+      "Bookmarks": [
+        {
+          "Frame": 0,
+          "Value": "SceneChange.BootDownload"
+        },
+        {
+          "Frame": 251,
+          "Value": "SceneChange.MainNavigation"
+        }
+      ],
+      "CpuBenchmark": {
+        "Median": 2.38250017,
+        "Score": 420.0,
+        "AdjustedScore": 105.0
+      },
+      "GpuBenchmark": {
+        "Median": 14.2534809,
+        "Score": 70.0,
+        "AdjustedScore": 17.5
+      },
+      "playerId": "annon"
+    },
+    "transactionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "id": "2"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+==> Log.Info(3):
+{
+  "jsonrpc": "2.0",
+  "method": "Log.Info",
+  "params": {
+    "messageName": "Client.BootSequenceReport",
+    "humanContext": "Duration of the application launch process including granular durations of notable events within. Durations are in seconds.",
+    "payloadObject": {
+      "buildVersion": "1336.701899",
+      "EndpointHash": "0.03",
+      "SimpleAssetDownloader_HashExistingManifest": "0.00",
+      "SimpleAssetDownloader_LoadManifest": "0.03",
+      "SimpleAssetDownloader_DeleteOldOrModifiedFiles": "0.02",
+      "SimpleAssetDownloader_DetermineAssetsToDownload": "0.01",
+      "SimpleAssetDownloader": "0.09",
+      "MdnAssetLibraryLoad_AssetBundles": "0.21",
+      "MdnAssetLibrary_SetupPayloadTypeDictionary": "0.09",
+      "MdnAssetLibraryLoad": "0.30",
+      "MDNGlobals_FindObjects": "0.06",
+      "MDNGlobals_CreateObjectPool": "0.00",
+      "MDNGlobals_CardDatabase": "2.66",
+      "MDNGlobals": "2.85",
+      "SceneLoad": "1.97",
+      "ObjectPooling": "2.02",
+      "SplashScreen": "3.15",
+      "BootSequenceDuration": "11.93",
+      "playerId": "annon"
+    },
+    "transactionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "id": "3"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+==> Event.GetActiveMatches(4):
+{
+  "jsonrpc": "2.0",
+  "method": "Event.GetActiveMatches",
+  "params": {},
+  "id": "4"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+==> Mercantile.GetStoreStatus(5):
+{
+  "jsonrpc": "2.0",
+  "method": "Mercantile.GetStoreStatus",
+  "params": {},
+  "id": "5"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+==> PlayerInventory.GetCatalogStatus(6):
+{
+  "jsonrpc": "2.0",
+  "method": "PlayerInventory.GetCatalogStatus",
+  "params": {},
+  "id": "6"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+==> PlayerInventory.GetFormats(7):
+{
+  "jsonrpc": "2.0",
+  "method": "PlayerInventory.GetFormats",
+  "params": {},
+  "id": "7"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+==> Deck.GetDeckListsV3(8):
+{
+  "jsonrpc": "2.0",
+  "method": "Deck.GetDeckListsV3",
+  "params": {},
+  "id": "8"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+==> Deck.GetDeckLimit(9):
+{
+  "jsonrpc": "2.0",
+  "method": "Deck.GetDeckLimit",
+  "params": {},
+  "id": "9"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+==> Event.GetCombinedRankInfo(10):
+{
+  "jsonrpc": "2.0",
+  "method": "Event.GetCombinedRankInfo",
+  "params": {},
+  "id": "10"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+==> PlayerInventory.GetRewardSchedule(11):
+{
+  "jsonrpc": "2.0",
+  "method": "PlayerInventory.GetRewardSchedule",
+  "params": {},
+  "id": "11"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+==> PlayerInventory.GetPlayerCardsV3(12):
+{
+  "jsonrpc": "2.0",
+  "method": "PlayerInventory.GetPlayerCardsV3",
+  "params": {},
+  "id": "12"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+==> PlayerInventory.GetPlayerInventory(13):
+{
+  "jsonrpc": "2.0",
+  "method": "PlayerInventory.GetPlayerInventory",
+  "params": {},
+  "id": "13"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+==> PlayerInventory.GetProductCatalog(14):
+{
+  "jsonrpc": "2.0",
+  "method": "PlayerInventory.GetProductCatalog",
+  "params": {
+    "catalogName": "PersistentCardSkinCatalog"
+  },
+  "id": "14"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+==> PlayerInventory.GetProductCatalog(15):
+{
+  "jsonrpc": "2.0",
+  "method": "PlayerInventory.GetProductCatalog",
+  "params": {
+    "catalogName": "PersistentAvatarCatalog"
+  },
+  "id": "15"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+==> PlayerInventory.GetProductCatalog(16):
+{
+  "jsonrpc": "2.0",
+  "method": "PlayerInventory.GetProductCatalog",
+  "params": {
+    "catalogName": "PersistentCardbackCatalog"
+  },
+  "id": "16"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+==> PlayerInventory.GetPlayerArtSkins(17):
+{
+  "jsonrpc": "2.0",
+  "method": "PlayerInventory.GetPlayerArtSkins",
+  "params": {},
+  "id": "17"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+==> Quest.GetPlayerQuests(18):
+{
+  "jsonrpc": "2.0",
+  "method": "Quest.GetPlayerQuests",
+  "params": {},
+  "id": "18"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+==> Deck.GetPreconDecks(19):
+{
+  "jsonrpc": "2.0",
+  "method": "Deck.GetPreconDecks",
+  "params": {},
+  "id": "19"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+==> Event.GetSeasonAndRankDetail(20):
+{
+  "jsonrpc": "2.0",
+  "method": "Event.GetSeasonAndRankDetail",
+  "params": {},
+  "id": "20"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+==> Progression.GetPlayerProgress(21):
+{
+  "jsonrpc": "2.0",
+  "method": "Progression.GetPlayerProgress",
+  "params": {},
+  "id": "21"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+==> Progression.GetAllTracks(22):
+{
+  "jsonrpc": "2.0",
+  "method": "Progression.GetAllTracks",
+  "params": {},
+  "id": "22"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+==> Log.Info(23):
+{
+  "jsonrpc": "2.0",
+  "method": "Log.Info",
+  "params": {
+    "messageName": "Client.UserDeviceSpecs",
+    "humanContext": "User Device Specs",
+    "payloadObject": {
+      "graphicsDeviceName": "AMD Radeon (TM) R9 380 Series",
+      "graphicsDeviceType": "Direct3D11",
+      "graphicsDeviceVendor": "ATI",
+      "graphicsDeviceVersion": "Direct3D 11.0 [level 11.1]",
+      "graphicsMemorySize": 3072,
+      "graphicsMultiThreaded": true,
+      "graphicsShaderLevel": 50,
+      "deviceUniqueIdentifier": "4f77c2b7d6e965ed9c6a932b3587a20d0b3bc632",
+      "deviceModel": "MS-7A57 (MSI)",
+      "deviceType": "Desktop",
+      "operatingSystem": "Windows 10  (10.0.0) 64bit",
+      "operatingSystemFamily": "Windows",
+      "processorCount": 8,
+      "processorFrequency": 4200,
+      "processorType": "Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz",
+      "systemMemorySize": 16340,
+      "isWindowed": false,
+      "gameResolution": {
+        "width": 3840,
+        "height": 2160
+      },
+      "monitorResolution": {
+        "width": 3840,
+        "height": 2160
+      },
+      "monitorSupportedResolutions": [
+        {
+          "width": 720,
+          "height": 400,
+          "validForWindow": false,
+          "validForFullscreen": true
+        },
+        {
+          "width": 720,
+          "height": 400,
+          "validForWindow": false,
+          "validForFullscreen": true
+        },
+        {
+          "width": 1280,
+          "height": 720,
+          "validForWindow": true,
+          "validForFullscreen": true
+        },
+        {
+          "width": 1280,
+          "height": 720,
+          "validForWindow": true,
+          "validForFullscreen": true
+        },
+        {
+          "width": 1280,
+          "height": 720,
+          "validForWindow": true,
+          "validForFullscreen": true
+        },
+        {
+          "width": 1280,
+          "height": 800,
+          "validForWindow": false,
+          "validForFullscreen": true
+        },
+        {
+          "width": 1360,
+          "height": 768,
+          "validForWindow": false,
+          "validForFullscreen": true
+        },
+        {
+          "width": 1366,
+          "height": 768,
+          "validForWindow": true,
+          "validForFullscreen": true
+        },
+        {
+          "width": 1600,
+          "height": 900,
+          "validForWindow": false,
+          "validForFullscreen": true
+        },
+        {
+          "width": 1680,
+          "height": 1050,
+          "validForWindow": false,
+          "validForFullscreen": true
+        },
+        {
+          "width": 1920,
+          "height": 1080,
+          "validForWindow": true,
+          "validForFullscreen": true
+        },
+        {
+          "width": 1920,
+          "height": 1080,
+          "validForWindow": true,
+          "validForFullscreen": true
+        },
+        {
+          "width": 1920,
+          "height": 1080,
+          "validForWindow": true,
+          "validForFullscreen": true
+        },
+        {
+          "width": 1920,
+          "height": 1080,
+          "validForWindow": true,
+          "validForFullscreen": true
+        },
+        {
+          "width": 1920,
+          "height": 1080,
+          "validForWindow": true,
+          "validForFullscreen": true
+        },
+        {
+          "width": 1920,
+          "height": 1200,
+          "validForWindow": false,
+          "validForFullscreen": true
+        },
+        {
+          "width": 2560,
+          "height": 1440,
+          "validForWindow": true,
+          "validForFullscreen": true
+        },
+        {
+          "width": 3200,
+          "height": 1800,
+          "validForWindow": false,
+          "validForFullscreen": true
+        },
+        {
+          "width": 3200,
+          "height": 1800,
+          "validForWindow": false,
+          "validForFullscreen": true
+        },
+        {
+          "width": 3840,
+          "height": 2160,
+          "validForWindow": false,
+          "validForFullscreen": true
+        },
+        {
+          "width": 3840,
+          "height": 2160,
+          "validForWindow": false,
+          "validForFullscreen": true
+        }
+      ],
+      "playerId": "ANNON"
+    },
+    "transactionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "id": "23"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+==> Log.Info(24):
+{
+  "jsonrpc": "2.0",
+  "method": "Log.Info",
+  "params": {
+    "messageName": "Client.Connected",
+    "humanContext": "Client connected to FrontDoor at: ProdA - client.arenagame-a.east.magic-the-gathering-arena.com:9405",
+    "payloadObject": {
+      "playerId": "ANNON",
+      "screenName": "annon#123456",
+      "timestamp": 636933389976288081,
+      "clientVersion": "1336.701899",
+      "settings": {
+        "gameplay": {
+          "disableEmotes": false,
+          "evergreenKeywordReminders": true,
+          "autoTap": true,
+          "autoOrderTriggeredAbilities": true,
+          "autoChooseReplacementEffects": true,
+          "showPhaseLadder": true,
+          "allPlayModesToggle": true
+        },
+        "audio": {
+          "master": 35.6908035,
+          "music": 0.0,
+          "effects": 46.6382,
+          "voice": 46.6120224,
+          "ambience": 89.656,
+          "playInBackground": false
+        },
+        "language": {
+          "language": "English"
+        }
+      }
+    },
+    "transactionId": "bb27c2f2-d0e1-4082-8d7a-17d553b1a077"
+  },
+  "id": "24"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+<== Log.Info(1)
+True
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+<== Log.Info(2)
+True
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+<== Log.Info(3)
+True
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+<== Event.GetActiveMatches(4)
+[]
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+<== Mercantile.GetStoreStatus(5)
+{
+  "StoreEnabled": true,
+  "GemsEnabled": true,
+  "PacksEnabled": true,
+  "BundlesEnabled": true,
+  "GuildBundlesEnabled": true
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+<== PlayerInventory.GetCatalogStatus(6)
+{
+  "CatalogsEnabled": true,
+  "CardSkinsEnabled": true,
+  "AvatarsEnabled": true,
+  "CardBacksEnabled": true,
+  "CatalogHash": "cs:619405f8-3a3f-78f8-3361-0f211d5df01b,cb:6f6908ea-c17c-2799-a447-4565dde94955,av:24735ee1-e3ae-6f5c-62de-f8c624a4478a"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+<== PlayerInventory.GetFormats(7)
+[
+  {
+    "name": "Cascade",
+    "sets": [
+      "ANA",
+      "DAR",
+      "M19",
+      "RIX",
+      "W17",
+      "XLN",
+      "GRN",
+      "G18",
+      "RNA",
+      "WAR"
+    ],
+    "bannedCards": [
+      "Lavinia, Azorius Renegade",
+      "Teferi, Time Raveler",
+      "Nexus of Fate"
+    ],
+    "cardCountRestriction": "None"
+  },
+  {
+    "name": "DirectGame",
+    "sets": [
+      "ANA",
+      "DAR",
+      "M19",
+      "RIX",
+      "W17",
+      "XLN",
+      "GRN",
+      "G18",
+      "RNA",
+      "WAR"
+    ],
+    "bannedCards": [],
+    "cardCountRestriction": "None"
+  },
+  {
+    "name": "GRN",
+    "sets": [
+      "GRN"
+    ],
+    "bannedCards": [],
+    "cardCountRestriction": "None"
+  },
+  {
+    "name": "Ixalan",
+    "sets": [
+      "XLN",
+      "RIX"
+    ],
+    "bannedCards": [],
+    "cardCountRestriction": "None"
+  },
+  {
+    "name": "NoInstants",
+    "sets": [
+      "ANA",
+      "DAR",
+      "M19",
+      "RIX",
+      "W17",
+      "XLN",
+      "GRN",
+      "G18",
+      "RNA"
+    ],
+    "bannedCards": [
+      "Abnormal Endurance",
+      "Adamant Will",
+      "Admiral's Order",
+      "Aegis of the Heavens",
+      "Aggressive Urge",
+      "Altar's Reap",
+      "Ancient Animus",
+      "Anticipate",
+      "Arbor Armament",
+      "Artful Takedown",
+      "Assassin's Trophy",
+      "Assure // Assemble",
+      "Befuddle",
+      "Blazing Hope",
+      "Blessed Light",
+      "Blessing of Belzenlok",
+      "Blinding Fog",
+      "Blink of an Eye",
+      "Bloodcrazed Paladin",
+      "Bombard",
+      "Bone to Ash",
+      "Bounty of Might",
+      "Bright Reprisal",
+      "Buccaneer's Bravado",
+      "Cancel",
+      "Capture Sphere",
+      "Cast Down",
+      "Chance for Glory",
+      "Charge",
+      "Chemister's Insight",
+      "Cherished Hatchling",
+      "Chromium, the Mutable",
+      "Collar the Culprit",
+      "Command the Storm",
+      "Confront the Assault",
+      "Costly Plunder",
+      "Crafty Cutpurse",
+      "Crash the Ramparts",
+      "Crashing Tide",
+      "Cruel Cut",
+      "Crush Contraband",
+      "Crushing Canopy",
+      "Dark Bargain",
+      "Dark Nourishment",
+      "Dazzling Lights",
+      "Demystify",
+      "Depths of Desire",
+      "Devious Cover-Up",
+      "Dinosaur Stampede",
+      "Dire Fleet Poisoner",
+      "Discovery // Dispersal",
+      "Disdainful Stroke",
+      "Disperse",
+      "Dive Down",
+      "Divine Verdict",
+      "Dream Eater",
+      "Dreamcaller Siren",
+      "Dual Shot",
+      "Electrify",
+      "Essence Scatter",
+      "Expansion // Explosion",
+      "Expel from Orazca",
+      "Fervent Strike",
+      "Fiery Cannonade",
+      "Fungal Infection",
+      "Garna, the Bloodflame",
+      "Gideon's Reproach",
+      "Gift of Growth",
+      "Healing Grace",
+      "Hired Blade",
+      "Hornswoggle",
+      "Huatli's Spurring",
+      "Hypothesizzle",
+      "Inescapable Blaze",
+      "Infernal Reckoning",
+      "Inspiration",
+      "Inspired Charge",
+      "Integrity // Intervention",
+      "Invert // Invent",
+      "Invoke the Divine",
+      "Ionize",
+      "Isolate",
+      "Join Shields",
+      "Justice Strike",
+      "Lightning Strike",
+      "Lookout's Dispersal",
+      "Make a Stand",
+      "March of the Multitudes",
+      "Mausoleum Secrets",
+      "Merfolk Trickster",
+      "Might of the Masses",
+      "Mighty Leap",
+      "Mission Briefing",
+      "Moment of Craving",
+      "Moment of Triumph",
+      "Murder",
+      "Naru Meha, Master Wizard",
+      "Naturalize",
+      "Necrotic Wound",
+      "Negate",
+      "Nexus of Fate",
+      "Nightmare's Thirst",
+      "Nimble Pilferer",
+      "Opt",
+      "Pack's Favor",
+      "Pause for Reflection",
+      "Perilous Voyage",
+      "Pierce the Sky",
+      "Plummet",
+      "Pounce",
+      "Price of Fame",
+      "Pride of Conquerors",
+      "Radiating Lightning",
+      "Radical Idea",
+      "Raff Capashen, Ship's Mage",
+      "Ral's Dispersal",
+      "Rallying Roar",
+      "Rampaging Ferocidon",
+      "Reaver Ambush",
+      "Reckless Rage",
+      "Release to the Wind",
+      "Rescue",
+      "Response // Resurgence",
+      "Revitalize",
+      "Righteous Blow",
+      "Risk Factor",
+      "Ritual of Rejuvenation",
+      "River Heralds' Boon",
+      "Root Snare",
+      "Run Aground",
+      "Run Amok",
+      "Sanguine Sacrament",
+      "Sea Legs",
+      "Seal Away",
+      "Sentinel of the Pearl Trident",
+      "Settle the Wreckage",
+      "Shake the Foundations",
+      "Shatter",
+      "Sheltering Light",
+      "Shivan Fire",
+      "Shock",
+      "Sinister Sabotage",
+      "Siren's Ruse",
+      "Skulduggery",
+      "Slash of Talons",
+      "Slice in Twain",
+      "Smelt",
+      "Snapping Sailback",
+      "Sonic Assault",
+      "Spell Pierce",
+      "Spell Swindle",
+      "Spit Flame",
+      "Spore Swarm",
+      "Status // Statue",
+      "Strangling Spores",
+      "Sure Strike",
+      "Swift Warden",
+      "Syncopate",
+      "Tactical Advantage",
+      "Take Heart",
+      "Titanic Growth",
+      "Totally Lost",
+      "Trumpet Blast",
+      "Uncomfortable Chill",
+      "Unexplained Disappearance",
+      "Unfriendly Fire",
+      "Unwind",
+      "Vampire's Zeal",
+      "Vanquish the Weak",
+      "Verdant Rebirth",
+      "Vicious Offering",
+      "Vona's Hunger",
+      "Vraska's Contempt",
+      "Whisper Agent",
+      "Wild Onslaught",
+      "Wind Strider",
+      "Wizard's Lightning",
+      "Wizard's Retort"
+    ],
+    "cardCountRestriction": "None"
+  },
+  {
+    "name": "Pandemonium",
+    "sets": [
+      "ANA",
+      "DAR",
+      "G18",
+      "GRN",
+      "M19",
+      "RIX",
+      "RNA",
+      "W17",
+      "WAR",
+      "XLN"
+    ],
+    "bannedCards": [
+      "Polyraptor",
+      "Rampaging Ferocidon",
+      "Shapers' Sanctuary",
+      "Thorn Lieutenant",
+      "Tocatli Honor Guard"
+    ],
+    "cardCountRestriction": "None"
+  },
+  {
+    "name": "Pauper",
+    "sets": [
+      "ANA",
+      "DAR",
+      "G18",
+      "GRN",
+      "M19",
+      "RIX",
+      "RNA",
+      "W17",
+      "WAR",
+      "XLN"
+    ],
+    "bannedCards": [
+      "Cloud of Faeries",
+      "Cloudpost",
+      "Cranial Plating",
+      "Empty the Warrens",
+      "Frantic Search",
+      "Grapeshot",
+      "Invigorate",
+      "Peregrine Drake",
+      "Temporal Fissure",
+      "Treasure Cruise"
+    ],
+    "cardCountRestriction": "None"
+  },
+  {
+    "name": "Ravnica",
+    "sets": [
+      "GRN",
+      "RNA",
+      "WAR"
+    ],
+    "bannedCards": [
+      "Gates Ablaze"
+    ],
+    "cardCountRestriction": "None"
+  },
+  {
+    "name": "Singleton",
+    "sets": [
+      "ANA",
+      "DAR",
+      "G18",
+      "GRN",
+      "M19",
+      "RIX",
+      "RNA",
+      "W17",
+      "WAR",
+      "XLN"
+    ],
+    "bannedCards": [],
+    "cardCountRestriction": "Singleton"
+  },
+  {
+    "name": "Standard",
+    "sets": [
+      "ANA",
+      "DAR",
+      "M19",
+      "RIX",
+      "W17",
+      "XLN",
+      "GRN",
+      "G18",
+      "RNA",
+      "WAR"
+    ],
+    "bannedCards": [
+      "Nexus of Fate",
+      "Rampaging Ferocidon"
+    ],
+    "cardCountRestriction": "None"
+  },
+  {
+    "name": "TraditionalStandard",
+    "sets": [
+      "DAR",
+      "G18",
+      "GRN",
+      "M19",
+      "RIX",
+      "RNA",
+      "W17",
+      "XLN",
+      "WAR"
+    ],
+    "bannedCards": [
+      "Rampaging Ferocidon"
+    ],
+    "cardCountRestriction": "None"
+  },
+  {
+    "name": "XLN",
+    "sets": [
+      "XLN"
+    ],
+    "bannedCards": [],
+    "cardCountRestriction": "None"
+  }
+]
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+<== Deck.GetDeckListsV3(8)
+[
+  {
+    "cardSkins": [],
+    "id": "58a4b597-62d4-4ee0-a9f3-40afa0169716",
+    "name": "Saprolings",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 67514,
+    "mainDeck": [
+      67514,
+      3,
+      68220,
+      8,
+      67600,
+      3,
+      67460,
+      4,
+      68236,
+      8,
+      68122,
+      4,
+      67292,
+      4,
+      66911,
+      1,
+      67424,
+      1,
+      67464,
+      3,
+      66223,
+      2,
+      68538,
+      2,
+      69781,
+      2,
+      67482,
+      3,
+      69211,
+      2,
+      68674,
+      1,
+      67266,
+      3,
+      68734,
+      3,
+      67466,
+      3
+    ],
+    "sideboard": [],
+    "cardBack": null,
+    "lastUpdated": "2019-05-06T02:23:01.6640435"
+  },
+  {
+    "cardSkins": [],
+    "id": "da09aa4f-c1e1-4eef-b523-38280b2f84d2",
+    "name": "Vampires",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 66947,
+    "mainDeck": [
+      68204,
+      5,
+      67586,
+      3,
+      66947,
+      4,
+      68220,
+      4,
+      68491,
+      4,
+      66793,
+      1,
+      66777,
+      1,
+      66495,
+      4,
+      66003,
+      3,
+      69320,
+      3,
+      66659,
+      4,
+      66757,
+      4,
+      69396,
+      4,
+      65961,
+      4,
+      65977,
+      4,
+      66221,
+      4,
+      69157,
+      1,
+      66009,
+      1,
+      66653,
+      1,
+      66645,
+      1
+    ],
+    "sideboard": [],
+    "cardBack": null,
+    "lastUpdated": "2019-05-05T01:12:29.148597"
+  },
+  {
+    "cardSkins": [],
+    "id": "6e6502d9-5b6d-44c6-8acc-228f67b6c289",
+    "name": "Enchantments",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 68128,
+    "mainDeck": [
+      67146,
+      4,
+      67740,
+      4,
+      67023,
+      6,
+      66493,
+      4,
+      67015,
+      10,
+      68128,
+      4,
+      68068,
+      2,
+      67160,
+      2,
+      69108,
+      1,
+      66891,
+      2,
+      66619,
+      3,
+      65993,
+      2,
+      67134,
+      1,
+      68739,
+      3,
+      69148,
+      4,
+      65961,
+      3,
+      68084,
+      1,
+      67132,
+      4
+    ],
+    "sideboard": [],
+    "cardBack": null,
+    "lastUpdated": "2019-04-30T00:56:56.4886919"
+  },
+  {
+    "cardSkins": [],
+    "id": "52ca8fb7-68d2-449a-96da-f7f1d6bbaee1",
+    "name": "Big Red Goblins",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 67390,
+    "mainDeck": [
+      67021,
+      1,
+      68570,
+      4,
+      68569,
+      2,
+      68576,
+      4,
+      66839,
+      3,
+      67362,
+      3,
+      67390,
+      3,
+      67940,
+      2,
+      67968,
+      1,
+      66477,
+      2,
+      67106,
+      3,
+      68234,
+      2,
+      68232,
+      1,
+      68230,
+      2,
+      68228,
+      2,
+      69411,
+      1,
+      68744,
+      1,
+      67634,
+      2,
+      67632,
+      1,
+      67630,
+      2,
+      67628,
+      2,
+      66529,
+      1,
+      66527,
+      2,
+      66525,
+      1,
+      66523,
+      2,
+      67992,
+      4,
+      68564,
+      1,
+      69242,
+      1,
+      67001,
+      1,
+      66311,
+      1,
+      67964,
+      2
+    ],
+    "sideboard": [],
+    "cardBack": "CardBack_EmbossedManaRed",
+    "lastUpdated": "2019-05-10T06:41:07.5591524"
+  },
+  {
+    "cardSkins": [],
+    "id": "3ec1745a-f9fe-4743-924a-0c5316573572",
+    "name": "WW Life",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 69140,
+    "mainDeck": [
+      68475,
+      4,
+      67690,
+      4,
+      68467,
+      1,
+      66003,
+      3,
+      67604,
+      7,
+      67116,
+      4,
+      67146,
+      4,
+      69157,
+      1,
+      69140,
+      4,
+      67724,
+      4,
+      68152,
+      2,
+      68208,
+      7,
+      68210,
+      6,
+      66663,
+      1,
+      67748,
+      1,
+      68469,
+      2,
+      69155,
+      2,
+      65993,
+      2,
+      67156,
+      1
+    ],
+    "sideboard": [],
+    "cardBack": "CardBack_EmbossedManaWhite",
+    "lastUpdated": "2019-05-06T05:13:00.6727051"
+  },
+  {
+    "cardSkins": [],
+    "id": "c2ee9531-521c-49ac-8d7f-94574ce22281",
+    "name": "Mono U",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 67240,
+    "mainDeck": [
+      66687,
+      4,
+      66121,
+      4,
+      67240,
+      4,
+      66057,
+      3,
+      67254,
+      4,
+      67224,
+      4,
+      66703,
+      2,
+      66067,
+      4,
+      66125,
+      2,
+      67618,
+      5,
+      68214,
+      5,
+      67614,
+      5,
+      68216,
+      4,
+      69175,
+      4,
+      67216,
+      4,
+      66705,
+      1,
+      67834,
+      1
+    ],
+    "sideboard": [
+      67828,
+      2,
+      66703,
+      1,
+      66071,
+      1,
+      67204,
+      2,
+      68498,
+      2,
+      68144,
+      2,
+      67790,
+      2,
+      68515,
+      1,
+      69165,
+      2
+    ],
+    "cardBack": "CardBack_EmbossedManaBlue",
+    "lastUpdated": "2019-05-06T05:13:39.7934737"
+  },
+  {
+    "cardSkins": [],
+    "id": "4af3d995-f706-4536-8a45-d46b641268ee",
+    "name": "Sultai Midrange",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 69311,
+    "mainDeck": [
+      67019,
+      2,
+      66781,
+      1,
+      67023,
+      2,
+      66889,
+      4,
+      66223,
+      2,
+      67600,
+      3,
+      68096,
+      2,
+      68694,
+      3,
+      66207,
+      1,
+      67588,
+      1,
+      68734,
+      3,
+      66401,
+      4,
+      69311,
+      4,
+      69548,
+      1,
+      66363,
+      4,
+      69394,
+      4,
+      66485,
+      3,
+      68740,
+      3,
+      67017,
+      1,
+      68597,
+      1,
+      66913,
+      2,
+      66705,
+      2,
+      67584,
+      2,
+      66325,
+      1,
+      69781,
+      2,
+      69543,
+      1,
+      66415,
+      1
+    ],
+    "sideboard": [],
+    "cardBack": null,
+    "lastUpdated": "2019-05-07T06:46:33.5856579"
+  },
+  {
+    "cardSkins": [],
+    "id": "0d0bf102-1bbb-4720-8423-f2de98379397",
+    "name": "Merfolk",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 66945,
+    "mainDeck": [
+      66945,
+      3,
+      68236,
+      6,
+      67584,
+      2,
+      66361,
+      4,
+      68212,
+      6,
+      66949,
+      4,
+      66871,
+      1,
+      66063,
+      4,
+      66363,
+      2,
+      66723,
+      4,
+      66125,
+      1,
+      66495,
+      4,
+      69160,
+      4,
+      67216,
+      2,
+      69364,
+      4,
+      66885,
+      4,
+      69394,
+      4,
+      66135,
+      1
+    ],
+    "sideboard": [],
+    "cardBack": null,
+    "lastUpdated": "2019-05-03T08:11:18.1087024"
+  },
+  {
+    "cardSkins": [],
+    "id": "103f2a01-914d-4c8c-a24b-cac78c64624e",
+    "name": "Drakes",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 68624,
+    "mainDeck": [
+      67017,
+      7,
+      66057,
+      3,
+      67224,
+      4,
+      68112,
+      4,
+      67021,
+      6,
+      67598,
+      2,
+      68732,
+      3,
+      68569,
+      3,
+      68653,
+      2,
+      68624,
+      4,
+      66125,
+      3,
+      69175,
+      4,
+      67992,
+      4,
+      66705,
+      1,
+      66067,
+      3,
+      68688,
+      4,
+      68738,
+      3
+    ],
+    "sideboard": [],
+    "cardBack": null,
+    "lastUpdated": "2019-05-05T01:13:49.2569637"
+  },
+  {
+    "cardSkins": [],
+    "id": "fda4b66f-1dc4-4517-9e8f-b3fcfd0981fd",
+    "name": "Simic++",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 69654,
+    "mainDeck": [
+      67023,
+      12,
+      69364,
+      3,
+      69311,
+      4,
+      66079,
+      2,
+      67584,
+      2,
+      69654,
+      4,
+      69781,
+      2,
+      66495,
+      4,
+      66889,
+      4,
+      69615,
+      2,
+      68602,
+      4,
+      69394,
+      4,
+      66425,
+      2,
+      69603,
+      1,
+      69620,
+      1,
+      69624,
+      3,
+      69610,
+      2,
+      69259,
+      4
+    ],
+    "sideboard": [],
+    "cardBack": null,
+    "lastUpdated": "2019-05-07T06:28:33.6427262"
+  },
+  {
+    "cardSkins": [],
+    "id": "90b8b03f-8d53-417d-b207-058fc9d3953e",
+    "name": "Token Effort",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 68649,
+    "mainDeck": [
+      67015,
+      9,
+      67023,
+      5,
+      68467,
+      3,
+      66493,
+      4,
+      68739,
+      3,
+      68491,
+      3,
+      67146,
+      4,
+      68629,
+      3,
+      66003,
+      3,
+      68669,
+      2,
+      68649,
+      3,
+      68697,
+      3,
+      69157,
+      2,
+      69155,
+      2,
+      68644,
+      1,
+      67460,
+      4,
+      67512,
+      2,
+      66913,
+      1,
+      69464,
+      1,
+      69635,
+      2
+    ],
+    "sideboard": [],
+    "cardBack": null,
+    "lastUpdated": "2019-05-08T05:12:23.8745294"
+  },
+  {
+    "cardSkins": [],
+    "id": "41395e9a-ef66-4531-b653-583322aaf34d",
+    "name": "RDW",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 68576,
+    "mainDeck": [
+      66263,
+      4,
+      69235,
+      4,
+      68560,
+      3,
+      67992,
+      4,
+      68012,
+      4,
+      67358,
+      4,
+      66819,
+      4,
+      69243,
+      4,
+      67362,
+      3,
+      68576,
+      4,
+      66527,
+      5,
+      67628,
+      5,
+      68230,
+      4,
+      68228,
+      4,
+      67408,
+      4
+    ],
+    "sideboard": [],
+    "cardBack": "CardBack_EmbossedManaRed",
+    "lastUpdated": "2019-05-10T06:39:17.9068862"
+  },
+  {
+    "cardSkins": [],
+    "id": "34bb2150-d596-4dc9-8b0c-7b8413de6837",
+    "name": "Historic",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 67572,
+    "mainDeck": [
+      67017,
+      10,
+      66987,
+      2,
+      68172,
+      2,
+      67818,
+      3,
+      67826,
+      1,
+      67256,
+      3,
+      66125,
+      2,
+      69399,
+      3,
+      66489,
+      4,
+      67015,
+      5,
+      66705,
+      1,
+      68152,
+      2,
+      67192,
+      3,
+      67568,
+      4,
+      67576,
+      4,
+      67106,
+      3,
+      66477,
+      2,
+      67572,
+      3,
+      67176,
+      1,
+      67508,
+      2
+    ],
+    "sideboard": [],
+    "cardBack": null,
+    "lastUpdated": "2019-04-28T05:41:45.5315137"
+  },
+  {
+    "cardSkins": [],
+    "id": "19902446-8f49-4532-b99e-f53be00bda18",
+    "name": "Gates Midrange",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 68502,
+    "mainDeck": [
+      68502,
+      4,
+      69230,
+      4,
+      69380,
+      3,
+      69391,
+      3,
+      69398,
+      4,
+      68732,
+      4,
+      69254,
+      4,
+      68736,
+      2,
+      69406,
+      4,
+      69402,
+      3,
+      67992,
+      2,
+      69306,
+      4,
+      69131,
+      2,
+      69311,
+      3,
+      67940,
+      1,
+      68586,
+      3,
+      67023,
+      1,
+      68691,
+      3,
+      69394,
+      2,
+      68724,
+      1,
+      67017,
+      1,
+      68626,
+      1,
+      69279,
+      1
+    ],
+    "sideboard": [
+      67156,
+      1,
+      68653,
+      1,
+      66333,
+      1,
+      69170,
+      1,
+      67940,
+      1,
+      69289,
+      1,
+      66707,
+      1,
+      69329,
+      1,
+      69380,
+      1,
+      68644,
+      1,
+      69162,
+      1,
+      67698,
+      1,
+      68669,
+      1,
+      66027,
+      1,
+      69311,
+      1
+    ],
+    "cardBack": null,
+    "lastUpdated": "2019-05-05T01:07:31.1014969"
+  },
+  {
+    "cardSkins": [],
+    "id": "b3b51f7c-dfef-455a-b610-e571d9017dc9",
+    "name": "Ragesaurs",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 66423,
+    "mainDeck": [
+      66375,
+      2,
+      66379,
+      4,
+      66915,
+      4,
+      66495,
+      4,
+      66329,
+      4,
+      66371,
+      4,
+      66385,
+      2,
+      66961,
+      1,
+      66491,
+      3,
+      69407,
+      3,
+      66821,
+      2,
+      66913,
+      3,
+      66325,
+      2,
+      66341,
+      4,
+      66421,
+      1,
+      66423,
+      2,
+      68238,
+      5,
+      67642,
+      4,
+      68232,
+      1,
+      66865,
+      1,
+      68096,
+      2,
+      66373,
+      2
+    ],
+    "sideboard": [],
+    "cardBack": null,
+    "lastUpdated": "2019-05-05T01:15:08.1321862"
+  },
+  {
+    "cardSkins": [],
+    "id": "aa3db9e9-edd4-4963-975a-a786a3c75c94",
+    "name": "Dino Stompy",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 66865,
+    "mainDeck": [
+      66375,
+      2,
+      66325,
+      2,
+      66915,
+      4,
+      66913,
+      3,
+      66329,
+      4,
+      66371,
+      4,
+      69781,
+      4,
+      66379,
+      4,
+      67472,
+      1,
+      68238,
+      4,
+      66341,
+      4,
+      67636,
+      5,
+      67642,
+      5,
+      68240,
+      4,
+      70140,
+      2,
+      68050,
+      1,
+      68602,
+      3,
+      66877,
+      2,
+      68052,
+      2
+    ],
+    "sideboard": [],
+    "cardBack": "CardBack_EmbossedManaGreen",
+    "lastUpdated": "2019-05-06T05:12:46.2714192"
+  },
+  {
+    "cardSkins": [],
+    "id": "feddf860-3318-4056-849e-d276ef61be8d",
+    "name": "Petitioners",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 69172,
+    "mainDeck": [
+      67828,
+      2,
+      67017,
+      21,
+      69172,
+      22,
+      67204,
+      2,
+      69185,
+      4,
+      67816,
+      2,
+      66125,
+      2,
+      66705,
+      1,
+      68500,
+      1,
+      68493,
+      1,
+      69165,
+      2
+    ],
+    "sideboard": [
+      67252,
+      1,
+      67238,
+      1,
+      67788,
+      1,
+      67204,
+      1,
+      69187,
+      4,
+      69172,
+      6
+    ],
+    "cardBack": "CardBack_EmbossedManaBlue",
+    "lastUpdated": "2019-05-06T05:12:27.1854691"
+  },
+  {
+    "cardSkins": [],
+    "id": "4096b218-0b3f-40b6-9830-e9a5d3c5f4f6",
+    "name": "Goblin March",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 69236,
+    "mainDeck": [
+      66477,
+      1,
+      69236,
+      4,
+      67964,
+      4,
+      68012,
+      4,
+      67390,
+      3,
+      67021,
+      22,
+      68016,
+      1,
+      67362,
+      1,
+      67968,
+      1,
+      67392,
+      4,
+      66315,
+      3,
+      67944,
+      4,
+      66839,
+      3,
+      68570,
+      4,
+      67940,
+      1
+    ],
+    "sideboard": [
+      69225,
+      4,
+      66835,
+      2,
+      67950,
+      1,
+      67940,
+      1,
+      68016,
+      1,
+      66477,
+      1
+    ],
+    "cardBack": "CardBack_EmbossedManaRed",
+    "lastUpdated": "2019-05-06T05:11:21.8797285"
+  },
+  {
+    "cardSkins": [],
+    "id": "15be660e-2687-4cf2-8e57-3e7bdd4754a2",
+    "name": "Gruul Warrior",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 69307,
+    "mainDeck": [
+      67021,
+      6,
+      67494,
+      2,
+      69242,
+      2,
+      66495,
+      4,
+      67023,
+      6,
+      66491,
+      3,
+      69407,
+      3,
+      69307,
+      2,
+      68086,
+      3,
+      68198,
+      2,
+      68570,
+      3,
+      68602,
+      4,
+      66839,
+      3,
+      68597,
+      3,
+      69355,
+      3,
+      67992,
+      4,
+      68564,
+      1,
+      67362,
+      3,
+      67984,
+      3
+    ],
+    "sideboard": [
+      69373,
+      1,
+      67940,
+      1,
+      68572,
+      1,
+      66837,
+      1,
+      68006,
+      1,
+      67426,
+      1,
+      69289,
+      1,
+      67342,
+      1,
+      68574,
+      1,
+      68560,
+      1,
+      66311,
+      1,
+      69294,
+      1,
+      68566,
+      1,
+      66325,
+      1,
+      68096,
+      1
+    ],
+    "cardBack": null,
+    "lastUpdated": "2019-05-10T06:41:54.6138367"
+  },
+  {
+    "cardSkins": [],
+    "id": "2be98ed1-f5ea-49b5-8fce-a8c14ba4f028",
+    "name": "Fugitive Rats",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 67306,
+    "mainDeck": [
+      67242,
+      4,
+      67019,
+      8,
+      67306,
+      19,
+      67017,
+      4,
+      66485,
+      2,
+      68740,
+      2,
+      67003,
+      1,
+      66067,
+      4,
+      66125,
+      2,
+      68196,
+      2,
+      67266,
+      2,
+      68528,
+      2,
+      66057,
+      2,
+      67224,
+      4,
+      68688,
+      2
+    ],
+    "sideboard": [
+      68525,
+      4,
+      66223,
+      1,
+      67208,
+      1,
+      67782,
+      1,
+      69179,
+      2,
+      66705,
+      1,
+      66057,
+      1,
+      67306,
+      2
+    ],
+    "cardBack": null,
+    "lastUpdated": "2019-04-11T16:11:44.3982119"
+  },
+  {
+    "cardSkins": [],
+    "id": "13da2a6d-8ac2-44d1-8189-b8fbbe210ad3",
+    "name": "Stompy",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 67468,
+    "mainDeck": [
+      67023,
+      5,
+      66913,
+      3,
+      66401,
+      4,
+      68597,
+      3,
+      68086,
+      1,
+      68238,
+      5,
+      67468,
+      3,
+      67636,
+      4,
+      67642,
+      4,
+      68240,
+      4,
+      70140,
+      2,
+      66889,
+      4,
+      66363,
+      4,
+      68599,
+      1,
+      68094,
+      2,
+      68096,
+      2,
+      67410,
+      2,
+      68602,
+      3,
+      68604,
+      2,
+      66325,
+      1,
+      69603,
+      1
+    ],
+    "sideboard": [],
+    "cardBack": "CardBack_EmbossedManaGreen",
+    "lastUpdated": "2019-05-06T05:11:10.095573"
+  },
+  {
+    "cardSkins": [],
+    "id": "fd7378e8-fe22-4086-ba5a-9fff2c3b82a0",
+    "name": "WW",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 67146,
+    "mainDeck": [
+      68467,
+      2,
+      66003,
+      3,
+      67604,
+      6,
+      67116,
+      4,
+      67146,
+      4,
+      68491,
+      3,
+      69157,
+      2,
+      69155,
+      2,
+      67132,
+      4,
+      68208,
+      6,
+      68210,
+      6,
+      66663,
+      4,
+      66659,
+      4,
+      65961,
+      2,
+      68476,
+      4,
+      69464,
+      1,
+      69471,
+      3
+    ],
+    "sideboard": [],
+    "cardBack": "CardBack_EmbossedManaWhite",
+    "lastUpdated": "2019-05-08T05:15:37.5112147"
+  },
+  {
+    "cardSkins": [],
+    "id": "9b7c25a9-ea65-4642-8fb7-cf360cae19b3",
+    "name": "Boros Weenies",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 68114,
+    "mainDeck": [
+      66003,
+      3,
+      67015,
+      11,
+      65961,
+      3,
+      66659,
+      4,
+      67146,
+      4,
+      69155,
+      2,
+      67752,
+      3,
+      68467,
+      2,
+      67021,
+      1,
+      68491,
+      3,
+      68735,
+      3,
+      67582,
+      3,
+      68114,
+      3,
+      69157,
+      1,
+      67132,
+      4,
+      66663,
+      4,
+      68194,
+      1,
+      67116,
+      4,
+      69464,
+      1
+    ],
+    "sideboard": [],
+    "cardBack": null,
+    "lastUpdated": "2019-04-29T04:06:39.5396258"
+  },
+  {
+    "cardSkins": [],
+    "id": "2b47f368-fa71-4b70-bcec-94d071f8f697",
+    "name": "Dimir Thief",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 68666,
+    "mainDeck": [
+      67266,
+      2,
+      68688,
+      4,
+      66775,
+      2,
+      66485,
+      3,
+      67019,
+      6,
+      69175,
+      4,
+      67284,
+      1,
+      66125,
+      1,
+      67017,
+      6,
+      68666,
+      3,
+      68667,
+      4,
+      68740,
+      3,
+      67224,
+      3,
+      69512,
+      1,
+      66415,
+      2,
+      68726,
+      2,
+      68628,
+      1,
+      69685,
+      2,
+      69453,
+      1,
+      69646,
+      1,
+      66223,
+      2,
+      70141,
+      2,
+      67292,
+      1,
+      68645,
+      1,
+      66487,
+      1,
+      66705,
+      1
+    ],
+    "sideboard": [
+      67292,
+      1,
+      68545,
+      1,
+      70141,
+      1,
+      66071,
+      1,
+      66705,
+      1,
+      68496,
+      1,
+      69543,
+      1,
+      69542,
+      1,
+      67810,
+      1,
+      66093,
+      1,
+      67284,
+      1,
+      69453,
+      1,
+      68164,
+      1,
+      67196,
+      1,
+      69162,
+      1
+    ],
+    "cardBack": null,
+    "lastUpdated": "2019-05-03T08:08:19.9909617"
+  },
+  {
+    "cardSkins": [],
+    "id": "45d9160d-b2d2-4244-b8ed-4cda83988e08",
+    "name": "Black Weenies",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 69541,
+    "mainDeck": [
+      67864,
+      4,
+      68220,
+      19,
+      68528,
+      2,
+      67878,
+      1,
+      68538,
+      4,
+      69204,
+      3,
+      69201,
+      3,
+      67266,
+      3,
+      70141,
+      1,
+      67862,
+      2,
+      66221,
+      3,
+      69210,
+      2,
+      69541,
+      4,
+      69547,
+      4,
+      69538,
+      1,
+      67860,
+      3,
+      69543,
+      1
+    ],
+    "sideboard": [],
+    "cardBack": "CardBack_EmbossedManaBlack",
+    "lastUpdated": "2019-05-06T05:10:48.6256004"
+  },
+  {
+    "cardSkins": [],
+    "id": "3d662538-b8cf-47f4-a27f-532a2f477cf6",
+    "name": "Jump-start",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 68635,
+    "mainDeck": [
+      67196,
+      1,
+      67224,
+      4,
+      68558,
+      4,
+      67017,
+      7,
+      67598,
+      2,
+      68732,
+      2,
+      68569,
+      2,
+      68513,
+      2,
+      69235,
+      4,
+      66057,
+      3,
+      68738,
+      3,
+      68493,
+      4,
+      68635,
+      4,
+      68574,
+      3,
+      67940,
+      2,
+      67021,
+      6,
+      68615,
+      2,
+      68560,
+      2,
+      68552,
+      3
+    ],
+    "sideboard": [],
+    "cardBack": null,
+    "lastUpdated": "2019-05-05T01:14:00.2916832"
+  },
+  {
+    "cardSkins": [],
+    "id": "1851a403-ee42-4a6d-a30f-0d873a7600c2",
+    "name": "Spectacle",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 69341,
+    "mainDeck": [
+      66819,
+      3,
+      67021,
+      11,
+      67358,
+      4,
+      68012,
+      4,
+      66263,
+      4,
+      67992,
+      4,
+      69235,
+      4,
+      67408,
+      3,
+      69243,
+      4,
+      67920,
+      4,
+      67019,
+      2,
+      69341,
+      3,
+      66483,
+      3,
+      69393,
+      4,
+      68574,
+      1,
+      68558,
+      2
+    ],
+    "sideboard": [
+      68569,
+      3,
+      69201,
+      3,
+      67940,
+      2,
+      67970,
+      2,
+      67362,
+      1,
+      69245,
+      1,
+      66819,
+      1
+    ],
+    "cardBack": null,
+    "lastUpdated": "2019-04-28T05:50:22.6353031"
+  },
+  {
+    "cardSkins": [],
+    "id": "33213a0c-deb9-4dea-b43c-33ca21c3cd41",
+    "name": "Human Sacrifice",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 69211,
+    "mainDeck": [
+      67940,
+      1,
+      67019,
+      6,
+      68570,
+      4,
+      69211,
+      2,
+      69219,
+      1,
+      69285,
+      2,
+      67021,
+      6,
+      67992,
+      3,
+      66239,
+      1,
+      69300,
+      3,
+      69344,
+      4,
+      69341,
+      3,
+      69352,
+      2,
+      66483,
+      3,
+      69393,
+      4,
+      66495,
+      4,
+      69237,
+      1,
+      69207,
+      2,
+      66987,
+      1,
+      69204,
+      3,
+      69313,
+      2,
+      69543,
+      1,
+      69548,
+      1
+    ],
+    "sideboard": [
+      67940,
+      1,
+      68581,
+      1,
+      66765,
+      1,
+      69325,
+      1,
+      67992,
+      1,
+      68569,
+      3,
+      68543,
+      1,
+      67866,
+      1,
+      67326,
+      1,
+      69352,
+      1,
+      69292,
+      2,
+      69309,
+      1
+    ],
+    "cardBack": null,
+    "lastUpdated": "2019-05-07T06:44:28.955684"
+  },
+  {
+    "cardSkins": [],
+    "id": "1c56f7c4-f784-46ff-a851-55f03d658385",
+    "name": "Wanted Mythics",
+    "description": "",
+    "format": "DirectGame",
+    "deckTileId": 67156,
+    "mainDeck": [
+      67748,
+      4,
+      67156,
+      3,
+      66081,
+      1,
+      67838,
+      1,
+      67892,
+      2,
+      69213,
+      4,
+      66793,
+      3,
+      68530,
+      3,
+      68552,
+      4,
+      66839,
+      4,
+      69242,
+      3,
+      68599,
+      4,
+      66287,
+      1,
+      69250,
+      3,
+      68096,
+      3,
+      66325,
+      4,
+      67518,
+      4,
+      66931,
+      2,
+      69333,
+      4,
+      66431,
+      1,
+      68656,
+      2,
+      66921,
+      2,
+      68614,
+      3,
+      66945,
+      4,
+      69323,
+      2,
+      66975,
+      1,
+      68104,
+      4,
+      66991,
+      2,
+      67810,
+      2,
+      69614,
+      2,
+      69543,
+      2,
+      69467,
+      2,
+      69504,
+      2,
+      69464,
+      2,
+      69656,
+      3,
+      69548,
+      2,
+      69721,
+      1,
+      69578,
+      2,
+      69584,
+      2,
+      69295,
+      1
+    ],
+    "sideboard": [],
+    "cardBack": null,
+    "lastUpdated": "2019-05-05T23:42:02.2035098"
+  },
+  {
+    "cardSkins": [],
+    "id": "50c04b38-b420-4492-94b4-55c3be98836c",
+    "name": "Wanted Rares",
+    "description": "",
+    "format": "DirectGame",
+    "deckTileId": 66003,
+    "mainDeck": [
+      66003,
+      4,
+      68691,
+      4,
+      69139,
+      4,
+      69155,
+      4,
+      66045,
+      4,
+      66009,
+      3,
+      66653,
+      3,
+      69157,
+      3,
+      66029,
+      2,
+      67764,
+      3,
+      67698,
+      4,
+      67220,
+      3,
+      68500,
+      4,
+      66109,
+      3,
+      67580,
+      4,
+      69204,
+      4,
+      69211,
+      4,
+      67878,
+      4,
+      67860,
+      4,
+      66223,
+      4,
+      66815,
+      4,
+      69237,
+      4,
+      67362,
+      4,
+      67396,
+      1,
+      68560,
+      4,
+      66871,
+      4,
+      68038,
+      4,
+      69256,
+      4,
+      66335,
+      3,
+      67448,
+      4,
+      67468,
+      4,
+      66375,
+      4,
+      67472,
+      3,
+      66911,
+      2,
+      69293,
+      2,
+      69315,
+      4,
+      69298,
+      2,
+      68653,
+      4,
+      69313,
+      4,
+      68641,
+      2,
+      69307,
+      4,
+      66423,
+      3,
+      68644,
+      4,
+      68665,
+      3,
+      66933,
+      2,
+      69402,
+      4,
+      66477,
+      4,
+      66473,
+      2,
+      68714,
+      4,
+      68176,
+      1,
+      67572,
+      4,
+      67538,
+      2,
+      69399,
+      4,
+      67586,
+      4,
+      66485,
+      4,
+      68740,
+      4,
+      68738,
+      4,
+      67598,
+      4,
+      66483,
+      4,
+      68734,
+      4,
+      67600,
+      4,
+      66491,
+      4,
+      69407,
+      4,
+      67582,
+      4,
+      68735,
+      4,
+      68739,
+      4,
+      67584,
+      4,
+      69173,
+      2,
+      69342,
+      1,
+      69673,
+      2,
+      69670,
+      4
+    ],
+    "sideboard": [],
+    "cardBack": null,
+    "lastUpdated": "2019-05-08T06:20:13.3607131"
+  },
+  {
+    "cardSkins": [],
+    "id": "6801125e-4bb5-4eb5-94fe-9b1461816c82",
+    "name": "Hot Elves",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 67496,
+    "mainDeck": [
+      67940,
+      2,
+      68584,
+      2,
+      68038,
+      4,
+      66531,
+      9,
+      67494,
+      2,
+      69259,
+      4,
+      69781,
+      4,
+      67448,
+      2,
+      68072,
+      2,
+      69329,
+      2,
+      66491,
+      4,
+      69407,
+      4,
+      66495,
+      4,
+      69256,
+      4,
+      68602,
+      4,
+      67468,
+      3,
+      68568,
+      1,
+      69294,
+      1,
+      68086,
+      2
+    ],
+    "sideboard": [],
+    "cardBack": null,
+    "lastUpdated": "2019-04-30T19:14:44.9752913"
+  },
+  {
+    "cardSkins": [],
+    "id": "42d5040d-8b79-4f0a-9969-ae30bb64fbed",
+    "name": "Orzhov Control",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 69129,
+    "mainDeck": [
+      69129,
+      2,
+      67001,
+      2,
+      69358,
+      2,
+      68469,
+      3,
+      69298,
+      2,
+      69396,
+      4,
+      67586,
+      4,
+      65993,
+      4,
+      69315,
+      4,
+      69314,
+      3,
+      69320,
+      4,
+      66499,
+      8,
+      69150,
+      2,
+      66515,
+      6,
+      66473,
+      2,
+      66477,
+      4,
+      66223,
+      4
+    ],
+    "sideboard": [],
+    "cardBack": null,
+    "lastUpdated": "2019-04-30T19:15:05.3928898"
+  },
+  {
+    "cardSkins": [],
+    "id": "8f2815aa-25a2-482f-8734-41e3d8e4809e",
+    "name": "Orzhov Midrange",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 69314,
+    "mainDeck": [
+      68491,
+      2,
+      69284,
+      4,
+      67132,
+      4,
+      67298,
+      4,
+      69155,
+      2,
+      67686,
+      2,
+      69314,
+      2,
+      67266,
+      3,
+      67292,
+      3,
+      69320,
+      3,
+      66003,
+      3,
+      67146,
+      4,
+      69408,
+      7,
+      69410,
+      5,
+      68182,
+      3,
+      69396,
+      4,
+      67586,
+      3,
+      68463,
+      1,
+      69464,
+      1
+    ],
+    "sideboard": [],
+    "cardBack": "CardBack_EmbossedDefaultArena",
+    "lastUpdated": "2019-05-05T01:12:13.3471897"
+  },
+  {
+    "cardSkins": [],
+    "id": "cc715798-830b-4e6c-9f2c-80e3e62f1fa6",
+    "name": "Dark Knights",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 67488,
+    "mainDeck": [
+      67134,
+      2,
+      67132,
+      4,
+      67298,
+      4,
+      67740,
+      3,
+      67116,
+      4,
+      69320,
+      3,
+      67146,
+      4,
+      69408,
+      10,
+      69396,
+      4,
+      67586,
+      3,
+      67154,
+      1,
+      67488,
+      1,
+      66495,
+      4,
+      67764,
+      2,
+      67150,
+      4,
+      69148,
+      3,
+      66653,
+      1,
+      67128,
+      3
+    ],
+    "sideboard": [],
+    "cardBack": null,
+    "lastUpdated": "2019-05-05T01:11:54.4119832"
+  },
+  {
+    "cardSkins": [],
+    "id": "e7e90ee7-a7bf-4187-bf97-d7a3349efdb7",
+    "name": "1K Reclamation",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 68668,
+    "mainDeck": [
+      67196,
+      2,
+      69394,
+      4,
+      68493,
+      4,
+      68691,
+      3,
+      66531,
+      1,
+      69306,
+      4,
+      67584,
+      2,
+      66507,
+      2,
+      67224,
+      4,
+      66491,
+      3,
+      67992,
+      4,
+      68738,
+      3,
+      69407,
+      3,
+      67598,
+      2,
+      68668,
+      3,
+      69277,
+      4,
+      67590,
+      2,
+      66109,
+      1,
+      67013,
+      2,
+      67984,
+      2,
+      67768,
+      2,
+      69265,
+      3
+    ],
+    "sideboard": [],
+    "cardBack": null,
+    "lastUpdated": "2019-05-05T01:14:48.5472112"
+  },
+  {
+    "cardSkins": [],
+    "id": "6222d441-d200-45f0-bfcf-c499088034da",
+    "name": "Paint it Black",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 67280,
+    "mainDeck": [
+      66775,
+      2,
+      66781,
+      2,
+      68545,
+      2,
+      66793,
+      1,
+      66223,
+      2,
+      66477,
+      2,
+      67106,
+      2,
+      67588,
+      1,
+      67019,
+      20,
+      69198,
+      2,
+      67284,
+      1,
+      67266,
+      2,
+      67294,
+      1,
+      68528,
+      2,
+      67292,
+      2,
+      67280,
+      2,
+      68152,
+      2,
+      68688,
+      3,
+      67001,
+      1,
+      67580,
+      2,
+      66771,
+      2,
+      66143,
+      1,
+      69542,
+      1,
+      69543,
+      1,
+      69548,
+      1
+    ],
+    "sideboard": [
+      68268,
+      1,
+      67300,
+      1,
+      67332,
+      1,
+      67304,
+      1,
+      67294,
+      1,
+      66987,
+      1,
+      69198,
+      1,
+      67266,
+      1,
+      67106,
+      1,
+      67276,
+      1,
+      67284,
+      1,
+      66143,
+      1,
+      66991,
+      1,
+      66471,
+      1,
+      68164,
+      1
+    ],
+    "cardBack": "CardBack_EmbossedManaBlack",
+    "lastUpdated": "2019-05-07T06:42:45.5288146"
+  },
+  {
+    "cardSkins": [],
+    "id": "06eff8f7-fa25-4471-8581-f07a9b2c8f72",
+    "name": "Dregs",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 68634,
+    "mainDeck": [
+      66531,
+      7,
+      68634,
+      4,
+      68591,
+      2,
+      69204,
+      3,
+      68596,
+      1,
+      68597,
+      3,
+      67440,
+      3,
+      67588,
+      3,
+      68538,
+      4,
+      68651,
+      2,
+      68734,
+      3,
+      68543,
+      2,
+      69211,
+      2,
+      66781,
+      2,
+      66515,
+      4,
+      67600,
+      3,
+      68535,
+      1,
+      66913,
+      2,
+      68184,
+      2,
+      68694,
+      2,
+      67922,
+      4,
+      68641,
+      1
+    ],
+    "sideboard": [],
+    "cardBack": null,
+    "lastUpdated": "2019-05-06T02:30:57.9113153"
+  },
+  {
+    "cardSkins": [],
+    "id": "ddaf6b3c-e6ee-49e6-9ee7-f6f37463ab05",
+    "name": "Esper Midrange",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 67266,
+    "mainDeck": [
+      67266,
+      4,
+      66057,
+      2,
+      66485,
+      4,
+      66489,
+      4,
+      69396,
+      4,
+      69399,
+      4,
+      66415,
+      4,
+      67586,
+      4,
+      66185,
+      4,
+      66085,
+      2,
+      67156,
+      2,
+      67738,
+      4,
+      66781,
+      3,
+      66515,
+      1,
+      68666,
+      4,
+      68667,
+      2,
+      69155,
+      4,
+      68740,
+      4
+    ],
+    "sideboard": [
+      69279,
+      2,
+      69284,
+      2,
+      69293,
+      2,
+      66175,
+      2,
+      69320,
+      1,
+      67284,
+      2,
+      66991,
+      2,
+      66223,
+      2
+    ],
+    "cardBack": null,
+    "lastUpdated": "2019-03-06T03:49:54.5824784"
+  },
+  {
+    "cardSkins": [],
+    "id": "466b4ae7-a195-4805-bde6-012a7a11a88a",
+    "name": "Smothering Emergency",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 69150,
+    "mainDeck": [
+      69394,
+      4,
+      68493,
+      4,
+      67698,
+      1,
+      69297,
+      4,
+      66531,
+      1,
+      68048,
+      4,
+      66489,
+      3,
+      69396,
+      1,
+      69306,
+      4,
+      69399,
+      2,
+      67584,
+      2,
+      66507,
+      1,
+      67586,
+      2,
+      66771,
+      2,
+      67810,
+      1,
+      66093,
+      1,
+      68734,
+      2,
+      66499,
+      1,
+      69173,
+      4,
+      66199,
+      1,
+      67750,
+      4,
+      69150,
+      4,
+      66493,
+      3,
+      68739,
+      4
+    ],
+    "sideboard": [
+      67940,
+      1,
+      69285,
+      1,
+      69198,
+      1,
+      67156,
+      1,
+      69170,
+      1,
+      66707,
+      1,
+      66093,
+      1,
+      69262,
+      1,
+      68078,
+      1,
+      66027,
+      1,
+      67284,
+      1,
+      68668,
+      1,
+      68673,
+      1,
+      66433,
+      1,
+      66975,
+      1
+    ],
+    "cardBack": null,
+    "lastUpdated": "2019-03-08T04:13:18.7971135"
+  },
+  {
+    "cardSkins": [],
+    "id": "83e047a1-d8dc-4247-aa95-f63436b97d50",
+    "name": "Chromatic Black",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 67580,
+    "mainDeck": [
+      67580,
+      4,
+      67266,
+      1,
+      68714,
+      4,
+      69198,
+      3,
+      69311,
+      4,
+      67294,
+      1,
+      67106,
+      3,
+      66771,
+      4,
+      66775,
+      4,
+      68545,
+      2,
+      66515,
+      21,
+      66473,
+      1,
+      67284,
+      2,
+      66477,
+      4,
+      66223,
+      2
+    ],
+    "sideboard": [
+      66143,
+      1,
+      67940,
+      1,
+      67698,
+      1,
+      69162,
+      1,
+      66175,
+      1,
+      65993,
+      1,
+      69170,
+      1,
+      68653,
+      1,
+      66093,
+      1,
+      66027,
+      1,
+      66287,
+      1,
+      67218,
+      1,
+      68673,
+      1,
+      66975,
+      1,
+      66991,
+      1
+    ],
+    "cardBack": null,
+    "lastUpdated": "2019-03-10T05:07:18.942926"
+  },
+  {
+    "cardSkins": [],
+    "id": "e4ef12ad-4f96-4615-bf69-eb6cdbaaf455",
+    "name": "Cutie Control",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 69296,
+    "mainDeck": [
+      69296,
+      3,
+      66485,
+      3,
+      66489,
+      4,
+      69396,
+      4,
+      69399,
+      3,
+      67586,
+      3,
+      69315,
+      3,
+      66771,
+      3,
+      66775,
+      3,
+      69320,
+      3,
+      66091,
+      3,
+      68493,
+      1,
+      69198,
+      2,
+      67750,
+      4,
+      66515,
+      3,
+      66223,
+      2,
+      68740,
+      3,
+      68182,
+      1,
+      68196,
+      1,
+      68188,
+      1,
+      69279,
+      1,
+      67266,
+      2,
+      69685,
+      2,
+      69643,
+      1,
+      69483,
+      1
+    ],
+    "sideboard": [
+      69162,
+      1,
+      67698,
+      1,
+      65993,
+      1,
+      67148,
+      1,
+      66471,
+      1,
+      67284,
+      1,
+      67218,
+      1,
+      68673,
+      1,
+      66027,
+      1,
+      69170,
+      1,
+      66705,
+      1,
+      66991,
+      1,
+      67816,
+      1,
+      69298,
+      1,
+      69543,
+      1
+    ],
+    "cardBack": "CardBack_EmbossedDefaultArena",
+    "lastUpdated": "2019-05-07T06:47:36.7753241"
+  },
+  {
+    "cardSkins": [],
+    "id": "9de0a7bd-2092-4486-8974-e1984459d3d6",
+    "name": "Sultai Midrange BO3",
+    "description": "",
+    "format": "TraditionalStandard",
+    "deckTileId": 69311,
+    "mainDeck": [
+      67019,
+      1,
+      66781,
+      1,
+      67023,
+      5,
+      66889,
+      4,
+      66223,
+      2,
+      67600,
+      3,
+      68096,
+      2,
+      68694,
+      2,
+      67266,
+      3,
+      67588,
+      1,
+      68734,
+      3,
+      66401,
+      4,
+      69311,
+      4,
+      66415,
+      2,
+      66363,
+      4,
+      69394,
+      4,
+      66485,
+      3,
+      68740,
+      3,
+      67017,
+      1,
+      66913,
+      3,
+      66433,
+      1,
+      69781,
+      4
+    ],
+    "sideboard": [
+      70141,
+      4,
+      66705,
+      3,
+      69198,
+      1,
+      68613,
+      1,
+      68545,
+      1,
+      66325,
+      2,
+      68597,
+      3
+    ],
+    "cardBack": null,
+    "lastUpdated": "2019-05-03T08:12:52.1190961"
+  },
+  {
+    "cardSkins": [],
+    "id": "2e104b81-bb7c-4d2c-88c8-9e633aa96109",
+    "name": "Grixis Control",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 69656,
+    "mainDeck": [
+      68116,
+      1,
+      66223,
+      1,
+      66775,
+      2,
+      67284,
+      1,
+      69393,
+      4,
+      67590,
+      1,
+      68740,
+      3,
+      68667,
+      4,
+      66415,
+      1,
+      66705,
+      2,
+      66483,
+      3,
+      69198,
+      2,
+      67021,
+      1,
+      67017,
+      1,
+      67266,
+      2,
+      68493,
+      3,
+      67019,
+      4,
+      68545,
+      2,
+      67598,
+      2,
+      67218,
+      1,
+      68738,
+      3,
+      66109,
+      1,
+      66485,
+      3,
+      68515,
+      4,
+      66921,
+      1,
+      69285,
+      2,
+      69656,
+      1,
+      69542,
+      1,
+      69512,
+      1,
+      69543,
+      1,
+      69548,
+      1
+    ],
+    "sideboard": [],
+    "cardBack": null,
+    "lastUpdated": "2019-05-07T06:43:33.3510146"
+  },
+  {
+    "cardSkins": [],
+    "id": "aec06dff-e764-4a13-a4d8-7b3b6b40aec1",
+    "name": "Golgari Midrange",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 68674,
+    "mainDeck": [
+      67023,
+      10,
+      66781,
+      2,
+      67019,
+      6,
+      66889,
+      4,
+      66223,
+      1,
+      67600,
+      3,
+      68538,
+      1,
+      68096,
+      1,
+      68694,
+      3,
+      67266,
+      2,
+      66325,
+      1,
+      67588,
+      2,
+      68734,
+      3,
+      66401,
+      4,
+      68674,
+      1,
+      66363,
+      4,
+      67284,
+      1,
+      68597,
+      3,
+      66913,
+      3,
+      66433,
+      1,
+      69543,
+      1,
+      69631,
+      1,
+      69548,
+      1,
+      66775,
+      1
+    ],
+    "sideboard": [],
+    "cardBack": null,
+    "lastUpdated": "2019-05-07T06:49:16.1687135"
+  },
+  {
+    "cardSkins": [],
+    "id": "b6aa5bfc-6773-40bd-9924-b5c14c61b44e",
+    "name": "Nivs Gone Wild",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 69277,
+    "mainDeck": [
+      67196,
+      2,
+      69394,
+      4,
+      68493,
+      4,
+      68691,
+      3,
+      66531,
+      3,
+      69306,
+      4,
+      67584,
+      2,
+      66507,
+      3,
+      67224,
+      2,
+      66491,
+      3,
+      67388,
+      4,
+      68738,
+      3,
+      69407,
+      3,
+      67598,
+      2,
+      68653,
+      3,
+      69277,
+      4,
+      67021,
+      1,
+      66109,
+      1,
+      66477,
+      1,
+      68048,
+      1,
+      68515,
+      4,
+      67238,
+      1,
+      66251,
+      2
+    ],
+    "sideboard": [
+      68060,
+      1,
+      66991,
+      1,
+      69162,
+      1,
+      66125,
+      1,
+      66471,
+      1,
+      66707,
+      1,
+      66103,
+      1,
+      68496,
+      1,
+      67940,
+      1,
+      68498,
+      1,
+      69311,
+      1,
+      66705,
+      1,
+      66465,
+      1,
+      66487,
+      1,
+      68078,
+      1
+    ],
+    "cardBack": null,
+    "lastUpdated": "2019-05-05T01:14:24.2113752"
+  },
+  {
+    "cardSkins": [],
+    "id": "f539c8cb-60e4-434f-a5a9-464e6b1b452d",
+    "name": "Simic-Sultai Control",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 67226,
+    "mainDeck": [
+      69394,
+      4,
+      67266,
+      2,
+      68493,
+      4,
+      69198,
+      1,
+      66485,
+      3,
+      69306,
+      4,
+      67584,
+      2,
+      66507,
+      2,
+      66771,
+      4,
+      66775,
+      4,
+      68734,
+      3,
+      67226,
+      2,
+      68726,
+      2,
+      66459,
+      2,
+      68545,
+      1,
+      66109,
+      1,
+      66515,
+      2,
+      66223,
+      2,
+      68740,
+      3,
+      69277,
+      4,
+      67600,
+      3,
+      66477,
+      1,
+      69174,
+      2,
+      69406,
+      2
+    ],
+    "sideboard": [
+      68613,
+      1,
+      67940,
+      1,
+      67698,
+      1,
+      69162,
+      2,
+      66175,
+      1,
+      69311,
+      1,
+      68649,
+      1,
+      69170,
+      1,
+      66093,
+      1,
+      66103,
+      1,
+      68078,
+      1,
+      66027,
+      1,
+      68515,
+      1,
+      66991,
+      1
+    ],
+    "cardBack": null,
+    "lastUpdated": "2019-05-03T08:13:30.1901196"
+  },
+  {
+    "cardSkins": [],
+    "id": "a36abece-b31a-4492-bada-2a129f662dea",
+    "name": "Temur Elves",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 69302,
+    "mainDeck": [
+      67023,
+      1,
+      69364,
+      3,
+      69311,
+      3,
+      67448,
+      2,
+      67584,
+      2,
+      68096,
+      2,
+      69781,
+      4,
+      66495,
+      4,
+      68584,
+      2,
+      68602,
+      3,
+      69394,
+      4,
+      67468,
+      3,
+      66491,
+      3,
+      69259,
+      4,
+      68086,
+      3,
+      69302,
+      4,
+      67494,
+      2,
+      68738,
+      3,
+      67598,
+      2,
+      69407,
+      3,
+      67940,
+      2,
+      69323,
+      1
+    ],
+    "sideboard": [],
+    "cardBack": null,
+    "lastUpdated": "2019-05-05T01:14:35.2621519"
+  },
+  {
+    "cardSkins": [],
+    "id": "b046916e-b76f-4beb-8285-0288fbbabc9f",
+    "name": "Boros Battalion",
+    "description": "Decks/Precon/Precon_TwitchPrime_desc",
+    "format": "precon",
+    "deckTileId": 68614,
+    "mainDeck": [
+      68614,
+      2,
+      67582,
+      3,
+      67021,
+      6,
+      67015,
+      7,
+      68677,
+      4,
+      68617,
+      4,
+      68659,
+      4,
+      66653,
+      1,
+      68670,
+      3,
+      66495,
+      4,
+      67156,
+      1,
+      69139,
+      2,
+      68735,
+      3,
+      68643,
+      3,
+      67116,
+      4,
+      69155,
+      2,
+      66045,
+      2,
+      68664,
+      4,
+      68665,
+      1,
+      67132,
+      4,
+      69464,
+      1,
+      69647,
+      1
+    ],
+    "sideboard": [],
+    "cardBack": null,
+    "lastUpdated": "2019-04-30T00:31:37.498223"
+  },
+  {
+    "cardSkins": [],
+    "id": "b3a2e7e3-420a-45ea-a751-6a01f700f2e8",
+    "name": "BO3 Bolas",
+    "description": "",
+    "format": "TraditionalStandard",
+    "deckTileId": 69656,
+    "mainDeck": [
+      69285,
+      3,
+      69393,
+      4,
+      69570,
+      1,
+      66483,
+      4,
+      66485,
+      4,
+      66175,
+      3,
+      69646,
+      3,
+      66415,
+      2,
+      68569,
+      2,
+      69656,
+      3,
+      68116,
+      4,
+      67388,
+      2,
+      68738,
+      4,
+      67598,
+      4,
+      66515,
+      2,
+      68666,
+      4,
+      68667,
+      4,
+      69676,
+      2,
+      69453,
+      1,
+      68740,
+      4
+    ],
+    "sideboard": [
+      69198,
+      2,
+      68498,
+      2,
+      66175,
+      1,
+      69646,
+      1,
+      68569,
+      1,
+      66775,
+      2,
+      69512,
+      2,
+      66705,
+      2,
+      68545,
+      1,
+      66471,
+      1
+    ],
+    "cardBack": null,
+    "lastUpdated": "2019-05-01T19:09:03.2991243"
+  },
+  {
+    "cardSkins": [],
+    "id": "8b0c1883-0cdd-4bb5-af95-12030ca3edb6",
+    "name": "BO3 Ral",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 69660,
+    "mainDeck": [
+      67768,
+      4,
+      69492,
+      4,
+      68493,
+      3,
+      67954,
+      1,
+      68691,
+      4,
+      66507,
+      8,
+      66263,
+      4,
+      66523,
+      7,
+      66091,
+      4,
+      69660,
+      4,
+      69685,
+      3,
+      66109,
+      2,
+      67992,
+      4,
+      68738,
+      4,
+      67598,
+      4
+    ],
+    "sideboard": [
+      68615,
+      1,
+      66251,
+      2,
+      68569,
+      2,
+      69512,
+      2,
+      66705,
+      4,
+      68653,
+      2,
+      66839,
+      2
+    ],
+    "cardBack": null,
+    "lastUpdated": "2019-05-01T19:11:13.7282782"
+  },
+  {
+    "cardSkins": [],
+    "id": "98dda24f-1886-496a-b8a3-800d06bc0ca8",
+    "name": "BO3 Feather",
+    "description": "",
+    "format": "TraditionalStandard",
+    "deckTileId": 69647,
+    "mainDeck": [
+      67582,
+      4,
+      67132,
+      4,
+      69576,
+      3,
+      69647,
+      4,
+      66837,
+      3,
+      68735,
+      4,
+      69685,
+      3,
+      69593,
+      2,
+      66031,
+      4,
+      69671,
+      4,
+      69373,
+      2,
+      68114,
+      2,
+      69464,
+      3,
+      67021,
+      5,
+      67015,
+      9,
+      69460,
+      4
+    ],
+    "sideboard": [
+      65961,
+      3,
+      68614,
+      2,
+      67144,
+      3,
+      65993,
+      3,
+      66837,
+      1,
+      66045,
+      3
+    ],
+    "cardBack": null,
+    "lastUpdated": "2019-05-01T19:20:15.4672745"
+  },
+  {
+    "cardSkins": [],
+    "id": "cb585924-5b98-4d5d-9d71-a4f976d31b0f",
+    "name": "BO3 Dimir",
+    "description": "",
+    "format": "TraditionalStandard",
+    "deckTileId": 69676,
+    "mainDeck": [
+      69175,
+      4,
+      67017,
+      8,
+      67224,
+      4,
+      68666,
+      4,
+      67019,
+      5,
+      66415,
+      1,
+      69685,
+      2,
+      70141,
+      3,
+      67292,
+      1,
+      67266,
+      2,
+      68667,
+      4,
+      69676,
+      2,
+      66223,
+      2,
+      69646,
+      3,
+      69453,
+      1,
+      68688,
+      4,
+      68740,
+      4,
+      66485,
+      4,
+      66487,
+      1,
+      69504,
+      1
+    ],
+    "sideboard": [
+      66415,
+      1,
+      70141,
+      1,
+      67292,
+      1,
+      69512,
+      2,
+      66705,
+      2,
+      67284,
+      2,
+      68498,
+      2,
+      69198,
+      2,
+      66775,
+      2
+    ],
+    "cardBack": null,
+    "lastUpdated": "2019-05-01T19:39:56.4404993"
+  },
+  {
+    "cardSkins": [],
+    "id": "ff46cf42-2905-4d3d-8314-aebd27be8990",
+    "name": "BO3 Wizards",
+    "description": "",
+    "format": "TraditionalStandard",
+    "deckTileId": 67484,
+    "mainDeck": [
+      67992,
+      4,
+      67021,
+      8,
+      67946,
+      4,
+      69593,
+      4,
+      67358,
+      4,
+      67484,
+      3,
+      67017,
+      4,
+      67224,
+      4,
+      67406,
+      4,
+      69568,
+      4,
+      67984,
+      1,
+      67408,
+      4,
+      69576,
+      4,
+      68738,
+      4,
+      67598,
+      4
+    ],
+    "sideboard": [
+      68498,
+      2,
+      66471,
+      2,
+      68558,
+      4,
+      68569,
+      2,
+      68615,
+      1,
+      66251,
+      2,
+      69570,
+      2
+    ],
+    "cardBack": null,
+    "lastUpdated": "2019-05-01T19:45:37.0259196"
+  },
+  {
+    "cardSkins": [],
+    "id": "486ba896-cfe0-4efd-983e-1513ff53d488",
+    "name": "BO3 Feather V2",
+    "description": "",
+    "format": "TraditionalStandard",
+    "deckTileId": 69647,
+    "mainDeck": [
+      67582,
+      4,
+      69576,
+      4,
+      69647,
+      4,
+      66837,
+      2,
+      68735,
+      4,
+      67992,
+      4,
+      69593,
+      4,
+      66031,
+      4,
+      69671,
+      4,
+      68473,
+      2,
+      68614,
+      2,
+      65961,
+      3,
+      67021,
+      4,
+      67015,
+      6,
+      69460,
+      4,
+      69588,
+      2,
+      67011,
+      3
+    ],
+    "sideboard": [
+      68569,
+      2,
+      67686,
+      2,
+      67156,
+      2,
+      65975,
+      3,
+      66045,
+      3,
+      68570,
+      3
+    ],
+    "cardBack": null,
+    "lastUpdated": "2019-05-01T21:19:42.81"
+  },
+  {
+    "cardSkins": [],
+    "id": "229747c2-44e0-4d79-b99e-809260e76959",
+    "name": "Esperwalker",
+    "description": "",
+    "format": "Standard",
+    "deckTileId": 69670,
+    "mainDeck": [
+      69477,
+      2,
+      66485,
+      3,
+      66489,
+      4,
+      69396,
+      4,
+      69399,
+      3,
+      67586,
+      3,
+      69519,
+      1,
+      66775,
+      2,
+      69320,
+      2,
+      69198,
+      2,
+      66223,
+      1,
+      68740,
+      3,
+      67015,
+      1,
+      68196,
+      1,
+      67005,
+      1,
+      69680,
+      1,
+      69279,
+      1,
+      69643,
+      1,
+      69483,
+      1,
+      69512,
+      1,
+      69314,
+      2,
+      69453,
+      1,
+      67106,
+      2,
+      66109,
+      1,
+      69670,
+      1,
+      69488,
+      1,
+      68493,
+      1,
+      68667,
+      3,
+      67518,
+      2,
+      67332,
+      1,
+      69658,
+      1,
+      69315,
+      3,
+      67017,
+      1,
+      67019,
+      1,
+      69548,
+      1
+    ],
+    "sideboard": [],
+    "cardBack": "CardBack_EmbossedDefaultArena",
+    "lastUpdated": "2019-05-09T00:10:33.2087228"
+  },
+  {
+    "cardSkins": [],
+    "id": "965f3437-fefb-480e-abc0-1f6757a39fa1",
+    "name": "Friends of Ravnica",
+    "description": "",
+    "format": "Ravnica",
+    "deckTileId": 69680,
+    "mainDeck": [
+      69477,
+      2,
+      68498,
+      2,
+      68726,
+      4,
+      69396,
+      4,
+      69399,
+      3,
+      68484,
+      1,
+      69519,
+      1,
+      69320,
+      2,
+      69198,
+      3,
+      69392,
+      4,
+      68740,
+      3,
+      67015,
+      1,
+      69400,
+      4,
+      69152,
+      1,
+      69680,
+      2,
+      69279,
+      1,
+      69643,
+      1,
+      69483,
+      1,
+      69512,
+      2,
+      69314,
+      2,
+      69453,
+      3,
+      69670,
+      1,
+      69488,
+      1,
+      68493,
+      1,
+      68667,
+      3,
+      69658,
+      1,
+      69315,
+      3,
+      67017,
+      1,
+      67019,
+      1,
+      69548,
+      1
+    ],
+    "sideboard": [],
+    "cardBack": "CardBack_EmbossedDefaultArena",
+    "lastUpdated": "2019-05-10T16:22:14.7716545"
+  },
+  {
+    "cardSkins": [],
+    "id": "5afc0c11-fd1c-4a34-ab8f-b8d3eaefe454",
+    "name": "Rakdos Finally Wins",
+    "description": "",
+    "format": "Ravnica",
+    "deckTileId": 69313,
+    "mainDeck": [
+      69313,
+      2,
+      69235,
+      4,
+      68560,
+      3,
+      68558,
+      2,
+      69349,
+      4,
+      69242,
+      2,
+      69352,
+      4,
+      69243,
+      4,
+      69300,
+      4,
+      68576,
+      4,
+      66527,
+      5,
+      67628,
+      5,
+      68230,
+      4,
+      68228,
+      4,
+      69344,
+      4
+    ],
+    "sideboard": [],
+    "cardBack": "CardBack_EmbossedManaRed",
+    "lastUpdated": "2019-05-13T04:57:35.2398141"
+  }
+]
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+<== Deck.GetDeckLimit(9)
+60
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+<== Event.GetCombinedRankInfo(10)
+{
+  "playerId": "ANNON",
+  "constructedSeasonOrdinal": 5,
+  "constructedClass": "Gold",
+  "constructedLevel": 4,
+  "constructedStep": 2,
+  "constructedMatchesWon": 27,
+  "constructedMatchesLost": 30,
+  "constructedMatchesDrawn": 0,
+  "limitedSeasonOrdinal": 5,
+  "limitedClass": "Bronze",
+  "limitedLevel": 3,
+  "limitedStep": 2,
+  "limitedMatchesWon": 1,
+  "limitedMatchesLost": 1,
+  "limitedMatchesDrawn": 0,
+  "constructedPercentile": 0.0,
+  "constructedLeaderboardPlace": 0,
+  "limitedPercentile": 0.0,
+  "limitedLeaderboardPlace": 0
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+<== PlayerInventory.GetRewardSchedule(11)
+{
+  "dailyReset": "2019-05-14T09:00:00",
+  "weeklyReset": "2019-05-19T09:00:00",
+  "dailyRewards": [
+    {
+      "wins": 1,
+      "awardDescription": {
+        "image1": "ObjectiveIcon_CoinsLarge",
+        "image2": null,
+        "image3": null,
+        "prefab": "RewardPopup3DIcon_Coin",
+        "referenceId": null,
+        "headerLocKey": "MainNav/EventRewards/Gold_Reward",
+        "descriptionLocKey": "MainNav/EventRewards/Reward_Daily_Reset",
+        "quantity": "250",
+        "locParams": {
+          "number1": 250
+        },
+        "availableDate": "0001-01-01T00:00:00"
+      }
+    },
+    {
+      "wins": 2,
+      "awardDescription": {
+        "image1": "ObjectiveIcon_CoinsSmall",
+        "image2": null,
+        "image3": null,
+        "prefab": "RewardPopup3DIcon_Coin",
+        "referenceId": null,
+        "headerLocKey": "MainNav/EventRewards/Gold_Reward",
+        "descriptionLocKey": "MainNav/EventRewards/Reward_Daily_Reset",
+        "quantity": "100",
+        "locParams": {
+          "number1": 100
+        },
+        "availableDate": "0001-01-01T00:00:00"
+      }
+    },
+    {
+      "wins": 3,
+      "awardDescription": {
+        "image1": "ObjectiveIcon_CoinsSmall",
+        "image2": null,
+        "image3": null,
+        "prefab": "RewardPopup3DIcon_Coin",
+        "referenceId": null,
+        "headerLocKey": "MainNav/EventRewards/Gold_Reward",
+        "descriptionLocKey": "MainNav/EventRewards/Reward_Daily_Reset",
+        "quantity": "100",
+        "locParams": {
+          "number1": 100
+        },
+        "availableDate": "0001-01-01T00:00:00"
+      }
+    },
+    {
+      "wins": 4,
+      "awardDescription": {
+        "image1": "ObjectiveIcon_CoinsSmall",
+        "image2": null,
+        "image3": null,
+        "prefab": "RewardPopup3DIcon_Coin",
+        "referenceId": null,
+        "headerLocKey": "MainNav/EventRewards/Gold_Reward",
+        "descriptionLocKey": "MainNav/EventRewards/Reward_Daily_Reset",
+        "quantity": "100",
+        "locParams": {
+          "number1": 100
+        },
+        "availableDate": "0001-01-01T00:00:00"
+      }
+    },
+    {
+      "wins": 5,
+      "awardDescription": {
+        "image1": "ObjectiveIcon_IndividualCard",
+        "image2": null,
+        "image3": null,
+        "prefab": "RewardPopup3DIcon_Card_Uncommon",
+        "referenceId": null,
+        "headerLocKey": "MainNav/EventRewards/Card",
+        "descriptionLocKey": "MainNav/EventRewards/Reward_Daily_Reset",
+        "quantity": null,
+        "locParams": {
+          "number1": 1
+        },
+        "availableDate": "0001-01-01T00:00:00"
+      }
+    },
+    {
+      "wins": 6,
+      "awardDescription": {
+        "image1": "ObjectiveIcon_CoinsSmall",
+        "image2": null,
+        "image3": null,
+        "prefab": "RewardPopup3DIcon_Coin",
+        "referenceId": null,
+        "headerLocKey": "MainNav/EventRewards/Gold_Reward",
+        "descriptionLocKey": "MainNav/EventRewards/Reward_Daily_Reset",
+        "quantity": "50",
+        "locParams": {
+          "number1": 50
+        },
+        "availableDate": "0001-01-01T00:00:00"
+      }
+    },
+    {
+      "wins": 7,
+      "awardDescription": {
+        "image1": "ObjectiveIcon_IndividualCard",
+        "image2": null,
+        "image3": null,
+        "prefab": "RewardPopup3DIcon_Card_Uncommon",
+        "referenceId": null,
+        "headerLocKey": "MainNav/EventRewards/Card",
+        "descriptionLocKey": "MainNav/EventRewards/Reward_Daily_Reset",
+        "quantity": null,
+        "locParams": {
+          "number1": 1
+        },
+        "availableDate": "0001-01-01T00:00:00"
+      }
+    },
+    {
+      "wins": 8,
+      "awardDescription": {
+        "image1": "ObjectiveIcon_CoinsSmall",
+        "image2": null,
+        "image3": null,
+        "prefab": "RewardPopup3DIcon_Coin",
+        "referenceId": null,
+        "headerLocKey": "MainNav/EventRewards/Gold_Reward",
+        "descriptionLocKey": "MainNav/EventRewards/Reward_Daily_Reset",
+        "quantity": "50",
+        "locParams": {
+          "number1": 50
+        },
+        "availableDate": "0001-01-01T00:00:00"
+      }
+    },
+    {
+      "wins": 9,
+      "awardDescription": {
+        "image1": "ObjectiveIcon_IndividualCard",
+        "image2": null,
+        "image3": null,
+        "prefab": "RewardPopup3DIcon_Card_Uncommon",
+        "referenceId": null,
+        "headerLocKey": "MainNav/EventRewards/Card",
+        "descriptionLocKey": "MainNav/EventRewards/Reward_Daily_Reset",
+        "quantity": null,
+        "locParams": {
+          "number1": 1
+        },
+        "availableDate": "0001-01-01T00:00:00"
+      }
+    },
+    {
+      "wins": 10,
+      "awardDescription": {
+        "image1": "ObjectiveIcon_CoinsSmall",
+        "image2": null,
+        "image3": null,
+        "prefab": "RewardPopup3DIcon_Coin",
+        "referenceId": null,
+        "headerLocKey": "MainNav/EventRewards/Gold_Reward",
+        "descriptionLocKey": "MainNav/EventRewards/Reward_Daily_Reset",
+        "quantity": "50",
+        "locParams": {
+          "number1": 50
+        },
+        "availableDate": "0001-01-01T00:00:00"
+      }
+    },
+    {
+      "wins": 11,
+      "awardDescription": {
+        "image1": "ObjectiveIcon_IndividualCard",
+        "image2": null,
+        "image3": null,
+        "prefab": "RewardPopup3DIcon_Card_Uncommon",
+        "referenceId": null,
+        "headerLocKey": "MainNav/EventRewards/Card",
+        "descriptionLocKey": "MainNav/EventRewards/Reward_Daily_Reset",
+        "quantity": null,
+        "locParams": {
+          "number1": 1
+        },
+        "availableDate": "0001-01-01T00:00:00"
+      }
+    },
+    {
+      "wins": 12,
+      "awardDescription": {
+        "image1": "ObjectiveIcon_CoinsSmall",
+        "image2": null,
+        "image3": null,
+        "prefab": "RewardPopup3DIcon_Coin",
+        "referenceId": null,
+        "headerLocKey": "MainNav/EventRewards/Gold_Reward",
+        "descriptionLocKey": "MainNav/EventRewards/Reward_Daily_Reset",
+        "quantity": "25",
+        "locParams": {
+          "number1": 25
+        },
+        "availableDate": "0001-01-01T00:00:00"
+      }
+    },
+    {
+      "wins": 13,
+      "awardDescription": {
+        "image1": "ObjectiveIcon_IndividualCard",
+        "image2": null,
+        "image3": null,
+        "prefab": "RewardPopup3DIcon_Card_Uncommon",
+        "referenceId": null,
+        "headerLocKey": "MainNav/EventRewards/Card",
+        "descriptionLocKey": "MainNav/EventRewards/Reward_Daily_Reset",
+        "quantity": null,
+        "locParams": {
+          "number1": 1
+        },
+        "availableDate": "0001-01-01T00:00:00"
+      }
+    },
+    {
+      "wins": 14,
+      "awardDescription": {
+        "image1": "ObjectiveIcon_CoinsSmall",
+        "image2": null,
+        "image3": null,
+        "prefab": "RewardPopup3DIcon_Coin",
+        "referenceId": null,
+        "headerLocKey": "MainNav/EventRewards/Gold_Reward",
+        "descriptionLocKey": "MainNav/EventRewards/Reward_Daily_Reset",
+        "quantity": "25",
+        "locParams": {
+          "number1": 25
+        },
+        "availableDate": "0001-01-01T00:00:00"
+      }
+    },
+    {
+      "wins": 15,
+      "awardDescription": {
+        "image1": "ObjectiveIcon_IndividualCard",
+        "image2": null,
+        "image3": null,
+        "prefab": "RewardPopup3DIcon_Card_Uncommon",
+        "referenceId": null,
+        "headerLocKey": "MainNav/EventRewards/Card",
+        "descriptionLocKey": "MainNav/EventRewards/Reward_Daily_Reset",
+        "quantity": null,
+        "locParams": {
+          "number1": 1
+        },
+        "availableDate": "0001-01-01T00:00:00"
+      }
+    }
+  ],
+  "weeklyRewards": [
+    {
+      "wins": 5,
+      "awardDescription": {
+        "image1": "ObjectiveIcon_Pack_WAR",
+        "image2": null,
+        "image3": null,
+        "prefab": "RewardPopup3DIcon_Pack",
+        "referenceId": "100013",
+        "headerLocKey": "MainNav/EventRewards/Booster_Pack_Generic",
+        "descriptionLocKey": "MainNav/EventRewards/Weekly_Rewards_Text",
+        "quantity": null,
+        "locParams": {},
+        "availableDate": "0001-01-01T00:00:00"
+      }
+    },
+    {
+      "wins": 10,
+      "awardDescription": {
+        "image1": "ObjectiveIcon_Pack_WAR",
+        "image2": null,
+        "image3": null,
+        "prefab": "RewardPopup3DIcon_Pack",
+        "referenceId": "100013",
+        "headerLocKey": "MainNav/EventRewards/Booster_Pack_Generic",
+        "descriptionLocKey": "MainNav/EventRewards/Weekly_Rewards_Text",
+        "quantity": null,
+        "locParams": {},
+        "availableDate": "0001-01-01T00:00:00"
+      }
+    },
+    {
+      "wins": 15,
+      "awardDescription": {
+        "image1": "ObjectiveIcon_Pack_WAR",
+        "image2": null,
+        "image3": null,
+        "prefab": "RewardPopup3DIcon_Pack",
+        "referenceId": "100013",
+        "headerLocKey": "MainNav/EventRewards/Booster_Pack_Generic",
+        "descriptionLocKey": "MainNav/EventRewards/Weekly_Rewards_Text",
+        "quantity": null,
+        "locParams": {},
+        "availableDate": "0001-01-01T00:00:00"
+      }
+    }
+  ]
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+<== PlayerInventory.GetPlayerCardsV3(12)
+{
+  "68286": 1,
+  "68298": 3,
+  "69108": 1,
+  "68136": 3,
+  "67770": 4,
+  "67772": 3,
+  "68300": 1,
+  "66241": 4,
+  "67992": 4,
+  "68018": 3,
+  "68020": 3,
+  "66235": 4,
+  "68022": 4,
+  "68786": 1,
+  "67700": 4,
+  "67860": 3,
+  "67272": 4,
+  "67950": 1,
+  "68144": 2,
+  "67864": 4,
+  "67780": 4,
+  "67208": 4,
+  "67866": 4,
+  "68034": 4,
+  "68040": 4,
+  "68150": 4,
+  "67960": 3,
+  "68156": 2,
+  "67794": 4,
+  "66877": 2,
+  "68050": 1,
+  "66451": 4,
+  "67964": 4,
+  "67876": 4,
+  "68268": 2,
+  "68054": 4,
+  "67972": 3,
+  "67706": 4,
+  "68056": 4,
+  "67880": 2,
+  "67882": 4,
+  "68276": 3,
+  "67718": 4,
+  "67978": 2,
+  "67726": 4,
+  "67440": 4,
+  "67728": 3,
+  "66641": 4,
+  "68164": 3,
+  "67900": 4,
+  "67986": 4,
+  "67904": 3,
+  "67742": 3,
+  "67162": 4,
+  "66903": 3,
+  "68068": 4,
+  "67660": 3,
+  "68070": 3,
+  "68256": 2,
+  "67914": 4,
+  "67818": 3,
+  "67822": 2,
+  "67170": 4,
+  "68250": 1,
+  "69110": 1,
+  "68252": 2,
+  "66211": 4,
+  "66213": 4,
+  "67998": 4,
+  "68767": 1,
+  "68000": 2,
+  "67756": 4,
+  "67924": 4,
+  "68002": 4,
+  "68769": 3,
+  "67760": 2,
+  "67240": 4,
+  "68090": 4,
+  "67930": 4,
+  "66393": 4,
+  "68012": 4,
+  "68092": 2,
+  "68014": 4,
+  "67932": 4,
+  "66739": 4,
+  "67330": 3,
+  "67256": 3,
+  "66677": 3,
+  "68202": 4,
+  "68200": 4,
+  "68198": 4,
+  "68196": 4,
+  "68194": 4,
+  "68188": 4,
+  "68186": 4,
+  "68184": 4,
+  "68182": 4,
+  "68178": 4,
+  "68724": 4,
+  "68729": 4,
+  "68736": 4,
+  "68726": 4,
+  "68732": 4,
+  "68728": 4,
+  "68553": 4,
+  "68533": 4,
+  "68639": 4,
+  "68607": 4,
+  "68670": 4,
+  "68506": 4,
+  "68713": 2,
+  "66385": 2,
+  "66133": 3,
+  "66179": 4,
+  "66007": 3,
+  "66077": 4,
+  "66301": 2,
+  "65989": 4,
+  "66057": 4,
+  "66375": 2,
+  "68483": 4,
+  "68658": 4,
+  "68537": 4,
+  "68531": 4,
+  "68498": 4,
+  "68527": 4,
+  "68582": 4,
+  "68570": 4,
+  "66325": 2,
+  "68310": 3,
+  "66275": 4,
+  "68110": 4,
+  "66893": 4,
+  "66257": 3,
+  "66811": 3,
+  "66831": 2,
+  "66847": 4,
+  "66817": 1,
+  "67940": 2,
+  "68064": 1,
+  "68052": 2,
+  "68026": 4,
+  "66263": 4,
+  "66491": 3,
+  "68479": 4,
+  "68492": 4,
+  "68637": 4,
+  "68655": 4,
+  "68589": 4,
+  "68574": 4,
+  "68625": 3,
+  "68579": 4,
+  "68661": 4,
+  "68591": 4,
+  "68735": 3,
+  "68546": 4,
+  "68503": 4,
+  "68572": 4,
+  "68464": 4,
+  "68542": 4,
+  "68720": 4,
+  "68668": 4,
+  "67704": 3,
+  "67980": 1,
+  "67910": 4,
+  "67990": 2,
+  "66095": 3,
+  "68680": 4,
+  "68659": 4,
+  "68561": 4,
+  "68716": 2,
+  "68472": 4,
+  "69781": 4,
+  "66637": 4,
+  "68519": 4,
+  "68571": 4,
+  "68608": 4,
+  "68678": 4,
+  "68662": 4,
+  "68491": 4,
+  "67942": 4,
+  "66819": 4,
+  "65991": 4,
+  "67358": 4,
+  "68467": 4,
+  "67514": 3,
+  "67460": 4,
+  "67482": 4,
+  "67326": 3,
+  "68122": 4,
+  "67464": 4,
+  "67316": 3,
+  "66157": 4,
+  "67292": 4,
+  "67324": 4,
+  "67478": 1,
+  "66901": 2,
+  "66911": 1,
+  "67308": 4,
+  "67320": 3,
+  "66793": 1,
+  "67600": 3,
+  "68569": 4,
+  "67970": 4,
+  "67408": 4,
+  "68560": 3,
+  "68576": 4,
+  "66839": 3,
+  "67702": 2,
+  "67782": 1,
+  "67752": 4,
+  "68006": 4,
+  "67936": 2,
+  "67524": 3,
+  "66315": 4,
+  "66687": 4,
+  "68501": 4,
+  "67180": 3,
+  "67276": 1,
+  "66121": 4,
+  "66765": 4,
+  "66699": 4,
+  "67778": 4,
+  "66185": 4,
+  "66759": 4,
+  "66725": 4,
+  "67790": 3,
+  "66689": 3,
+  "66781": 2,
+  "66753": 1,
+  "66415": 3,
+  "66069": 1,
+  "66201": 3,
+  "66485": 3,
+  "67896": 2,
+  "67844": 2,
+  "67996": 3,
+  "67682": 4,
+  "68094": 4,
+  "67404": 4,
+  "66135": 4,
+  "66085": 3,
+  "67816": 4,
+  "68473": 4,
+  "66049": 2,
+  "66925": 1,
+  "68487": 4,
+  "67744": 2,
+  "68462": 4,
+  "66043": 4,
+  "65987": 3,
+  "66707": 1,
+  "68475": 4,
+  "65985": 2,
+  "66029": 1,
+  "68480": 3,
+  "66737": 1,
+  "66073": 4,
+  "67166": 4,
+  "66089": 3,
+  "66489": 4,
+  "67916": 1,
+  "67912": 4,
+  "66713": 2,
+  "67310": 1,
+  "66619": 3,
+  "68583": 3,
+  "67370": 3,
+  "66379": 4,
+  "67350": 3,
+  "67362": 3,
+  "67724": 4,
+  "66645": 4,
+  "67696": 2,
+  "67738": 3,
+  "68114": 4,
+  "66011": 4,
+  "67390": 4,
+  "66239": 1,
+  "65997": 3,
+  "67734": 1,
+  "67710": 3,
+  "68010": 2,
+  "67732": 2,
+  "67708": 4,
+  "67934": 4,
+  "67582": 3,
+  "67854": 3,
+  "67836": 2,
+  "67874": 2,
+  "67690": 4,
+  "65971": 4,
+  "66947": 4,
+  "66407": 4,
+  "67870": 4,
+  "67692": 4,
+  "67902": 3,
+  "66647": 2,
+  "66649": 1,
+  "66223": 2,
+  "67748": 1,
+  "66205": 3,
+  "66745": 2,
+  "67146": 4,
+  "67740": 4,
+  "68128": 4,
+  "67128": 3,
+  "68032": 4,
+  "66967": 1,
+  "68086": 3,
+  "67688": 3,
+  "67174": 3,
+  "67720": 4,
+  "67160": 2,
+  "68062": 4,
+  "66945": 3,
+  "66885": 4,
+  "66361": 4,
+  "66101": 4,
+  "66949": 4,
+  "66723": 4,
+  "66137": 4,
+  "66891": 2,
+  "66377": 4,
+  "67828": 3,
+  "66871": 1,
+  "66337": 1,
+  "66889": 4,
+  "66719": 1,
+  "66079": 2,
+  "68112": 4,
+  "67250": 4,
+  "67820": 1,
+  "66277": 1,
+  "66283": 2,
+  "66071": 2,
+  "66103": 1,
+  "67806": 1,
+  "67388": 4,
+  "67824": 4,
+  "67196": 4,
+  "67342": 4,
+  "68106": 4,
+  "67037": 2,
+  "67968": 1,
+  "67862": 2,
+  "67852": 4,
+  "67586": 3,
+  "66493": 4,
+  "67584": 2,
+  "67598": 2,
+  "66483": 3,
+  "66963": 3,
+  "66661": 1,
+  "68573": 4,
+  "68497": 4,
+  "68478": 4,
+  "68544": 4,
+  "68629": 3,
+  "68563": 3,
+  "68515": 4,
+  "67254": 4,
+  "67766": 2,
+  "67774": 2,
+  "66129": 4,
+  "68120": 1,
+  "68721": 4,
+  "68541": 4,
+  "68588": 4,
+  "68596": 4,
+  "68664": 4,
+  "66861": 4,
+  "66961": 1,
+  "66951": 2,
+  "66993": 3,
+  "66923": 4,
+  "66895": 4,
+  "66809": 3,
+  "66873": 4,
+  "66849": 3,
+  "66919": 1,
+  "66917": 4,
+  "66669": 1,
+  "66853": 2,
+  "66833": 4,
+  "66843": 3,
+  "66803": 2,
+  "66855": 2,
+  "66825": 3,
+  "66651": 3,
+  "66663": 4,
+  "67011": 4,
+  "66303": 4,
+  "66001": 4,
+  "66319": 3,
+  "65975": 3,
+  "66013": 1,
+  "66189": 4,
+  "66297": 4,
+  "66037": 4,
+  "66333": 4,
+  "66343": 4,
+  "66657": 3,
+  "66795": 4,
+  "66733": 2,
+  "66915": 4,
+  "66971": 3,
+  "68712": 4,
+  "68547": 4,
+  "68518": 4,
+  "68535": 4,
+  "68642": 4,
+  "68653": 3,
+  "67510": 4,
+  "66389": 4,
+  "66643": 3,
+  "68534": 3,
+  "68606": 4,
+  "67686": 2,
+  "67116": 4,
+  "67132": 4,
+  "68476": 4,
+  "67106": 3,
+  "67424": 1,
+  "68174": 2,
+  "66899": 2,
+  "66869": 3,
+  "66897": 2,
+  "66863": 4,
+  "66829": 1,
+  "66857": 3,
+  "66767": 2,
+  "66711": 3,
+  "66625": 2,
+  "66969": 4,
+  "66281": 3,
+  "66311": 1,
+  "66255": 3,
+  "66321": 4,
+  "66231": 2,
+  "66269": 4,
+  "66175": 4,
+  "66353": 3,
+  "66373": 3,
+  "65967": 3,
+  "66985": 3,
+  "66785": 4,
+  "67003": 4,
+  "66691": 4,
+  "67548": 1,
+  "67236": 4,
+  "67212": 4,
+  "67013": 4,
+  "68612": 4,
+  "68677": 4,
+  "68595": 4,
+  "68718": 4,
+  "68558": 4,
+  "68522": 4,
+  "68555": 4,
+  "68616": 4,
+  "68626": 4,
+  "66837": 2,
+  "66913": 3,
+  "67716": 2,
+  "68172": 2,
+  "68577": 4,
+  "66865": 4,
+  "67826": 2,
+  "68587": 4,
+  "68580": 4,
+  "68676": 4,
+  "68722": 4,
+  "68644": 1,
+  "68528": 3,
+  "68488": 4,
+  "68502": 4,
+  "68599": 1,
+  "67224": 4,
+  "66763": 3,
+  "67136": 3,
+  "68601": 4,
+  "68507": 4,
+  "68703": 4,
+  "68714": 1,
+  "66445": 2,
+  "66717": 3,
+  "66987": 2,
+  "66769": 4,
+  "66747": 2,
+  "66757": 4,
+  "66777": 4,
+  "66731": 1,
+  "66721": 3,
+  "66991": 1,
+  "66743": 3,
+  "66845": 3,
+  "66761": 3,
+  "66775": 4,
+  "66997": 3,
+  "66835": 4,
+  "66119": 4,
+  "66055": 4,
+  "66149": 2,
+  "65981": 4,
+  "66117": 1,
+  "66253": 4,
+  "66113": 2,
+  "66285": 4,
+  "66463": 3,
+  "66099": 4,
+  "66999": 3,
+  "66703": 3,
+  "66907": 1,
+  "66063": 4,
+  "69130": 4,
+  "67920": 4,
+  "68028": 2,
+  "68078": 2,
+  "68166": 3,
+  "68016": 2,
+  "67722": 1,
+  "67786": 1,
+  "67956": 3,
+  "68142": 1,
+  "67868": 2,
+  "68100": 2,
+  "68130": 2,
+  "68060": 1,
+  "68066": 1,
+  "68160": 1,
+  "67878": 1,
+  "68024": 1,
+  "68008": 2,
+  "68072": 2,
+  "67746": 2,
+  "69289": 4,
+  "66787": 3,
+  "69185": 4,
+  "69215": 4,
+  "69278": 4,
+  "69174": 4,
+  "69241": 4,
+  "69347": 4,
+  "69140": 4,
+  "69154": 4,
+  "69210": 4,
+  "69182": 4,
+  "69218": 4,
+  "69225": 4,
+  "69166": 4,
+  "69143": 1,
+  "69404": 4,
+  "69133": 4,
+  "69270": 4,
+  "69132": 4,
+  "69195": 4,
+  "69177": 4,
+  "69232": 4,
+  "69197": 3,
+  "69348": 4,
+  "69162": 4,
+  "69282": 4,
+  "69322": 2,
+  "69319": 4,
+  "69364": 4,
+  "69311": 4,
+  "69392": 4,
+  "69222": 4,
+  "69135": 4,
+  "69247": 4,
+  "69179": 4,
+  "69192": 4,
+  "69156": 4,
+  "69345": 4,
+  "69147": 4,
+  "69180": 4,
+  "69302": 4,
+  "69376": 4,
+  "69400": 4,
+  "69265": 4,
+  "69200": 4,
+  "69246": 4,
+  "69272": 4,
+  "69152": 4,
+  "69330": 4,
+  "69255": 4,
+  "69205": 4,
+  "69274": 4,
+  "69383": 4,
+  "69184": 4,
+  "69131": 4,
+  "69170": 2,
+  "69231": 4,
+  "69233": 4,
+  "69138": 4,
+  "69212": 4,
+  "69142": 4,
+  "69303": 4,
+  "69196": 4,
+  "69190": 4,
+  "69204": 3,
+  "69405": 2,
+  "69178": 4,
+  "69194": 4,
+  "69280": 4,
+  "69304": 4,
+  "69226": 4,
+  "69260": 4,
+  "69292": 4,
+  "69361": 4,
+  "69283": 4,
+  "69328": 2,
+  "69391": 4,
+  "69167": 4,
+  "69145": 4,
+  "69230": 4,
+  "69269": 4,
+  "69288": 2,
+  "69161": 4,
+  "69158": 4,
+  "69306": 4,
+  "69240": 4,
+  "69336": 4,
+  "69318": 4,
+  "69301": 4,
+  "69261": 4,
+  "69284": 4,
+  "69183": 2,
+  "67758": 2,
+  "68162": 2,
+  "67858": 2,
+  "67750": 4,
+  "68158": 1,
+  "67850": 3,
+  "67974": 1,
+  "67764": 2,
+  "67976": 2,
+  "67946": 1,
+  "67944": 4,
+  "68168": 2,
+  "67886": 2,
+  "67984": 4,
+  "67898": 1,
+  "67840": 1,
+  "67954": 3,
+  "67796": 1,
+  "67830": 1,
+  "67834": 1,
+  "68074": 3,
+  "68116": 1,
+  "68154": 2,
+  "67884": 1,
+  "69268": 4,
+  "69281": 4,
+  "69390": 4,
+  "68152": 3,
+  "68469": 3,
+  "66659": 4,
+  "66401": 4,
+  "66363": 4,
+  "66207": 1,
+  "66705": 4,
+  "66125": 4,
+  "66067": 4,
+  "67238": 4,
+  "68513": 4,
+  "68538": 4,
+  "66477": 2,
+  "69299": 4,
+  "69271": 4,
+  "69263": 4,
+  "69206": 4,
+  "69228": 4,
+  "69193": 4,
+  "69358": 3,
+  "69236": 4,
+  "66875": 1,
+  "66003": 3,
+  "66495": 4,
+  "69159": 4,
+  "69267": 4,
+  "69151": 4,
+  "69386": 4,
+  "69279": 4,
+  "68646": 4,
+  "67544": 2,
+  "69339": 4,
+  "69176": 4,
+  "69326": 4,
+  "69191": 4,
+  "69382": 4,
+  "69141": 4,
+  "69344": 4,
+  "69275": 4,
+  "69381": 3,
+  "69266": 4,
+  "69203": 4,
+  "69312": 4,
+  "69324": 4,
+  "69277": 4,
+  "69403": 2,
+  "69238": 4,
+  "69276": 4,
+  "69188": 4,
+  "69338": 4,
+  "69399": 3,
+  "69134": 4,
+  "69235": 4,
+  "69168": 4,
+  "69355": 4,
+  "69155": 2,
+  "69216": 4,
+  "69249": 4,
+  "69305": 4,
+  "69243": 4,
+  "69325": 4,
+  "69201": 4,
+  "69146": 3,
+  "69259": 4,
+  "69199": 4,
+  "69337": 4,
+  "69379": 4,
+  "69388": 4,
+  "69239": 4,
+  "69300": 4,
+  "69309": 4,
+  "69333": 3,
+  "69234": 2,
+  "69144": 4,
+  "68170": 1,
+  "67792": 2,
+  "67762": 1,
+  "67788": 1,
+  "67926": 1,
+  "67906": 1,
+  "68126": 1,
+  "67928": 1,
+  "67754": 1,
+  "68190": 1,
+  "67962": 1,
+  "67112": 4,
+  "69181": 4,
+  "69169": 4,
+  "69253": 4,
+  "69370": 4,
+  "69217": 4,
+  "69219": 4,
+  "69153": 4,
+  "69224": 4,
+  "69320": 4,
+  "69317": 4,
+  "69401": 4,
+  "69384": 4,
+  "69290": 4,
+  "69329": 4,
+  "69393": 4,
+  "69186": 4,
+  "69398": 4,
+  "69389": 4,
+  "69165": 4,
+  "69207": 4,
+  "69402": 3,
+  "69346": 4,
+  "69258": 4,
+  "69406": 4,
+  "68548": 4,
+  "67508": 3,
+  "69285": 2,
+  "69385": 4,
+  "69331": 4,
+  "69150": 4,
+  "69175": 4,
+  "65993": 4,
+  "69172": 4,
+  "69189": 2,
+  "69332": 1,
+  "69187": 4,
+  "69163": 4,
+  "69315": 3,
+  "69395": 4,
+  "69352": 4,
+  "69380": 4,
+  "69373": 3,
+  "69264": 4,
+  "69308": 4,
+  "69251": 4,
+  "69245": 4,
+  "69257": 4,
+  "67216": 4,
+  "69307": 2,
+  "69248": 4,
+  "69367": 3,
+  "66695": 4,
+  "68485": 4,
+  "69291": 4,
+  "69335": 4,
+  "66233": 2,
+  "66017": 2,
+  "66435": 4,
+  "66091": 4,
+  "66187": 3,
+  "66115": 4,
+  "66359": 4,
+  "66031": 3,
+  "66371": 4,
+  "66143": 2,
+  "67204": 4,
+  "67354": 4,
+  "67556": 4,
+  "67336": 4,
+  "67218": 2,
+  "67270": 4,
+  "67554": 4,
+  "67374": 2,
+  "67246": 4,
+  "67268": 4,
+  "67176": 1,
+  "66715": 1,
+  "66249": 2,
+  "66447": 2,
+  "66429": 2,
+  "66329": 4,
+  "68739": 3,
+  "68096": 2,
+  "66023": 2,
+  "66215": 2,
+  "66259": 2,
+  "66245": 3,
+  "67410": 4,
+  "68666": 3,
+  "69223": 4,
+  "69244": 4,
+  "69254": 4,
+  "69148": 4,
+  "69160": 4,
+  "69310": 4,
+  "69316": 4,
+  "69341": 3,
+  "69407": 3,
+  "67372": 4,
+  "67430": 2,
+  "67384": 4,
+  "67400": 2,
+  "68635": 4,
+  "66821": 2,
+  "67150": 4,
+  "68521": 4,
+  "68496": 4,
+  "68523": 4,
+  "68554": 4,
+  "68524": 2,
+  "68525": 4,
+  "68679": 4,
+  "68624": 4,
+  "68516": 1,
+  "68657": 4,
+  "68562": 4,
+  "68592": 4,
+  "68514": 4,
+  "68740": 3,
+  "66131": 4,
+  "69396": 4,
+  "69198": 4,
+  "68634": 4,
+  "68180": 1,
+  "69340": 3,
+  "69136": 4,
+  "69211": 2,
+  "69137": 4,
+  "69293": 1,
+  "69149": 4,
+  "69387": 4,
+  "69286": 3,
+  "69287": 4,
+  "69297": 2,
+  "69229": 4,
+  "69157": 2,
+  "69164": 4,
+  "68470": 3,
+  "69221": 4,
+  "69139": 3,
+  "69294": 1,
+  "67172": 3,
+  "67190": 4,
+  "67312": 4,
+  "67386": 4,
+  "67252": 4,
+  "67494": 2,
+  "66497": 4,
+  "66369": 4,
+  "67148": 4,
+  "67522": 4,
+  "67118": 3,
+  "67428": 4,
+  "67364": 2,
+  "67210": 4,
+  "67528": 4,
+  "67418": 1,
+  "67360": 3,
+  "67566": 3,
+  "67472": 1,
+  "67192": 4,
+  "67334": 3,
+  "67314": 4,
+  "67378": 4,
+  "67294": 4,
+  "68674": 1,
+  "67144": 2,
+  "67536": 4,
+  "67206": 2,
+  "67550": 1,
+  "67412": 4,
+  "67108": 4,
+  "67120": 1,
+  "67540": 2,
+  "67490": 2,
+  "67340": 1,
+  "67274": 4,
+  "67262": 4,
+  "67530": 3,
+  "67296": 2,
+  "67328": 4,
+  "67122": 3,
+  "67126": 2,
+  "67432": 2,
+  "67444": 3,
+  "67422": 1,
+  "68586": 4,
+  "66035": 3,
+  "66267": 2,
+  "66381": 1,
+  "66193": 3,
+  "66195": 4,
+  "66065": 2,
+  "66021": 1,
+  "66289": 4,
+  "66309": 2,
+  "66355": 2,
+  "66455": 4,
+  "65999": 3,
+  "66317": 4,
+  "68694": 3,
+  "67266": 3,
+  "67406": 4,
+  "67516": 3,
+  "67504": 3,
+  "67134": 3,
+  "67392": 4,
+  "67284": 2,
+  "67570": 3,
+  "68490": 4,
+  "68630": 4,
+  "68584": 4,
+  "68489": 4,
+  "68706": 2,
+  "68636": 4,
+  "67588": 3,
+  "67568": 4,
+  "67562": 4,
+  "66169": 1,
+  "69171": 1,
+  "67576": 4,
+  "69262": 2,
+  "68610": 4,
+  "68681": 4,
+  "68517": 4,
+  "68564": 4,
+  "68559": 1,
+  "68484": 4,
+  "68654": 4,
+  "68673": 3,
+  "68568": 2,
+  "68567": 4,
+  "68549": 4,
+  "68557": 2,
+  "68551": 4,
+  "68648": 4,
+  "68471": 3,
+  "68600": 4,
+  "68500": 1,
+  "68520": 2,
+  "68575": 4,
+  "68495": 4,
+  "68700": 2,
+  "68669": 4,
+  "68511": 4,
+  "68494": 3,
+  "68493": 4,
+  "68552": 3,
+  "68719": 4,
+  "68643": 4,
+  "68645": 1,
+  "68619": 4,
+  "68529": 4,
+  "68543": 3,
+  "68691": 3,
+  "68481": 4,
+  "68499": 1,
+  "68504": 4,
+  "68556": 4,
+  "68709": 4,
+  "68602": 4,
+  "68581": 4,
+  "68667": 4,
+  "68545": 3,
+  "68660": 4,
+  "68623": 4,
+  "68652": 4,
+  "68512": 3,
+  "68632": 2,
+  "68466": 4,
+  "66203": 2,
+  "66227": 4,
+  "68717": 4,
+  "67558": 1,
+  "67380": 4,
+  "67438": 4,
+  "67178": 4,
+  "67346": 4,
+  "67322": 4,
+  "67496": 2,
+  "67356": 1,
+  "67446": 4,
+  "67590": 4,
+  "67154": 3,
+  "67416": 2,
+  "67344": 4,
+  "67512": 4,
+  "67436": 1,
+  "67376": 3,
+  "67290": 4,
+  "67188": 2,
+  "67168": 2,
+  "67560": 4,
+  "67286": 2,
+  "67114": 1,
+  "67152": 2,
+  "67248": 4,
+  "67352": 3,
+  "67520": 3,
+  "67260": 2,
+  "67480": 3,
+  "67306": 4,
+  "67488": 1,
+  "67288": 4,
+  "67124": 2,
+  "67382": 2,
+  "67226": 2,
+  "67414": 4,
+  "67474": 4,
+  "67492": 2,
+  "67202": 3,
+  "67468": 3,
+  "67546": 1,
+  "67142": 1,
+  "67282": 4,
+  "67458": 4,
+  "67532": 1,
+  "69394": 4,
+  "68734": 3,
+  "66271": 1,
+  "66341": 4,
+  "65961": 4,
+  "66633": 4,
+  "66387": 3,
+  "66243": 4,
+  "66357": 2,
+  "66219": 2,
+  "66191": 4,
+  "66061": 3,
+  "66199": 2,
+  "66139": 4,
+  "66183": 4,
+  "65969": 3,
+  "66161": 2,
+  "65977": 4,
+  "66449": 1,
+  "65983": 4,
+  "66331": 2,
+  "66247": 1,
+  "66075": 1,
+  "66327": 2,
+  "66265": 4,
+  "66047": 2,
+  "66427": 3,
+  "66307": 4,
+  "66127": 1,
+  "66453": 3,
+  "66299": 3,
+  "66421": 3,
+  "66469": 1,
+  "66403": 1,
+  "66471": 2,
+  "66097": 2,
+  "66441": 1,
+  "66221": 4,
+  "66153": 1,
+  "66405": 2,
+  "66423": 2,
+  "66209": 2,
+  "66155": 2,
+  "66411": 2,
+  "66345": 2,
+  "67684": 1,
+  "68192": 2,
+  "69252": 2,
+  "66783": 2,
+  "70140": 3,
+  "70141": 4,
+  "68605": 4,
+  "68565": 4,
+  "68603": 4,
+  "68594": 4,
+  "68604": 4,
+  "68486": 4,
+  "68633": 4,
+  "68715": 4,
+  "68482": 4,
+  "68590": 4,
+  "68585": 1,
+  "68682": 1,
+  "68737": 2,
+  "66741": 2,
+  "68597": 4,
+  "69214": 4,
+  "68526": 4,
+  "68671": 4,
+  "68474": 4,
+  "68540": 4,
+  "68598": 4,
+  "68697": 4,
+  "68536": 1,
+  "68566": 4,
+  "68463": 3,
+  "68611": 4,
+  "68613": 4,
+  "68663": 4,
+  "68647": 4,
+  "66419": 2,
+  "68042": 2,
+  "68578": 4,
+  "68550": 4,
+  "68731": 1,
+  "68723": 4,
+  "68725": 4,
+  "68505": 1,
+  "68640": 4,
+  "68532": 2,
+  "68614": 2,
+  "68468": 4,
+  "68539": 4,
+  "68615": 2,
+  "67009": 2,
+  "69242": 2,
+  "67242": 4,
+  "68621": 2,
+  "68617": 4,
+  "68688": 4,
+  "68649": 4,
+  "68628": 4,
+  "68733": 3,
+  "68651": 4,
+  "65965": 1,
+  "66045": 2,
+  "67476": 1,
+  "69208": 4,
+  "68620": 2,
+  "68609": 4,
+  "68477": 2,
+  "66727": 1,
+  "67298": 4,
+  "67258": 4,
+  "67502": 1,
+  "67186": 1,
+  "67278": 3,
+  "67592": 3,
+  "67498": 1,
+  "66261": 2,
+  "66197": 3,
+  "68738": 3,
+  "68084": 1,
+  "66635": 2,
+  "68638": 3,
+  "69334": 3,
+  "66025": 1,
+  "66465": 1,
+  "66171": 3,
+  "66107": 3,
+  "68675": 2,
+  "67244": 2,
+  "67200": 4,
+  "67572": 3,
+  "67714": 1,
+  "68593": 2,
+  "67158": 2,
+  "66251": 4,
+  "69227": 4,
+  "69313": 2,
+  "67318": 2,
+  "67596": 3,
+  "66413": 2,
+  "66165": 2,
+  "67230": 3,
+  "67420": 3,
+  "67302": 1,
+  "67500": 1,
+  "65979": 3,
+  "67110": 1,
+  "67602": 4,
+  "67534": 1,
+  "66851": 4,
+  "67198": 1,
+  "67234": 4,
+  "67448": 2,
+  "66039": 2,
+  "67164": 2,
+  "66093": 1,
+  "66365": 2,
+  "66425": 2,
+  "66965": 2,
+  "66749": 1,
+  "67280": 2,
+  "67454": 4,
+  "67220": 1,
+  "67426": 4,
+  "67434": 1,
+  "67332": 1,
+  "67194": 4,
+  "67594": 4,
+  "67338": 3,
+  "67300": 1,
+  "67138": 2,
+  "67232": 2,
+  "67450": 2,
+  "67442": 1,
+  "67222": 1,
+  "67304": 1,
+  "67580": 2,
+  "66383": 2,
+  "67394": 3,
+  "67484": 2,
+  "67542": 2,
+  "69296": 4,
+  "66771": 4,
+  "67810": 1,
+  "66109": 1,
+  "67698": 1,
+  "67001": 1,
+  "66959": 2,
+  "66807": 3,
+  "66887": 1,
+  "66623": 3,
+  "66729": 1,
+  "66813": 1,
+  "66433": 2,
+  "66323": 2,
+  "65963": 1,
+  "67768": 2,
+  "68048": 2,
+  "66667": 1,
+  "66671": 4,
+  "66631": 1,
+  "66177": 1,
+  "66167": 2,
+  "66279": 2,
+  "66799": 1,
+  "66627": 2,
+  "66639": 2,
+  "67005": 1,
+  "66009": 1,
+  "66033": 1,
+  "66467": 1,
+  "66051": 2,
+  "66399": 1,
+  "66181": 1,
+  "67922": 4,
+  "66217": 1,
+  "67506": 1,
+  "66621": 1,
+  "66867": 2,
+  "66655": 1,
+  "67007": 2,
+  "66905": 1,
+  "66347": 1,
+  "66409": 1,
+  "65995": 1,
+  "66027": 1,
+  "66679": 1,
+  "66159": 1,
+  "68058": 1,
+  "67798": 3,
+  "66349": 1,
+  "68134": 1,
+  "65973": 1,
+  "68102": 1,
+  "66397": 2,
+  "66653": 1,
+  "68508": 1,
+  "68104": 1,
+  "66909": 1,
+  "68044": 1,
+  "69343": 2,
+  "69349": 4,
+  "66459": 2,
+  "66163": 1,
+  "67466": 4,
+  "66487": 1,
+  "66237": 1,
+  "68138": 1,
+  "67156": 1,
+  "69256": 2,
+  "66229": 1,
+  "66929": 1,
+  "69273": 1,
+  "69237": 1,
+  "69314": 2,
+  "67948": 1,
+  "67486": 1,
+  "68098": 1,
+  "66673": 1,
+  "69220": 1,
+  "68132": 1,
+  "68727": 4,
+  "68627": 1,
+  "68685": 1,
+  "66339": 1,
+  "66147": 1,
+  "69209": 2,
+  "66921": 1,
+  "66293": 1,
+  "66041": 1,
+  "68465": 2,
+  "68641": 1,
+  "67366": 1,
+  "69521": 4,
+  "69522": 3,
+  "69579": 4,
+  "69518": 4,
+  "69524": 3,
+  "69468": 4,
+  "69466": 1,
+  "69632": 3,
+  "69528": 4,
+  "69515": 4,
+  "69476": 3,
+  "69458": 4,
+  "69695": 3,
+  "69661": 1,
+  "69603": 1,
+  "69545": 4,
+  "69456": 3,
+  "69582": 4,
+  "69459": 4,
+  "69585": 4,
+  "69685": 4,
+  "68665": 1,
+  "68509": 1,
+  "69525": 4,
+  "69558": 4,
+  "69569": 4,
+  "69499": 4,
+  "69634": 4,
+  "69511": 4,
+  "69460": 4,
+  "69470": 4,
+  "69640": 2,
+  "69531": 1,
+  "69629": 2,
+  "69570": 2,
+  "69532": 4,
+  "69590": 4,
+  "69619": 4,
+  "69497": 4,
+  "69484": 4,
+  "69604": 4,
+  "69583": 4,
+  "69547": 4,
+  "69689": 3,
+  "69682": 2,
+  "69541": 4,
+  "69699": 2,
+  "69696": 4,
+  "69480": 3,
+  "69465": 4,
+  "69609": 4,
+  "69690": 4,
+  "69592": 4,
+  "69692": 4,
+  "69487": 4,
+  "69572": 4,
+  "69538": 1,
+  "69679": 2,
+  "69646": 1,
+  "69587": 4,
+  "69574": 3,
+  "69474": 4,
+  "69602": 3,
+  "69593": 4,
+  "69535": 4,
+  "69494": 2,
+  "69652": 3,
+  "69591": 4,
+  "69461": 3,
+  "69555": 4,
+  "69630": 3,
+  "69628": 2,
+  "69693": 4,
+  "69595": 4,
+  "69649": 1,
+  "69618": 2,
+  "69608": 3,
+  "69656": 1,
+  "69694": 4,
+  "69605": 4,
+  "69561": 2,
+  "69491": 4,
+  "69613": 1,
+  "69625": 4,
+  "69490": 3,
+  "69520": 4,
+  "69762": 3,
+  "69643": 1,
+  "69567": 4,
+  "69660": 2,
+  "69616": 4,
+  "69478": 4,
+  "69529": 1,
+  "69517": 1,
+  "69633": 3,
+  "69626": 4,
+  "69471": 4,
+  "69552": 4,
+  "69684": 2,
+  "69481": 3,
+  "69512": 2,
+  "69542": 2,
+  "69600": 4,
+  "69564": 4,
+  "69486": 4,
+  "69612": 4,
+  "69455": 3,
+  "69647": 2,
+  "69495": 4,
+  "69581": 4,
+  "69498": 4,
+  "69599": 4,
+  "69648": 2,
+  "69549": 4,
+  "69670": 1,
+  "69508": 3,
+  "69563": 4,
+  "69509": 2,
+  "69606": 4,
+  "69639": 2,
+  "69765": 3,
+  "69766": 1,
+  "69617": 2,
+  "69489": 4,
+  "69560": 4,
+  "69566": 2,
+  "69641": 1,
+  "69624": 3,
+  "69523": 4,
+  "69506": 2,
+  "69677": 2,
+  "69607": 2,
+  "69527": 4,
+  "69493": 3,
+  "69586": 1,
+  "69671": 1,
+  "69601": 3,
+  "69550": 2,
+  "69556": 4,
+  "69559": 4,
+  "69610": 4,
+  "69536": 2,
+  "69492": 2,
+  "69636": 2,
+  "69453": 4,
+  "69568": 3,
+  "69472": 1,
+  "69546": 3,
+  "69462": 3,
+  "69653": 2,
+  "69615": 4,
+  "69479": 1,
+  "69514": 2,
+  "69565": 3,
+  "69763": 1,
+  "69507": 1,
+  "69691": 4,
+  "69562": 1,
+  "69631": 2,
+  "69554": 3,
+  "69571": 4,
+  "69539": 4,
+  "69553": 3,
+  "69533": 2,
+  "69596": 4,
+  "69544": 4,
+  "69483": 4,
+  "69683": 2,
+  "69627": 3,
+  "69454": 2,
+  "69642": 2,
+  "69464": 1,
+  "69598": 3,
+  "69519": 1,
+  "69655": 2,
+  "69589": 2,
+  "69323": 2,
+  "69298": 1,
+  "69513": 3,
+  "69654": 4,
+  "69678": 1,
+  "69680": 2,
+  "69543": 1,
+  "69510": 3,
+  "69620": 1,
+  "69534": 1,
+  "69482": 1,
+  "69503": 1,
+  "69516": 1,
+  "69635": 2,
+  "69488": 1,
+  "68622": 1,
+  "68631": 1,
+  "69676": 2,
+  "67518": 2,
+  "67462": 2,
+  "68036": 3,
+  "67802": 1,
+  "69500": 1,
+  "69526": 1,
+  "69688": 1,
+  "69658": 1,
+  "69681": 1,
+  "69664": 1,
+  "69622": 1,
+  "69686": 1,
+  "69669": 1,
+  "69551": 1,
+  "69621": 1,
+  "69623": 1,
+  "69638": 1,
+  "69573": 1,
+  "69548": 1,
+  "69477": 2,
+  "66823": 1,
+  "69597": 1,
+  "69580": 1,
+  "69584": 1
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+<== PlayerInventory.GetPlayerInventory(13)
+{
+  "playerId": "ANNON",
+  "wcCommon": 15,
+  "wcUncommon": 6,
+  "wcRare": 0,
+  "wcMythic": 1,
+  "gold": 12750,
+  "gems": 625,
+  "draftTokens": 0,
+  "sealedTokens": 0,
+  "wcTrackPosition": 24,
+  "vaultProgress": 40.3,
+  "boosters": [],
+  "vanityItems": {
+    "pets": [],
+    "avatars": [],
+    "cardBacks": [
+      {
+        "name": "CardBack_EmbossedDefaultArena",
+        "mods": []
+      },
+      {
+        "name": "CardBack_EmbossedManaWhite",
+        "mods": []
+      },
+      {
+        "name": "CardBack_EmbossedManaBlue",
+        "mods": []
+      },
+      {
+        "name": "CardBack_EmbossedManaBlack",
+        "mods": []
+      },
+      {
+        "name": "CardBack_EmbossedManaRed",
+        "mods": []
+      },
+      {
+        "name": "CardBack_EmbossedManaGreen",
+        "mods": []
+      }
+    ]
+  },
+  "vouchers": [],
+  "vanitySelections": {
+    "avatarSelection": null,
+    "avatarModSelection": null,
+    "cardBackSelection": null,
+    "cardBackModSelection": null,
+    "petSelection": null,
+    "petModSelection": null
+  }
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+<== PlayerInventory.GetProductCatalog(14)
+{
+  "401429": [
+    {
+      "ccv": "DA",
+      "id": "401429",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404598": [
+    {
+      "ccv": "DA",
+      "id": "404598",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "129151": [
+    {
+      "ccv": "DA",
+      "id": "129151",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406481": [
+    {
+      "ccv": "DA",
+      "id": "406481",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402925": [
+    {
+      "ccv": "DA",
+      "id": "402925",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404872": [
+    {
+      "ccv": "DA",
+      "id": "404872",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406626": [
+    {
+      "ccv": "DA",
+      "id": "406626",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406607": [
+    {
+      "ccv": "DA",
+      "id": "406607",
+      "currency": "Gem",
+      "amount": 400,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406657": [
+    {
+      "ccv": "DA",
+      "id": "406657",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402595": [
+    {
+      "ccv": "DA",
+      "id": "402595",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406516": [
+    {
+      "ccv": "DA",
+      "id": "406516",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402660": [
+    {
+      "ccv": "DA",
+      "id": "402660",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "406502": [
+    {
+      "ccv": "DA",
+      "id": "406502",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402600": [
+    {
+      "ccv": "DA",
+      "id": "402600",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402725": [
+    {
+      "ccv": "DA",
+      "id": "402725",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406613": [
+    {
+      "ccv": "DA",
+      "id": "406613",
+      "currency": "Gem",
+      "amount": 400,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "118773": [
+    {
+      "ccv": "DA",
+      "id": "118773",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402511": [
+    {
+      "ccv": "DA",
+      "id": "402511",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404113": [
+    {
+      "ccv": "DA",
+      "id": "404113",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404990": [
+    {
+      "ccv": "DA",
+      "id": "404990",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402536": [
+    {
+      "ccv": "DA",
+      "id": "402536",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402277": [
+    {
+      "ccv": "DA",
+      "id": "402277",
+      "currency": "Gem",
+      "amount": 400,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "403321": [
+    {
+      "ccv": "DA",
+      "id": "403321",
+      "currency": "Gem",
+      "amount": 400,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402481": [
+    {
+      "ccv": "DA",
+      "id": "402481",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "406608": [
+    {
+      "ccv": "DA",
+      "id": "406608",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "406565": [
+    {
+      "ccv": "DA",
+      "id": "406565",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "406484": [
+    {
+      "ccv": "DA",
+      "id": "406484",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404922": [
+    {
+      "ccv": "DA",
+      "id": "404922",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402159": [
+    {
+      "ccv": "DA",
+      "id": "402159",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402479": [
+    {
+      "ccv": "DA",
+      "id": "402479",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402861": [
+    {
+      "ccv": "DA",
+      "id": "402861",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "405071": [
+    {
+      "ccv": "DA",
+      "id": "405071",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "401444": [
+    {
+      "ccv": "DA",
+      "id": "401444",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "403341": [
+    {
+      "ccv": "DA",
+      "id": "403341",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406609": [
+    {
+      "ccv": "DA",
+      "id": "406609",
+      "currency": "Gem",
+      "amount": 400,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406620": [
+    {
+      "ccv": "DA",
+      "id": "406620",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "406581": [
+    {
+      "ccv": "DA",
+      "id": "406581",
+      "currency": "Gem",
+      "amount": 400,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406591": [
+    {
+      "ccv": "DA",
+      "id": "406591",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402080": [
+    {
+      "ccv": "DA",
+      "id": "402080",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402230": [
+    {
+      "ccv": "DA",
+      "id": "402230",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402192": [
+    {
+      "ccv": "DA",
+      "id": "402192",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402622": [
+    {
+      "ccv": "DA",
+      "id": "402622",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402588": [
+    {
+      "ccv": "DA",
+      "id": "402588",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "405558": [
+    {
+      "ccv": "DA",
+      "id": "405558",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404086": [
+    {
+      "ccv": "DA",
+      "id": "404086",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402625": [
+    {
+      "ccv": "DA",
+      "id": "402625",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "406528": [
+    {
+      "ccv": "DA",
+      "id": "406528",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "404910": [
+    {
+      "ccv": "DA",
+      "id": "404910",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "406442": [
+    {
+      "ccv": "DA",
+      "id": "406442",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404921": [
+    {
+      "ccv": "DA",
+      "id": "404921",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404998": [
+    {
+      "ccv": "DA",
+      "id": "404998",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402631": [
+    {
+      "ccv": "DA",
+      "id": "402631",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402731": [
+    {
+      "ccv": "DA",
+      "id": "402731",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406588": [
+    {
+      "ccv": "DA",
+      "id": "406588",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "403134": [
+    {
+      "ccv": "DA",
+      "id": "403134",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404110": [
+    {
+      "ccv": "DA",
+      "id": "404110",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402406": [
+    {
+      "ccv": "DA",
+      "id": "402406",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402659": [
+    {
+      "ccv": "DA",
+      "id": "402659",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404135": [
+    {
+      "ccv": "DA",
+      "id": "404135",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "406562": [
+    {
+      "ccv": "DA",
+      "id": "406562",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "404525": [
+    {
+      "ccv": "DA",
+      "id": "404525",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404969": [
+    {
+      "ccv": "DA",
+      "id": "404969",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406439": [
+    {
+      "ccv": "DA",
+      "id": "406439",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404315": [
+    {
+      "ccv": "DA",
+      "id": "404315",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402160": [
+    {
+      "ccv": "DA",
+      "id": "402160",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402788": [
+    {
+      "ccv": "DA",
+      "id": "402788",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402504": [
+    {
+      "ccv": "DA",
+      "id": "402504",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402499": [
+    {
+      "ccv": "DA",
+      "id": "402499",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402031": [
+    {
+      "ccv": "DA",
+      "id": "402031",
+      "currency": "Gem",
+      "amount": 400,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "403320": [
+    {
+      "ccv": "DA",
+      "id": "403320",
+      "currency": "Gem",
+      "amount": 400,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "152027": [
+    {
+      "ccv": "DA",
+      "id": "152027",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "406477": [
+    {
+      "ccv": "DA",
+      "id": "406477",
+      "currency": "Gem",
+      "amount": 400,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406681": [
+    {
+      "ccv": "DA",
+      "id": "406681",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402352": [
+    {
+      "ccv": "DA",
+      "id": "402352",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "406643": [
+    {
+      "ccv": "DA",
+      "id": "406643",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404850": [
+    {
+      "ccv": "DA",
+      "id": "404850",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "400748": [
+    {
+      "ccv": "DA",
+      "id": "400748",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402222": [
+    {
+      "ccv": "DA",
+      "id": "402222",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "406656": [
+    {
+      "ccv": "DA",
+      "id": "406656",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406637": [
+    {
+      "ccv": "DA",
+      "id": "406637",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404081": [
+    {
+      "ccv": "DA",
+      "id": "404081",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406595": [
+    {
+      "ccv": "DA",
+      "id": "406595",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406670": [
+    {
+      "ccv": "DA",
+      "id": "406670",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402663": [
+    {
+      "ccv": "DA",
+      "id": "402663",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "405001": [
+    {
+      "ccv": "DA",
+      "id": "405001",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402110": [
+    {
+      "ccv": "DA",
+      "id": "402110",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "400332": [
+    {
+      "ccv": "DA",
+      "id": "400332",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402004": [
+    {
+      "ccv": "DA",
+      "id": "402004",
+      "currency": "Gem",
+      "amount": 400,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "122154": [
+    {
+      "ccv": "DA",
+      "id": "122154",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "406636": [
+    {
+      "ccv": "DA",
+      "id": "406636",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402393": [
+    {
+      "ccv": "DA",
+      "id": "402393",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "401271": [
+    {
+      "ccv": "DA",
+      "id": "401271",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406667": [
+    {
+      "ccv": "DA",
+      "id": "406667",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402647": [
+    {
+      "ccv": "DA",
+      "id": "402647",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "401263": [
+    {
+      "ccv": "DA",
+      "id": "401263",
+      "currency": "Gem",
+      "amount": 400,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406554": [
+    {
+      "ccv": "DA",
+      "id": "406554",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402394": [
+    {
+      "ccv": "DA",
+      "id": "402394",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "406621": [
+    {
+      "ccv": "DA",
+      "id": "406621",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "405795": [
+    {
+      "ccv": "DA",
+      "id": "405795",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404940": [
+    {
+      "ccv": "DA",
+      "id": "404940",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402959": [
+    {
+      "ccv": "DA",
+      "id": "402959",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "403035": [
+    {
+      "ccv": "DA",
+      "id": "403035",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402358": [
+    {
+      "ccv": "DA",
+      "id": "402358",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "403355": [
+    {
+      "ccv": "DA",
+      "id": "403355",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406634": [
+    {
+      "ccv": "DA",
+      "id": "406634",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406567": [
+    {
+      "ccv": "DA",
+      "id": "406567",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406495": [
+    {
+      "ccv": "DA",
+      "id": "406495",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406600": [
+    {
+      "ccv": "DA",
+      "id": "406600",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406531": [
+    {
+      "ccv": "DA",
+      "id": "406531",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402579": [
+    {
+      "ccv": "DA",
+      "id": "402579",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402874": [
+    {
+      "ccv": "DA",
+      "id": "402874",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402606": [
+    {
+      "ccv": "DA",
+      "id": "402606",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402770": [
+    {
+      "ccv": "DA",
+      "id": "402770",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "403347": [
+    {
+      "ccv": "DA",
+      "id": "403347",
+      "currency": "Gem",
+      "amount": 400,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406619": [
+    {
+      "ccv": "DA",
+      "id": "406619",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "406496": [
+    {
+      "ccv": "DA",
+      "id": "406496",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406485": [
+    {
+      "ccv": "DA",
+      "id": "406485",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "400831": [
+    {
+      "ccv": "DA",
+      "id": "400831",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "405946": [
+    {
+      "ccv": "DA",
+      "id": "405946",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404077": [
+    {
+      "ccv": "DA",
+      "id": "404077",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404161": [
+    {
+      "ccv": "DA",
+      "id": "404161",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "145150": [
+    {
+      "ccv": "DA",
+      "id": "145150",
+      "currency": "Gem",
+      "amount": 400,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406566": [
+    {
+      "ccv": "DA",
+      "id": "406566",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406530": [
+    {
+      "ccv": "DA",
+      "id": "406530",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406494": [
+    {
+      "ccv": "DA",
+      "id": "406494",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402480": [
+    {
+      "ccv": "DA",
+      "id": "402480",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402508": [
+    {
+      "ccv": "DA",
+      "id": "402508",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404402": [
+    {
+      "ccv": "DA",
+      "id": "404402",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402398": [
+    {
+      "ccv": "DA",
+      "id": "402398",
+      "currency": "Gem",
+      "amount": 400,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "405035": [
+    {
+      "ccv": "DA",
+      "id": "405035",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402604": [
+    {
+      "ccv": "DA",
+      "id": "402604",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402357": [
+    {
+      "ccv": "DA",
+      "id": "402357",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406689": [
+    {
+      "ccv": "DA",
+      "id": "406689",
+      "currency": "Gem",
+      "amount": 400,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "405008": [
+    {
+      "ccv": "DA",
+      "id": "405008",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402566": [
+    {
+      "ccv": "DA",
+      "id": "402566",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402534": [
+    {
+      "ccv": "DA",
+      "id": "402534",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402478": [
+    {
+      "ccv": "DA",
+      "id": "402478",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "404796": [
+    {
+      "ccv": "DA",
+      "id": "404796",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "406540": [
+    {
+      "ccv": "DA",
+      "id": "406540",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "404968": [
+    {
+      "ccv": "DA",
+      "id": "404968",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "405194": [
+    {
+      "ccv": "DA",
+      "id": "405194",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "401445": [
+    {
+      "ccv": "DA",
+      "id": "401445",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404912": [
+    {
+      "ccv": "DA",
+      "id": "404912",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "404795": [
+    {
+      "ccv": "DA",
+      "id": "404795",
+      "currency": "Gem",
+      "amount": 400,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "405075": [
+    {
+      "ccv": "DA",
+      "id": "405075",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "405037": [
+    {
+      "ccv": "DA",
+      "id": "405037",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "406648": [
+    {
+      "ccv": "DA",
+      "id": "406648",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404933": [
+    {
+      "ccv": "DA",
+      "id": "404933",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404083": [
+    {
+      "ccv": "DA",
+      "id": "404083",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402864": [
+    {
+      "ccv": "DA",
+      "id": "402864",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402396": [
+    {
+      "ccv": "DA",
+      "id": "402396",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402162": [
+    {
+      "ccv": "DA",
+      "id": "402162",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "406522": [
+    {
+      "ccv": "DA",
+      "id": "406522",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402808": [
+    {
+      "ccv": "DA",
+      "id": "402808",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406593": [
+    {
+      "ccv": "DA",
+      "id": "406593",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406578": [
+    {
+      "ccv": "DA",
+      "id": "406578",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "406627": [
+    {
+      "ccv": "DA",
+      "id": "406627",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402356": [
+    {
+      "ccv": "DA",
+      "id": "402356",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "404909": [
+    {
+      "ccv": "DA",
+      "id": "404909",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "403189": [
+    {
+      "ccv": "DA",
+      "id": "403189",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406695": [
+    {
+      "ccv": "DA",
+      "id": "406695",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406524": [
+    {
+      "ccv": "DA",
+      "id": "406524",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406661": [
+    {
+      "ccv": "DA",
+      "id": "406661",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402350": [
+    {
+      "ccv": "DA",
+      "id": "402350",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "405078": [
+    {
+      "ccv": "DA",
+      "id": "405078",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406665": [
+    {
+      "ccv": "DA",
+      "id": "406665",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404924": [
+    {
+      "ccv": "DA",
+      "id": "404924",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "403310": [
+    {
+      "ccv": "DA",
+      "id": "403310",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402862": [
+    {
+      "ccv": "DA",
+      "id": "402862",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402496": [
+    {
+      "ccv": "DA",
+      "id": "402496",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402353": [
+    {
+      "ccv": "DA",
+      "id": "402353",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "406467": [
+    {
+      "ccv": "DA",
+      "id": "406467",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402389": [
+    {
+      "ccv": "DA",
+      "id": "402389",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "406534": [
+    {
+      "ccv": "DA",
+      "id": "406534",
+      "currency": "Gem",
+      "amount": 400,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404913": [
+    {
+      "ccv": "DA",
+      "id": "404913",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "404914": [
+    {
+      "ccv": "DA",
+      "id": "404914",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "404870": [
+    {
+      "ccv": "DA",
+      "id": "404870",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402053": [
+    {
+      "ccv": "DA",
+      "id": "402053",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "405557": [
+    {
+      "ccv": "DA",
+      "id": "405557",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "405016": [
+    {
+      "ccv": "DA",
+      "id": "405016",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402008": [
+    {
+      "ccv": "DA",
+      "id": "402008",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406568": [
+    {
+      "ccv": "DA",
+      "id": "406568",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406555": [
+    {
+      "ccv": "DA",
+      "id": "406555",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "403359": [
+    {
+      "ccv": "DA",
+      "id": "403359",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402723": [
+    {
+      "ccv": "DA",
+      "id": "402723",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "404494": [
+    {
+      "ccv": "DA",
+      "id": "404494",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406690": [
+    {
+      "ccv": "DA",
+      "id": "406690",
+      "currency": "Gem",
+      "amount": 400,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402594": [
+    {
+      "ccv": "DA",
+      "id": "402594",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402679": [
+    {
+      "ccv": "DA",
+      "id": "402679",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "403390": [
+    {
+      "ccv": "DA",
+      "id": "403390",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "403389": [
+    {
+      "ccv": "DA",
+      "id": "403389",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "138444": [
+    {
+      "ccv": "DA",
+      "id": "138444",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402259": [
+    {
+      "ccv": "DA",
+      "id": "402259",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402769": [
+    {
+      "ccv": "DA",
+      "id": "402769",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404127": [
+    {
+      "ccv": "DA",
+      "id": "404127",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402416": [
+    {
+      "ccv": "DA",
+      "id": "402416",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "405215": [
+    {
+      "ccv": "DA",
+      "id": "405215",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402407": [
+    {
+      "ccv": "DA",
+      "id": "402407",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404491": [
+    {
+      "ccv": "DA",
+      "id": "404491",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402951": [
+    {
+      "ccv": "DA",
+      "id": "402951",
+      "currency": "Gem",
+      "amount": 400,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406597": [
+    {
+      "ccv": "DA",
+      "id": "406597",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406700": [
+    {
+      "ccv": "DA",
+      "id": "406700",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402953": [
+    {
+      "ccv": "DA",
+      "id": "402953",
+      "currency": "Gem",
+      "amount": 400,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "407935": [
+    {
+      "ccv": "DA",
+      "id": "407935",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "162091": [
+    {
+      "ccv": "DA",
+      "id": "162091",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406664": [
+    {
+      "ccv": "DA",
+      "id": "406664",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406523": [
+    {
+      "ccv": "DA",
+      "id": "406523",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402913": [
+    {
+      "ccv": "DA",
+      "id": "402913",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "406117": [
+    {
+      "ccv": "DA",
+      "id": "406117",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404456": [
+    {
+      "ccv": "DA",
+      "id": "404456",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "405918": [
+    {
+      "ccv": "DA",
+      "id": "405918",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "405070": [
+    {
+      "ccv": "DA",
+      "id": "405070",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "406625": [
+    {
+      "ccv": "DA",
+      "id": "406625",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402397": [
+    {
+      "ccv": "DA",
+      "id": "402397",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "405975": [
+    {
+      "ccv": "DA",
+      "id": "405975",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406559": [
+    {
+      "ccv": "DA",
+      "id": "406559",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406543": [
+    {
+      "ccv": "DA",
+      "id": "406543",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402057": [
+    {
+      "ccv": "DA",
+      "id": "402057",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "405092": [
+    {
+      "ccv": "DA",
+      "id": "405092",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402473": [
+    {
+      "ccv": "DA",
+      "id": "402473",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "403032": [
+    {
+      "ccv": "DA",
+      "id": "403032",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "408198": [
+    {
+      "ccv": "DA",
+      "id": "408198",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402619": [
+    {
+      "ccv": "DA",
+      "id": "402619",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406645": [
+    {
+      "ccv": "DA",
+      "id": "406645",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402649": [
+    {
+      "ccv": "DA",
+      "id": "402649",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404849": [
+    {
+      "ccv": "DA",
+      "id": "404849",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "405007": [
+    {
+      "ccv": "DA",
+      "id": "405007",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402349": [
+    {
+      "ccv": "DA",
+      "id": "402349",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "406483": [
+    {
+      "ccv": "DA",
+      "id": "406483",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "404985": [
+    {
+      "ccv": "DA",
+      "id": "404985",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "404980": [
+    {
+      "ccv": "DA",
+      "id": "404980",
+      "currency": "Gem",
+      "amount": 400,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402608": [
+    {
+      "ccv": "DA",
+      "id": "402608",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402603": [
+    {
+      "ccv": "DA",
+      "id": "402603",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402351": [
+    {
+      "ccv": "DA",
+      "id": "402351",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402391": [
+    {
+      "ccv": "DA",
+      "id": "402391",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "406649": [
+    {
+      "ccv": "DA",
+      "id": "406649",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402677": [
+    {
+      "ccv": "DA",
+      "id": "402677",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402944": [
+    {
+      "ccv": "DA",
+      "id": "402944",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402907": [
+    {
+      "ccv": "DA",
+      "id": "402907",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406519": [
+    {
+      "ccv": "DA",
+      "id": "406519",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "403235": [
+    {
+      "ccv": "DA",
+      "id": "403235",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404488": [
+    {
+      "ccv": "DA",
+      "id": "404488",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402452": [
+    {
+      "ccv": "DA",
+      "id": "402452",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402577": [
+    {
+      "ccv": "DA",
+      "id": "402577",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406676": [
+    {
+      "ccv": "DA",
+      "id": "406676",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404299": [
+    {
+      "ccv": "DA",
+      "id": "404299",
+      "currency": "Gem",
+      "amount": 400,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402087": [
+    {
+      "ccv": "DA",
+      "id": "402087",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406642": [
+    {
+      "ccv": "DA",
+      "id": "406642",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404869": [
+    {
+      "ccv": "DA",
+      "id": "404869",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402471": [
+    {
+      "ccv": "DA",
+      "id": "402471",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "406659": [
+    {
+      "ccv": "DA",
+      "id": "406659",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404165": [
+    {
+      "ccv": "DA",
+      "id": "404165",
+      "currency": "Gem",
+      "amount": 400,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406598": [
+    {
+      "ccv": "DA",
+      "id": "406598",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404112": [
+    {
+      "ccv": "DA",
+      "id": "404112",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402111": [
+    {
+      "ccv": "DA",
+      "id": "402111",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402003": [
+    {
+      "ccv": "DA",
+      "id": "402003",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402163": [
+    {
+      "ccv": "DA",
+      "id": "402163",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "405058": [
+    {
+      "ccv": "DA",
+      "id": "405058",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402200": [
+    {
+      "ccv": "DA",
+      "id": "402200",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402243": [
+    {
+      "ccv": "DA",
+      "id": "402243",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404114": [
+    {
+      "ccv": "DA",
+      "id": "404114",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "405594": [
+    {
+      "ccv": "DA",
+      "id": "405594",
+      "currency": "Gem",
+      "amount": 400,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "401425": [
+    {
+      "ccv": "DA",
+      "id": "401425",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "403356": [
+    {
+      "ccv": "DA",
+      "id": "403356",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402940": [
+    {
+      "ccv": "DA",
+      "id": "402940",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "405089": [
+    {
+      "ccv": "DA",
+      "id": "405089",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "404831": [
+    {
+      "ccv": "DA",
+      "id": "404831",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402050": [
+    {
+      "ccv": "DA",
+      "id": "402050",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "405021": [
+    {
+      "ccv": "DA",
+      "id": "405021",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402399": [
+    {
+      "ccv": "DA",
+      "id": "402399",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402905": [
+    {
+      "ccv": "DA",
+      "id": "402905",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "121609": [
+    {
+      "ccv": "DA",
+      "id": "121609",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402932": [
+    {
+      "ccv": "DA",
+      "id": "402932",
+      "currency": "Gem",
+      "amount": 400,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402863": [
+    {
+      "ccv": "DA",
+      "id": "402863",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406683": [
+    {
+      "ccv": "DA",
+      "id": "406683",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406549": [
+    {
+      "ccv": "DA",
+      "id": "406549",
+      "currency": "Gem",
+      "amount": 400,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402096": [
+    {
+      "ccv": "DA",
+      "id": "402096",
+      "currency": "Gem",
+      "amount": 400,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406575": [
+    {
+      "ccv": "DA",
+      "id": "406575",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402474": [
+    {
+      "ccv": "DA",
+      "id": "402474",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402482": [
+    {
+      "ccv": "DA",
+      "id": "402482",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "404084": [
+    {
+      "ccv": "DA",
+      "id": "404084",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406482": [
+    {
+      "ccv": "DA",
+      "id": "406482",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402607": [
+    {
+      "ccv": "DA",
+      "id": "402607",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404082": [
+    {
+      "ccv": "DA",
+      "id": "404082",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "405561": [
+    {
+      "ccv": "DA",
+      "id": "405561",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404911": [
+    {
+      "ccv": "DA",
+      "id": "404911",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "404121": [
+    {
+      "ccv": "DA",
+      "id": "404121",
+      "currency": "Gem",
+      "amount": 400,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "405062": [
+    {
+      "ccv": "DA",
+      "id": "405062",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402395": [
+    {
+      "ccv": "DA",
+      "id": "402395",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "406685": [
+    {
+      "ccv": "DA",
+      "id": "406685",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406512": [
+    {
+      "ccv": "DA",
+      "id": "406512",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "403181": [
+    {
+      "ccv": "DA",
+      "id": "403181",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406680": [
+    {
+      "ccv": "DA",
+      "id": "406680",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "403327": [
+    {
+      "ccv": "DA",
+      "id": "403327",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402475": [
+    {
+      "ccv": "DA",
+      "id": "402475",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "404597": [
+    {
+      "ccv": "DA",
+      "id": "404597",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406652": [
+    {
+      "ccv": "DA",
+      "id": "406652",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402355": [
+    {
+      "ccv": "DA",
+      "id": "402355",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "405077": [
+    {
+      "ccv": "DA",
+      "id": "405077",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404465": [
+    {
+      "ccv": "DA",
+      "id": "404465",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402505": [
+    {
+      "ccv": "DA",
+      "id": "402505",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402934": [
+    {
+      "ccv": "DA",
+      "id": "402934",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406592": [
+    {
+      "ccv": "DA",
+      "id": "406592",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402652": [
+    {
+      "ccv": "DA",
+      "id": "402652",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402377": [
+    {
+      "ccv": "DA",
+      "id": "402377",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406489": [
+    {
+      "ccv": "DA",
+      "id": "406489",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402071": [
+    {
+      "ccv": "DA",
+      "id": "402071",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404936": [
+    {
+      "ccv": "DA",
+      "id": "404936",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "406466": [
+    {
+      "ccv": "DA",
+      "id": "406466",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402615": [
+    {
+      "ccv": "DA",
+      "id": "402615",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404511": [
+    {
+      "ccv": "DA",
+      "id": "404511",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404815": [
+    {
+      "ccv": "DA",
+      "id": "404815",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "405570": [
+    {
+      "ccv": "DA",
+      "id": "405570",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "405578": [
+    {
+      "ccv": "DA",
+      "id": "405578",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404602": [
+    {
+      "ccv": "DA",
+      "id": "404602",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402390": [
+    {
+      "ccv": "DA",
+      "id": "402390",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402082": [
+    {
+      "ccv": "DA",
+      "id": "402082",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406663": [
+    {
+      "ccv": "DA",
+      "id": "406663",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402035": [
+    {
+      "ccv": "DA",
+      "id": "402035",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "406538": [
+    {
+      "ccv": "DA",
+      "id": "406538",
+      "currency": "Gem",
+      "amount": 400,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "406476": [
+    {
+      "ccv": "DA",
+      "id": "406476",
+      "currency": "Gem",
+      "amount": 400,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402792": [
+    {
+      "ccv": "DA",
+      "id": "402792",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402472": [
+    {
+      "ccv": "DA",
+      "id": "402472",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "405036": [
+    {
+      "ccv": "DA",
+      "id": "405036",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402338": [
+    {
+      "ccv": "DA",
+      "id": "402338",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404160": [
+    {
+      "ccv": "DA",
+      "id": "404160",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "403326": [
+    {
+      "ccv": "DA",
+      "id": "403326",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "404085": [
+    {
+      "ccv": "DA",
+      "id": "404085",
+      "currency": "Gem",
+      "amount": 1000,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "402354": [
+    {
+      "ccv": "DA",
+      "id": "402354",
+      "currency": "Gem",
+      "amount": 0,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "402621": [
+    {
+      "ccv": "DA",
+      "id": "402621",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ]
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+<== PlayerInventory.GetProductCatalog(15)
+{
+  "Avatar_Basic_LilianaVess": [
+    {
+      "id": "Avatar_Basic_LilianaVess",
+      "currency": "Gold",
+      "amount": 10,
+      "purchasable": false,
+      "free": true
+    },
+    {
+      "id": "Avatar_Basic_LilianaVess",
+      "currency": "Gem",
+      "amount": 10,
+      "purchasable": false,
+      "free": true
+    }
+  ],
+  "Avatar_Basic_AjaniGoldmane": [
+    {
+      "id": "Avatar_Basic_AjaniGoldmane",
+      "currency": "Gold",
+      "amount": 10,
+      "purchasable": false,
+      "free": true
+    },
+    {
+      "id": "Avatar_Basic_AjaniGoldmane",
+      "currency": "Gem",
+      "amount": 10,
+      "purchasable": false,
+      "free": true
+    }
+  ],
+  "Avatar_Basic_ChandraNalaar": [
+    {
+      "id": "Avatar_Basic_ChandraNalaar",
+      "currency": "Gold",
+      "amount": 10,
+      "purchasable": false,
+      "free": true
+    },
+    {
+      "id": "Avatar_Basic_ChandraNalaar",
+      "currency": "Gem",
+      "amount": 10,
+      "purchasable": false,
+      "free": true
+    }
+  ],
+  "Avatar_Basic_GideonJura": [
+    {
+      "id": "Avatar_Basic_GideonJura",
+      "currency": "Gold",
+      "amount": 10,
+      "purchasable": false,
+      "free": true
+    },
+    {
+      "id": "Avatar_Basic_GideonJura",
+      "currency": "Gem",
+      "amount": 10,
+      "purchasable": false,
+      "free": true
+    }
+  ],
+  "Avatar_Basic_JaceBeleren": [
+    {
+      "id": "Avatar_Basic_JaceBeleren",
+      "currency": "Gold",
+      "amount": 10,
+      "purchasable": false,
+      "free": true
+    },
+    {
+      "id": "Avatar_Basic_JaceBeleren",
+      "currency": "Gem",
+      "amount": 10,
+      "purchasable": false,
+      "free": true
+    }
+  ],
+  "Avatar_Basic_JayaBallard": [
+    {
+      "id": "Avatar_Basic_JayaBallard",
+      "currency": "Gold",
+      "amount": 10,
+      "purchasable": false,
+      "free": true
+    },
+    {
+      "id": "Avatar_Basic_JayaBallard",
+      "currency": "Gem",
+      "amount": 10,
+      "purchasable": false,
+      "free": true
+    }
+  ],
+  "Avatar_Basic_Karn": [
+    {
+      "id": "Avatar_Basic_Karn",
+      "currency": "Gold",
+      "amount": 10,
+      "purchasable": false,
+      "free": true
+    },
+    {
+      "id": "Avatar_Basic_Karn",
+      "currency": "Gem",
+      "amount": 10,
+      "purchasable": false,
+      "free": true
+    }
+  ],
+  "Avatar_Basic_NissaRevane": [
+    {
+      "id": "Avatar_Basic_NissaRevane",
+      "currency": "Gold",
+      "amount": 10,
+      "purchasable": false,
+      "free": true
+    },
+    {
+      "id": "Avatar_Basic_NissaRevane",
+      "currency": "Gem",
+      "amount": 10,
+      "purchasable": false,
+      "free": true
+    }
+  ],
+  "Avatar_Basic_SarkhanVol": [
+    {
+      "id": "Avatar_Basic_SarkhanVol",
+      "currency": "Gold",
+      "amount": 10,
+      "purchasable": false,
+      "free": true
+    },
+    {
+      "id": "Avatar_Basic_SarkhanVol",
+      "currency": "Gem",
+      "amount": 10,
+      "purchasable": false,
+      "free": true
+    }
+  ],
+  "Avatar_Basic_Teferi": [
+    {
+      "id": "Avatar_Basic_Teferi",
+      "currency": "Gold",
+      "amount": 10,
+      "purchasable": false,
+      "free": true
+    },
+    {
+      "id": "Avatar_Basic_Teferi",
+      "currency": "Gem",
+      "amount": 10,
+      "purchasable": false,
+      "free": true
+    }
+  ],
+  "Avatar_Basic_Tezzeret": [
+    {
+      "id": "Avatar_Basic_Tezzeret",
+      "currency": "Gold",
+      "amount": 10,
+      "purchasable": false,
+      "free": true
+    },
+    {
+      "id": "Avatar_Basic_Tezzeret",
+      "currency": "Gem",
+      "amount": 10,
+      "purchasable": false,
+      "free": true
+    }
+  ],
+  "Avatar_Basic_VivienReid": [
+    {
+      "id": "Avatar_Basic_VivienReid",
+      "currency": "Gold",
+      "amount": 10,
+      "purchasable": false,
+      "free": true
+    },
+    {
+      "id": "Avatar_Basic_VivienReid",
+      "currency": "Gem",
+      "amount": 10,
+      "purchasable": false,
+      "free": true
+    }
+  ],
+  "Avatar_Basic_Vannifar": [
+    {
+      "id": "Avatar_Basic_Vannifar",
+      "currency": "Gold",
+      "amount": 10,
+      "purchasable": false,
+      "free": false
+    },
+    {
+      "id": "Avatar_Basic_Vannifar",
+      "currency": "Gem",
+      "amount": 10,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "Avatar_Basic_Kaya": [
+    {
+      "id": "Avatar_Basic_Kaya",
+      "currency": "Gold",
+      "amount": 10,
+      "purchasable": false,
+      "free": false
+    },
+    {
+      "id": "Avatar_Basic_Kaya",
+      "currency": "Gem",
+      "amount": 10,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "Avatar_Basic_Vraska": [
+    {
+      "id": "Avatar_Basic_Vraska",
+      "currency": "Gold",
+      "amount": 10,
+      "purchasable": false,
+      "free": false
+    },
+    {
+      "id": "Avatar_Basic_Vraska",
+      "currency": "Gem",
+      "amount": 10,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "Avatar_Basic_Dovin": [
+    {
+      "id": "Avatar_Basic_Dovin",
+      "currency": "Gold",
+      "amount": 10,
+      "purchasable": false,
+      "free": false
+    },
+    {
+      "id": "Avatar_Basic_Dovin",
+      "currency": "Gem",
+      "amount": 10,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "Avatar_Basic_Trostani": [
+    {
+      "id": "Avatar_Basic_Trostani",
+      "currency": "Gold",
+      "amount": 10,
+      "purchasable": false,
+      "free": false
+    },
+    {
+      "id": "Avatar_Basic_Trostani",
+      "currency": "Gem",
+      "amount": 10,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "Avatar_Basic_Lazav": [
+    {
+      "id": "Avatar_Basic_Lazav",
+      "currency": "Gold",
+      "amount": 10,
+      "purchasable": false,
+      "free": false
+    },
+    {
+      "id": "Avatar_Basic_Lazav",
+      "currency": "Gem",
+      "amount": 10,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "Avatar_Basic_Domri": [
+    {
+      "id": "Avatar_Basic_Domri",
+      "currency": "Gold",
+      "amount": 10,
+      "purchasable": false,
+      "free": false
+    },
+    {
+      "id": "Avatar_Basic_Domri",
+      "currency": "Gem",
+      "amount": 10,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "Avatar_Basic_Ral": [
+    {
+      "id": "Avatar_Basic_Ral",
+      "currency": "Gold",
+      "amount": 10,
+      "purchasable": false,
+      "free": false
+    },
+    {
+      "id": "Avatar_Basic_Ral",
+      "currency": "Gem",
+      "amount": 10,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "Avatar_Basic_Aurelia": [
+    {
+      "id": "Avatar_Basic_Aurelia",
+      "currency": "Gold",
+      "amount": 10,
+      "purchasable": false,
+      "free": false
+    },
+    {
+      "id": "Avatar_Basic_Aurelia",
+      "currency": "Gem",
+      "amount": 10,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "Avatar_Basic_Rakdos": [
+    {
+      "id": "Avatar_Basic_Rakdos",
+      "currency": "Gold",
+      "amount": 10,
+      "purchasable": false,
+      "free": false
+    },
+    {
+      "id": "Avatar_Basic_Rakdos",
+      "currency": "Gem",
+      "amount": 10,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "Avatar_Basic_Huatli": [
+    {
+      "id": "Avatar_Basic_Huatli",
+      "currency": "Gold",
+      "amount": 3000,
+      "purchasable": true,
+      "free": false
+    },
+    {
+      "id": "Avatar_Basic_Huatli",
+      "currency": "Gem",
+      "amount": 500,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "Avatar_Basic_Angrath": [
+    {
+      "id": "Avatar_Basic_Angrath",
+      "currency": "Gold",
+      "amount": 3000,
+      "purchasable": true,
+      "free": false
+    },
+    {
+      "id": "Avatar_Basic_Angrath",
+      "currency": "Gem",
+      "amount": 500,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "Avatar_Basic_Bolas_DragonGod": [
+    {
+      "id": "Avatar_Basic_Bolas_DragonGod",
+      "currency": "Gold",
+      "amount": 3000,
+      "purchasable": false,
+      "free": false
+    },
+    {
+      "id": "Avatar_Basic_Bolas_DragonGod",
+      "currency": "Gem",
+      "amount": 500,
+      "purchasable": false,
+      "free": false
+    }
+  ]
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+<== PlayerInventory.GetProductCatalog(16)
+{
+  "Cardback_Default_ClassicDeckmaster": [
+    {
+      "id": "Cardback_Default_ClassicDeckmaster",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": false,
+      "free": true
+    }
+  ],
+  "Cardback_Default_ClassicNoDeckmaster": [
+    {
+      "id": "Cardback_Default_ClassicNoDeckmaster",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": false,
+      "free": true
+    }
+  ],
+  "CardBack_SolRing": [
+    {
+      "id": "CardBack_SolRing",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "CardBack_LocketAzorius": [
+    {
+      "id": "CardBack_LocketAzorius",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "CardBack_LocketOrzhov": [
+    {
+      "id": "CardBack_LocketOrzhov",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "CardBack_LocketDimir": [
+    {
+      "id": "CardBack_LocketDimir",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "CardBack_LocketIzzet": [
+    {
+      "id": "CardBack_LocketIzzet",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "CardBack_LocketRakdos": [
+    {
+      "id": "CardBack_LocketRakdos",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "CardBack_LocketGolgari": [
+    {
+      "id": "CardBack_LocketGolgari",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "CardBack_LocketGruul": [
+    {
+      "id": "CardBack_LocketGruul",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "CardBack_LocketBoros": [
+    {
+      "id": "CardBack_LocketBoros",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "CardBack_LocketSelesnya": [
+    {
+      "id": "CardBack_LocketSelesnya",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "CardBack_LocketSimic": [
+    {
+      "id": "CardBack_LocketSimic",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "CardBack_MetallicAzorius": [
+    {
+      "id": "CardBack_MetallicAzorius",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "CardBack_MetallicOrzhov": [
+    {
+      "id": "CardBack_MetallicOrzhov",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "CardBack_MetallicDimir": [
+    {
+      "id": "CardBack_MetallicDimir",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "CardBack_MetallicIzzet": [
+    {
+      "id": "CardBack_MetallicIzzet",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "CardBack_MetallicRakdos": [
+    {
+      "id": "CardBack_MetallicRakdos",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "CardBack_MetallicGolgari": [
+    {
+      "id": "CardBack_MetallicGolgari",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "CardBack_MetallicGruul": [
+    {
+      "id": "CardBack_MetallicGruul",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "CardBack_MetallicBoros": [
+    {
+      "id": "CardBack_MetallicBoros",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "CardBack_MetallicSelesnya": [
+    {
+      "id": "CardBack_MetallicSelesnya",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "CardBack_MetallicSimic": [
+    {
+      "id": "CardBack_MetallicSimic",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": true,
+      "free": false
+    }
+  ],
+  "CardBack_EmbossedManaWhite": [
+    {
+      "id": "CardBack_EmbossedManaWhite",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "CardBack_EmbossedManaBlue": [
+    {
+      "id": "CardBack_EmbossedManaBlue",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "CardBack_EmbossedManaBlack": [
+    {
+      "id": "CardBack_EmbossedManaBlack",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "CardBack_EmbossedManaRed": [
+    {
+      "id": "CardBack_EmbossedManaRed",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "CardBack_EmbossedManaGreen": [
+    {
+      "id": "CardBack_EmbossedManaGreen",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "CardBack_EmbossedDefaultArena": [
+    {
+      "id": "CardBack_EmbossedDefaultArena",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "CardBack_EmbossedSetWAR": [
+    {
+      "id": "CardBack_EmbossedSetWAR",
+      "currency": "Gem",
+      "amount": 600,
+      "purchasable": false,
+      "free": false
+    }
+  ],
+  "CardBack_DepthArt_NicolBolasDragonGod": [
+    {
+      "id": "CardBack_DepthArt_NicolBolasDragonGod",
+      "currency": "Gem",
+      "amount": 1200,
+      "purchasable": false,
+      "free": false
+    }
+  ]
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+<== PlayerInventory.GetPlayerArtSkins(17)
+{
+  "122154": "DA",
+  "152027": "DA",
+  "400332": "DA",
+  "400748": "DA",
+  "400831": "DA",
+  "401425": "DA",
+  "402057": "DA",
+  "402192": "DA",
+  "402399": "DA",
+  "402723": "DA",
+  "402913": "DA",
+  "402959": "DA",
+  "403359": "DA",
+  "404135": "DA",
+  "404160": "DA",
+  "404488": "DA",
+  "404796": "DA",
+  "405215": "DA",
+  "405570": "DA"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+<== Quest.GetPlayerQuests(18)
+[
+  {
+    "questId": "27ca3d82-d417-4d47-99ae-1d64840db46c",
+    "goal": 30,
+    "locKey": "Quests/Quest_Orzhov_Domination",
+    "tileResourceId": "d7552d4b-d413-42ee-9edc-21e61b98e52b",
+    "treasureResourceId": "83b335e3-673c-4ce7-975d-c6dd974b43de",
+    "questTrack": "Default",
+    "isNewQuest": false,
+    "endingProgress": 0,
+    "startingProgress": 0,
+    "canSwap": false,
+    "inventoryUpdate": null,
+    "chestDescription": {
+      "image1": "ObjectiveIcon_CoinsLarge",
+      "image2": null,
+      "image3": null,
+      "prefab": "RewardPopup3DIcon_Coin",
+      "referenceId": null,
+      "headerLocKey": "MainNav/EventRewards/Gold_Reward",
+      "descriptionLocKey": null,
+      "quantity": "750",
+      "locParams": {
+        "number1": 750
+      },
+      "availableDate": "0001-01-01T00:00:00"
+    },
+    "hoursWaitAfterComplete": 0
+  }
+]
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+<== Deck.GetPreconDecks(19)
+[
+  {
+    "id": "9e8ab353-15ec-4760-aca3-5390839aca09",
+    "name": "?=?Loc/Decks/Precon/Precon_Azorius_Ascension",
+    "description": "WU Ascend",
+    "format": "precon",
+    "resourceId": "e240f00c-c5a7-434a-99a3-3446d2bc88aa",
+    "deckTileId": null,
+    "mainDeck": [
+      {
+        "id": "66701",
+        "quantity": 1
+      },
+      {
+        "id": "64801",
+        "quantity": 1
+      },
+      {
+        "id": "64881",
+        "quantity": 1
+      },
+      {
+        "id": "67001",
+        "quantity": 1
+      },
+      {
+        "id": "66619",
+        "quantity": 1
+      },
+      {
+        "id": "64887",
+        "quantity": 2
+      },
+      {
+        "id": "64815",
+        "quantity": 1
+      },
+      {
+        "id": "64891",
+        "quantity": 1
+      },
+      {
+        "id": "64817",
+        "quantity": 1
+      },
+      {
+        "id": "65493",
+        "quantity": 1
+      },
+      {
+        "id": "65311",
+        "quantity": 1
+      },
+      {
+        "id": "64903",
+        "quantity": 2
+      },
+      {
+        "id": "66691",
+        "quantity": 1
+      },
+      {
+        "id": "66487",
+        "quantity": 1
+      },
+      {
+        "id": "64825",
+        "quantity": 1
+      },
+      {
+        "id": "64909",
+        "quantity": 1
+      },
+      {
+        "id": "64913",
+        "quantity": 2
+      },
+      {
+        "id": "67017",
+        "quantity": 10
+      },
+      {
+        "id": "65993",
+        "quantity": 1
+      },
+      {
+        "id": "64919",
+        "quantity": 1
+      },
+      {
+        "id": "65469",
+        "quantity": 4
+      },
+      {
+        "id": "66705",
+        "quantity": 1
+      },
+      {
+        "id": "66091",
+        "quantity": 2
+      },
+      {
+        "id": "66013",
+        "quantity": 1
+      },
+      {
+        "id": "67015",
+        "quantity": 9
+      },
+      {
+        "id": "66965",
+        "quantity": 1
+      },
+      {
+        "id": "66103",
+        "quantity": 1
+      },
+      {
+        "id": "66721",
+        "quantity": 2
+      },
+      {
+        "id": "66727",
+        "quantity": 1
+      },
+      {
+        "id": "66663",
+        "quantity": 2
+      },
+      {
+        "id": "66127",
+        "quantity": 1
+      },
+      {
+        "id": "65529",
+        "quantity": 1
+      },
+      {
+        "id": "65575",
+        "quantity": 1
+      },
+      {
+        "id": "64947",
+        "quantity": 1
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-06-29T21:19:17.0352043Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "8a6b493d-fa6d-47d4-9788-bff07d2cfb7e",
+    "name": "?=?Loc/Decks/Precon/Precon_Blue",
+    "description": "Decks/Precon/Precon_July_U",
+    "format": "",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 67256,
+    "mainDeck": [
+      {
+        "id": "67256",
+        "quantity": 1
+      },
+      {
+        "id": "67818",
+        "quantity": 1
+      },
+      {
+        "id": "67240",
+        "quantity": 1
+      },
+      {
+        "id": "67794",
+        "quantity": 3
+      },
+      {
+        "id": "68212",
+        "quantity": 25
+      },
+      {
+        "id": "68150",
+        "quantity": 4
+      },
+      {
+        "id": "68144",
+        "quantity": 1
+      },
+      {
+        "id": "67772",
+        "quantity": 3
+      },
+      {
+        "id": "67770",
+        "quantity": 2
+      },
+      {
+        "id": "67822",
+        "quantity": 2
+      },
+      {
+        "id": "66451",
+        "quantity": 2
+      },
+      {
+        "id": "68156",
+        "quantity": 2
+      },
+      {
+        "id": "66739",
+        "quantity": 3
+      },
+      {
+        "id": "68136",
+        "quantity": 1
+      },
+      {
+        "id": "67208",
+        "quantity": 1
+      },
+      {
+        "id": "67780",
+        "quantity": 2
+      },
+      {
+        "id": "68300",
+        "quantity": 1
+      },
+      {
+        "id": "68256",
+        "quantity": 1
+      },
+      {
+        "id": "68164",
+        "quantity": 1
+      },
+      {
+        "id": "68298",
+        "quantity": 3
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-11-28T01:18:22.2065054Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "12d6cdd0-1040-486a-bec7-ba27eabf4b1f",
+    "name": "?=?Loc/Decks/Precon/Precon_Boros_Assault",
+    "description": "WR Exert",
+    "format": "precon",
+    "resourceId": "551cad78-30e0-4625-b293-e6933d0ea115",
+    "deckTileId": null,
+    "mainDeck": [
+      {
+        "id": "64831",
+        "quantity": 1
+      },
+      {
+        "id": "65643",
+        "quantity": 1
+      },
+      {
+        "id": "65481",
+        "quantity": 1
+      },
+      {
+        "id": "65033",
+        "quantity": 1
+      },
+      {
+        "id": "65483",
+        "quantity": 1
+      },
+      {
+        "id": "66619",
+        "quantity": 1
+      },
+      {
+        "id": "65035",
+        "quantity": 1
+      },
+      {
+        "id": "65039",
+        "quantity": 1
+      },
+      {
+        "id": "64813",
+        "quantity": 1
+      },
+      {
+        "id": "64815",
+        "quantity": 1
+      },
+      {
+        "id": "65049",
+        "quantity": 1
+      },
+      {
+        "id": "65491",
+        "quantity": 2
+      },
+      {
+        "id": "65493",
+        "quantity": 1
+      },
+      {
+        "id": "64819",
+        "quantity": 1
+      },
+      {
+        "id": "66819",
+        "quantity": 1
+      },
+      {
+        "id": "65659",
+        "quantity": 1
+      },
+      {
+        "id": "64833",
+        "quantity": 1
+      },
+      {
+        "id": "65069",
+        "quantity": 1
+      },
+      {
+        "id": "65199",
+        "quantity": 2
+      },
+      {
+        "id": "65993",
+        "quantity": 1
+      },
+      {
+        "id": "66263",
+        "quantity": 1
+      },
+      {
+        "id": "65081",
+        "quantity": 2
+      },
+      {
+        "id": "67021",
+        "quantity": 10
+      },
+      {
+        "id": "65087",
+        "quantity": 1
+      },
+      {
+        "id": "65511",
+        "quantity": 1
+      },
+      {
+        "id": "65325",
+        "quantity": 1
+      },
+      {
+        "id": "67015",
+        "quantity": 10
+      },
+      {
+        "id": "65687",
+        "quantity": 1
+      },
+      {
+        "id": "66021",
+        "quantity": 2
+      },
+      {
+        "id": "65763",
+        "quantity": 2
+      },
+      {
+        "id": "65883",
+        "quantity": 1
+      },
+      {
+        "id": "66659",
+        "quantity": 2
+      },
+      {
+        "id": "65527",
+        "quantity": 1
+      },
+      {
+        "id": "67011",
+        "quantity": 2
+      },
+      {
+        "id": "64867",
+        "quantity": 1
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-06-29T21:19:17.187982Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "f9015348-a0cb-4f96-8847-4d6fd6daacbd",
+    "name": "?=?Loc/Decks/Precon/Precon_NPE_GRN_BG",
+    "description": "Decks/Precon/Precon_NPE_GRN_BG_Desc",
+    "format": "precon",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 67514,
+    "mainDeck": [
+      {
+        "id": "67514",
+        "quantity": 1
+      },
+      {
+        "id": "67866",
+        "quantity": 3
+      },
+      {
+        "id": "68220",
+        "quantity": 10
+      },
+      {
+        "id": "67600",
+        "quantity": 1
+      },
+      {
+        "id": "67460",
+        "quantity": 3
+      },
+      {
+        "id": "68236",
+        "quantity": 10
+      },
+      {
+        "id": "67482",
+        "quantity": 3
+      },
+      {
+        "id": "67272",
+        "quantity": 3
+      },
+      {
+        "id": "67326",
+        "quantity": 1
+      },
+      {
+        "id": "68122",
+        "quantity": 3
+      },
+      {
+        "id": "67464",
+        "quantity": 2
+      },
+      {
+        "id": "67316",
+        "quantity": 2
+      },
+      {
+        "id": "66157",
+        "quantity": 2
+      },
+      {
+        "id": "67292",
+        "quantity": 3
+      },
+      {
+        "id": "67324",
+        "quantity": 3
+      },
+      {
+        "id": "67478",
+        "quantity": 1
+      },
+      {
+        "id": "66901",
+        "quantity": 1
+      },
+      {
+        "id": "66911",
+        "quantity": 1
+      },
+      {
+        "id": "67308",
+        "quantity": 1
+      },
+      {
+        "id": "67320",
+        "quantity": 1
+      },
+      {
+        "id": "66793",
+        "quantity": 1
+      },
+      {
+        "id": "68184",
+        "quantity": 4
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-09-05T00:43:45.9338237Z",
+    "lockedForUse": false,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "230dd82f-f205-432a-8915-906a810df196",
+    "name": "?=?Loc/Decks/Precon/Precon_NPE_GRN_BR",
+    "description": "Decks/Precon/Precon_NPE_GRN_BR_Desc",
+    "format": "precon",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 66839,
+    "mainDeck": [
+      {
+        "id": "66839",
+        "quantity": 1
+      },
+      {
+        "id": "67964",
+        "quantity": 3
+      },
+      {
+        "id": "68228",
+        "quantity": 10
+      },
+      {
+        "id": "68106",
+        "quantity": 3
+      },
+      {
+        "id": "68220",
+        "quantity": 10
+      },
+      {
+        "id": "66483",
+        "quantity": 1
+      },
+      {
+        "id": "67910",
+        "quantity": 3
+      },
+      {
+        "id": "67866",
+        "quantity": 3
+      },
+      {
+        "id": "67912",
+        "quantity": 2
+      },
+      {
+        "id": "67037",
+        "quantity": 2
+      },
+      {
+        "id": "67968",
+        "quantity": 1
+      },
+      {
+        "id": "68268",
+        "quantity": 1
+      },
+      {
+        "id": "67904",
+        "quantity": 1
+      },
+      {
+        "id": "67862",
+        "quantity": 1
+      },
+      {
+        "id": "67390",
+        "quantity": 1
+      },
+      {
+        "id": "67852",
+        "quantity": 2
+      },
+      {
+        "id": "67900",
+        "quantity": 3
+      },
+      {
+        "id": "67934",
+        "quantity": 4
+      },
+      {
+        "id": "68178",
+        "quantity": 4
+      },
+      {
+        "id": "67876",
+        "quantity": 1
+      },
+      {
+        "id": "67992",
+        "quantity": 3
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-09-04T23:20:20.4761192Z",
+    "lockedForUse": false,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "beef51ab-0020-0000-0000-123456789abc",
+    "name": "?=?Loc/Decks/Precon/Precon_XLN-BR-Pirate",
+    "description": "",
+    "format": "precon",
+    "resourceId": "beef51ab-0020-0001-0000-123456789abc",
+    "deckTileId": null,
+    "mainDeck": [
+      {
+        "id": "66253",
+        "quantity": 1
+      },
+      {
+        "id": "66163",
+        "quantity": 1
+      },
+      {
+        "id": "66221",
+        "quantity": 1
+      },
+      {
+        "id": "66249",
+        "quantity": 1
+      },
+      {
+        "id": "66315",
+        "quantity": 1
+      },
+      {
+        "id": "66177",
+        "quantity": 1
+      },
+      {
+        "id": "66227",
+        "quantity": 1
+      },
+      {
+        "id": "66207",
+        "quantity": 1
+      },
+      {
+        "id": "66201",
+        "quantity": 1
+      },
+      {
+        "id": "66259",
+        "quantity": 1
+      },
+      {
+        "id": "66161",
+        "quantity": 1
+      },
+      {
+        "id": "66237",
+        "quantity": 1
+      },
+      {
+        "id": "66273",
+        "quantity": 1
+      },
+      {
+        "id": "66203",
+        "quantity": 1
+      },
+      {
+        "id": "66283",
+        "quantity": 1
+      },
+      {
+        "id": "66233",
+        "quantity": 1
+      },
+      {
+        "id": "66239",
+        "quantity": 1
+      },
+      {
+        "id": "66179",
+        "quantity": 1
+      },
+      {
+        "id": "66187",
+        "quantity": 1
+      },
+      {
+        "id": "66173",
+        "quantity": 1
+      },
+      {
+        "id": "66293",
+        "quantity": 1
+      },
+      {
+        "id": "66289",
+        "quantity": 1
+      },
+      {
+        "id": "66235",
+        "quantity": 1
+      },
+      {
+        "id": "66291",
+        "quantity": 1
+      },
+      {
+        "id": "66189",
+        "quantity": 1
+      },
+      {
+        "id": "66457",
+        "quantity": 1
+      },
+      {
+        "id": "66181",
+        "quantity": 1
+      },
+      {
+        "id": "66263",
+        "quantity": 1
+      },
+      {
+        "id": "66467",
+        "quantity": 1
+      },
+      {
+        "id": "66469",
+        "quantity": 1
+      },
+      {
+        "id": "66261",
+        "quantity": 1
+      },
+      {
+        "id": "66211",
+        "quantity": 1
+      },
+      {
+        "id": "66437",
+        "quantity": 1
+      },
+      {
+        "id": "66453",
+        "quantity": 1
+      },
+      {
+        "id": "66287",
+        "quantity": 1
+      },
+      {
+        "id": "66471",
+        "quantity": 1
+      },
+      {
+        "id": "66483",
+        "quantity": 4
+      },
+      {
+        "id": "66529",
+        "quantity": 12
+      },
+      {
+        "id": "66521",
+        "quantity": 8
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-06-29T21:19:17.2531609Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "fdbf393c-96d5-4b23-af4d-ec79e8560758",
+    "name": "?=?Loc/Decks/Precon/Precon_Dimir_Manipulation",
+    "description": "UB Control",
+    "format": "precon",
+    "resourceId": "712f88b3-fc97-4819-99aa-336b88c3c7ad",
+    "deckTileId": null,
+    "mainDeck": [
+      {
+        "id": "66789",
+        "quantity": 1
+      },
+      {
+        "id": "66051",
+        "quantity": 1
+      },
+      {
+        "id": "64881",
+        "quantity": 1
+      },
+      {
+        "id": "64887",
+        "quantity": 2
+      },
+      {
+        "id": "64891",
+        "quantity": 1
+      },
+      {
+        "id": "65539",
+        "quantity": 1
+      },
+      {
+        "id": "65601",
+        "quantity": 1
+      },
+      {
+        "id": "64903",
+        "quantity": 2
+      },
+      {
+        "id": "67003",
+        "quantity": 2
+      },
+      {
+        "id": "66487",
+        "quantity": 1
+      },
+      {
+        "id": "64983",
+        "quantity": 1
+      },
+      {
+        "id": "64909",
+        "quantity": 1
+      },
+      {
+        "id": "66763",
+        "quantity": 1
+      },
+      {
+        "id": "64913",
+        "quantity": 2
+      },
+      {
+        "id": "66695",
+        "quantity": 1
+      },
+      {
+        "id": "66769",
+        "quantity": 1
+      },
+      {
+        "id": "67017",
+        "quantity": 10
+      },
+      {
+        "id": "64919",
+        "quantity": 1
+      },
+      {
+        "id": "66775",
+        "quantity": 2
+      },
+      {
+        "id": "66705",
+        "quantity": 1
+      },
+      {
+        "id": "66707",
+        "quantity": 1
+      },
+      {
+        "id": "66091",
+        "quantity": 2
+      },
+      {
+        "id": "66093",
+        "quantity": 1
+      },
+      {
+        "id": "66781",
+        "quantity": 1
+      },
+      {
+        "id": "66783",
+        "quantity": 1
+      },
+      {
+        "id": "66721",
+        "quantity": 1
+      },
+      {
+        "id": "66729",
+        "quantity": 1
+      },
+      {
+        "id": "65471",
+        "quantity": 4
+      },
+      {
+        "id": "65575",
+        "quantity": 1
+      },
+      {
+        "id": "67019",
+        "quantity": 9
+      },
+      {
+        "id": "66477",
+        "quantity": 1
+      },
+      {
+        "id": "65585",
+        "quantity": 1
+      },
+      {
+        "id": "66219",
+        "quantity": 1
+      },
+      {
+        "id": "66225",
+        "quantity": 1
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-06-29T21:19:17.3057038Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "55d676c6-c3cf-455f-afc2-5ab8f331ae8d",
+    "name": "?=?Loc/Decks/Precon/Precon_Green",
+    "description": "Decks/Precon/Precon_July_G",
+    "format": "",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 66877,
+    "mainDeck": [
+      {
+        "id": "66877",
+        "quantity": 1
+      },
+      {
+        "id": "68050",
+        "quantity": 1
+      },
+      {
+        "id": "68068",
+        "quantity": 1
+      },
+      {
+        "id": "68286",
+        "quantity": 1
+      },
+      {
+        "id": "68164",
+        "quantity": 1
+      },
+      {
+        "id": "66393",
+        "quantity": 1
+      },
+      {
+        "id": "68018",
+        "quantity": 2
+      },
+      {
+        "id": "68034",
+        "quantity": 2
+      },
+      {
+        "id": "68040",
+        "quantity": 2
+      },
+      {
+        "id": "68054",
+        "quantity": 2
+      },
+      {
+        "id": "67440",
+        "quantity": 2
+      },
+      {
+        "id": "66903",
+        "quantity": 2
+      },
+      {
+        "id": "68092",
+        "quantity": 2
+      },
+      {
+        "id": "68020",
+        "quantity": 3
+      },
+      {
+        "id": "68022",
+        "quantity": 3
+      },
+      {
+        "id": "68056",
+        "quantity": 3
+      },
+      {
+        "id": "68070",
+        "quantity": 3
+      },
+      {
+        "id": "68090",
+        "quantity": 3
+      },
+      {
+        "id": "68236",
+        "quantity": 25
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-09-04T20:48:12.3314753Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "3b71e463-7a19-4a62-8695-855e024e645f",
+    "name": "?=?Loc/Decks/Precon/Precon_Black",
+    "description": "Decks/Precon/Precon_July_B",
+    "format": "Standard",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 67860,
+    "mainDeck": [
+      {
+        "id": "67860",
+        "quantity": 2
+      },
+      {
+        "id": "67866",
+        "quantity": 3
+      },
+      {
+        "id": "67330",
+        "quantity": 1
+      },
+      {
+        "id": "67864",
+        "quantity": 3
+      },
+      {
+        "id": "68220",
+        "quantity": 25
+      },
+      {
+        "id": "67932",
+        "quantity": 3
+      },
+      {
+        "id": "67272",
+        "quantity": 3
+      },
+      {
+        "id": "67918",
+        "quantity": 2
+      },
+      {
+        "id": "67880",
+        "quantity": 2
+      },
+      {
+        "id": "67876",
+        "quantity": 2
+      },
+      {
+        "id": "67900",
+        "quantity": 4
+      },
+      {
+        "id": "67924",
+        "quantity": 2
+      },
+      {
+        "id": "68164",
+        "quantity": 1
+      },
+      {
+        "id": "67930",
+        "quantity": 2
+      },
+      {
+        "id": "67322",
+        "quantity": 1
+      },
+      {
+        "id": "67872",
+        "quantity": 2
+      },
+      {
+        "id": "68528",
+        "quantity": 2
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2019-03-11T20:12:58.7861493Z",
+    "lockedForUse": false,
+    "lockedForEdit": false,
+    "cardBack": null,
+    "isValid": false
+  },
+  {
+    "id": "a8e7c251-ea7a-49d5-8685-619008380aa8",
+    "name": "?=?Loc/Decks/Precon/Precon_Blue",
+    "description": "Decks/Precon/Precon_July_U",
+    "format": "Standard",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 67256,
+    "mainDeck": [
+      {
+        "id": "67256",
+        "quantity": 1
+      },
+      {
+        "id": "67240",
+        "quantity": 1
+      },
+      {
+        "id": "67782",
+        "quantity": 1
+      },
+      {
+        "id": "68212",
+        "quantity": 25
+      },
+      {
+        "id": "68150",
+        "quantity": 3
+      },
+      {
+        "id": "68144",
+        "quantity": 2
+      },
+      {
+        "id": "67772",
+        "quantity": 4
+      },
+      {
+        "id": "67794",
+        "quantity": 4
+      },
+      {
+        "id": "67770",
+        "quantity": 2
+      },
+      {
+        "id": "67822",
+        "quantity": 2
+      },
+      {
+        "id": "68156",
+        "quantity": 4
+      },
+      {
+        "id": "66739",
+        "quantity": 4
+      },
+      {
+        "id": "68136",
+        "quantity": 1
+      },
+      {
+        "id": "68300",
+        "quantity": 1
+      },
+      {
+        "id": "68164",
+        "quantity": 1
+      },
+      {
+        "id": "66051",
+        "quantity": 3
+      },
+      {
+        "id": "67778",
+        "quantity": 1
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2019-03-11T20:12:36.5938111Z",
+    "lockedForUse": false,
+    "lockedForEdit": false,
+    "cardBack": null,
+    "isValid": false
+  },
+  {
+    "id": "2ade24b4-63c4-4604-b72e-603926e1504b",
+    "name": "?=?Loc/Decks/Precon/Precon_Green",
+    "description": "Decks/Precon/Precon_July_G",
+    "format": "Standard",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 66877,
+    "mainDeck": [
+      {
+        "id": "66877",
+        "quantity": 1
+      },
+      {
+        "id": "68050",
+        "quantity": 1
+      },
+      {
+        "id": "67440",
+        "quantity": 3
+      },
+      {
+        "id": "68236",
+        "quantity": 25
+      },
+      {
+        "id": "68034",
+        "quantity": 3
+      },
+      {
+        "id": "68054",
+        "quantity": 3
+      },
+      {
+        "id": "68056",
+        "quantity": 2
+      },
+      {
+        "id": "68022",
+        "quantity": 4
+      },
+      {
+        "id": "68020",
+        "quantity": 2
+      },
+      {
+        "id": "68092",
+        "quantity": 2
+      },
+      {
+        "id": "68164",
+        "quantity": 1
+      },
+      {
+        "id": "68066",
+        "quantity": 1
+      },
+      {
+        "id": "68090",
+        "quantity": 3
+      },
+      {
+        "id": "68070",
+        "quantity": 3
+      },
+      {
+        "id": "68018",
+        "quantity": 2
+      },
+      {
+        "id": "68024",
+        "quantity": 2
+      },
+      {
+        "id": "68076",
+        "quantity": 2
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2019-03-11T20:12:08.0972783Z",
+    "lockedForUse": false,
+    "lockedForEdit": false,
+    "cardBack": null,
+    "isValid": false
+  },
+  {
+    "id": "3e38f7da-22bc-46c7-aa8f-624b98c2d113",
+    "name": "?=?Loc/Decks/Precon/Precon_Red",
+    "description": "Decks/Precon/Precon_July_R",
+    "format": "Standard",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 67978,
+    "mainDeck": [
+      {
+        "id": "67978",
+        "quantity": 1
+      },
+      {
+        "id": "67950",
+        "quantity": 1
+      },
+      {
+        "id": "68012",
+        "quantity": 3
+      },
+      {
+        "id": "68228",
+        "quantity": 25
+      },
+      {
+        "id": "67964",
+        "quantity": 4
+      },
+      {
+        "id": "67972",
+        "quantity": 3
+      },
+      {
+        "id": "68276",
+        "quantity": 3
+      },
+      {
+        "id": "68164",
+        "quantity": 1
+      },
+      {
+        "id": "68002",
+        "quantity": 3
+      },
+      {
+        "id": "67660",
+        "quantity": 2
+      },
+      {
+        "id": "67992",
+        "quantity": 4
+      },
+      {
+        "id": "66241",
+        "quantity": 3
+      },
+      {
+        "id": "68014",
+        "quantity": 2
+      },
+      {
+        "id": "66803",
+        "quantity": 3
+      },
+      {
+        "id": "67980",
+        "quantity": 2
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2019-03-13T21:58:30.7123454Z",
+    "lockedForUse": false,
+    "lockedForEdit": false,
+    "cardBack": null,
+    "isValid": false
+  },
+  {
+    "id": "89622fa6-abf0-409e-b585-0f56d8514a77",
+    "name": "?=?Loc/Decks/Precon/Precon_White",
+    "description": "Decks/Precon/Precon_July_W",
+    "format": "Standard",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 69110,
+    "mainDeck": [
+      {
+        "id": "69110",
+        "quantity": 1
+      },
+      {
+        "id": "67726",
+        "quantity": 1
+      },
+      {
+        "id": "67730",
+        "quantity": 3
+      },
+      {
+        "id": "68786",
+        "quantity": 1
+      },
+      {
+        "id": "67706",
+        "quantity": 1
+      },
+      {
+        "id": "68164",
+        "quantity": 1
+      },
+      {
+        "id": "69108",
+        "quantity": 1
+      },
+      {
+        "id": "68767",
+        "quantity": 1
+      },
+      {
+        "id": "67700",
+        "quantity": 3
+      },
+      {
+        "id": "67744",
+        "quantity": 2
+      },
+      {
+        "id": "67170",
+        "quantity": 2
+      },
+      {
+        "id": "68252",
+        "quantity": 3
+      },
+      {
+        "id": "67760",
+        "quantity": 3
+      },
+      {
+        "id": "67742",
+        "quantity": 2
+      },
+      {
+        "id": "68769",
+        "quantity": 3
+      },
+      {
+        "id": "68204",
+        "quantity": 25
+      },
+      {
+        "id": "67696",
+        "quantity": 2
+      },
+      {
+        "id": "67738",
+        "quantity": 2
+      },
+      {
+        "id": "66043",
+        "quantity": 3
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2019-03-11T20:11:41.6511404Z",
+    "lockedForUse": false,
+    "lockedForEdit": false,
+    "cardBack": null,
+    "isValid": false
+  },
+  {
+    "id": "9d12ba01-7167-46b6-a0ca-2c321403735b",
+    "name": "?=?Loc/Decks/Precon/Precon_White",
+    "description": "Decks/Precon/Precon_July_W",
+    "format": "",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 68250,
+    "mainDeck": [
+      {
+        "id": "68250",
+        "quantity": 1
+      },
+      {
+        "id": "67726",
+        "quantity": 1
+      },
+      {
+        "id": "66677",
+        "quantity": 1
+      },
+      {
+        "id": "68786",
+        "quantity": 1
+      },
+      {
+        "id": "67706",
+        "quantity": 1
+      },
+      {
+        "id": "68164",
+        "quantity": 1
+      },
+      {
+        "id": "69108",
+        "quantity": 1
+      },
+      {
+        "id": "69110",
+        "quantity": 1
+      },
+      {
+        "id": "68767",
+        "quantity": 1
+      },
+      {
+        "id": "67700",
+        "quantity": 2
+      },
+      {
+        "id": "67718",
+        "quantity": 2
+      },
+      {
+        "id": "67728",
+        "quantity": 2
+      },
+      {
+        "id": "67162",
+        "quantity": 2
+      },
+      {
+        "id": "67170",
+        "quantity": 2
+      },
+      {
+        "id": "68252",
+        "quantity": 2
+      },
+      {
+        "id": "67760",
+        "quantity": 2
+      },
+      {
+        "id": "66641",
+        "quantity": 3
+      },
+      {
+        "id": "67742",
+        "quantity": 3
+      },
+      {
+        "id": "67756",
+        "quantity": 3
+      },
+      {
+        "id": "68769",
+        "quantity": 3
+      },
+      {
+        "id": "68204",
+        "quantity": 25
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-08-24T23:27:13.5934964Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "442d5b34-9488-4e88-9a5e-8e3b50b8ad6c",
+    "name": "?=?Loc/Decks/Precon/Precon_Red",
+    "description": "Decks/Precon/Precon_July_R",
+    "format": "",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 67978,
+    "mainDeck": [
+      {
+        "id": "67978",
+        "quantity": 1
+      },
+      {
+        "id": "67950",
+        "quantity": 1
+      },
+      {
+        "id": "66235",
+        "quantity": 1
+      },
+      {
+        "id": "68276",
+        "quantity": 3
+      },
+      {
+        "id": "68228",
+        "quantity": 25
+      },
+      {
+        "id": "67964",
+        "quantity": 3
+      },
+      {
+        "id": "68012",
+        "quantity": 2
+      },
+      {
+        "id": "67986",
+        "quantity": 2
+      },
+      {
+        "id": "67972",
+        "quantity": 3
+      },
+      {
+        "id": "67998",
+        "quantity": 2
+      },
+      {
+        "id": "68014",
+        "quantity": 2
+      },
+      {
+        "id": "68164",
+        "quantity": 1
+      },
+      {
+        "id": "68000",
+        "quantity": 1
+      },
+      {
+        "id": "68002",
+        "quantity": 3
+      },
+      {
+        "id": "67960",
+        "quantity": 2
+      },
+      {
+        "id": "67660",
+        "quantity": 3
+      },
+      {
+        "id": "67992",
+        "quantity": 3
+      },
+      {
+        "id": "66241",
+        "quantity": 2
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-11-28T01:18:16.749387Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "59f700de-2107-4b8d-b3f1-965e1114e46c",
+    "name": "?=?Loc/Decks/Precon/Precon_Golgari_Exploration",
+    "description": "UB Explore",
+    "format": "precon",
+    "resourceId": "e450c5db-8552-44dd-8ed5-7628b8a4bd90",
+    "deckTileId": null,
+    "mainDeck": [
+      {
+        "id": "66401",
+        "quantity": 3
+      },
+      {
+        "id": "66163",
+        "quantity": 1
+      },
+      {
+        "id": "65601",
+        "quantity": 1
+      },
+      {
+        "id": "66345",
+        "quantity": 1
+      },
+      {
+        "id": "66873",
+        "quantity": 1
+      },
+      {
+        "id": "64983",
+        "quantity": 1
+      },
+      {
+        "id": "67023",
+        "quantity": 10
+      },
+      {
+        "id": "67007",
+        "quantity": 4
+      },
+      {
+        "id": "66763",
+        "quantity": 1
+      },
+      {
+        "id": "65871",
+        "quantity": 1
+      },
+      {
+        "id": "65875",
+        "quantity": 1
+      },
+      {
+        "id": "66769",
+        "quantity": 1
+      },
+      {
+        "id": "66353",
+        "quantity": 2
+      },
+      {
+        "id": "66943",
+        "quantity": 1
+      },
+      {
+        "id": "66187",
+        "quantity": 3
+      },
+      {
+        "id": "66773",
+        "quantity": 1
+      },
+      {
+        "id": "66363",
+        "quantity": 1
+      },
+      {
+        "id": "66775",
+        "quantity": 2
+      },
+      {
+        "id": "66901",
+        "quantity": 1
+      },
+      {
+        "id": "66781",
+        "quantity": 1
+      },
+      {
+        "id": "66783",
+        "quantity": 1
+      },
+      {
+        "id": "65167",
+        "quantity": 1
+      },
+      {
+        "id": "66207",
+        "quantity": 2
+      },
+      {
+        "id": "66467",
+        "quantity": 1
+      },
+      {
+        "id": "65747",
+        "quantity": 1
+      },
+      {
+        "id": "66911",
+        "quantity": 1
+      },
+      {
+        "id": "66913",
+        "quantity": 1
+      },
+      {
+        "id": "66391",
+        "quantity": 2
+      },
+      {
+        "id": "66791",
+        "quantity": 1
+      },
+      {
+        "id": "65183",
+        "quantity": 1
+      },
+      {
+        "id": "66225",
+        "quantity": 1
+      },
+      {
+        "id": "67019",
+        "quantity": 9
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-06-29T21:19:17.5765651Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "892a9702-5cb6-42c2-ab4e-9798bafd8660",
+    "name": "?=?Loc/Decks/Precon/Precon_Grim_Captains_Call",
+    "description": "Community Decklist",
+    "format": "precon",
+    "resourceId": "ec1a13d7-fed8-47dc-8e88-3bc2ce834567",
+    "deckTileId": null,
+    "mainDeck": [
+      {
+        "id": "66491",
+        "quantity": 4
+      },
+      {
+        "id": "66363",
+        "quantity": 4
+      },
+      {
+        "id": "65999",
+        "quantity": 4
+      },
+      {
+        "id": "66423",
+        "quantity": 3
+      },
+      {
+        "id": "66283",
+        "quantity": 3
+      },
+      {
+        "id": "66375",
+        "quantity": 2
+      },
+      {
+        "id": "66431",
+        "quantity": 1
+      },
+      {
+        "id": "66341",
+        "quantity": 4
+      },
+      {
+        "id": "66369",
+        "quantity": 3
+      },
+      {
+        "id": "66365",
+        "quantity": 4
+      },
+      {
+        "id": "66181",
+        "quantity": 3
+      },
+      {
+        "id": "66433",
+        "quantity": 2
+      },
+      {
+        "id": "66263",
+        "quantity": 3
+      },
+      {
+        "id": "66483",
+        "quantity": 4
+      },
+      {
+        "id": "66493",
+        "quantity": 4
+      },
+      {
+        "id": "66521",
+        "quantity": 2
+      },
+      {
+        "id": "66529",
+        "quantity": 2
+      },
+      {
+        "id": "66537",
+        "quantity": 6
+      },
+      {
+        "id": "66505",
+        "quantity": 2
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-06-29T21:19:17.6408164Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "9e7e71d3-efc9-471a-9620-d8e7f3b1225d",
+    "name": "?=?Loc/Decks/Precon/Precon_NPE_GRN_BG",
+    "description": "Decks/Precon/Precon_NPE_GRN_BG_Desc",
+    "format": "precon",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 67514,
+    "mainDeck": [
+      {
+        "id": "67514",
+        "quantity": 1
+      },
+      {
+        "id": "67866",
+        "quantity": 3
+      },
+      {
+        "id": "68220",
+        "quantity": 10
+      },
+      {
+        "id": "67600",
+        "quantity": 1
+      },
+      {
+        "id": "67460",
+        "quantity": 3
+      },
+      {
+        "id": "68236",
+        "quantity": 10
+      },
+      {
+        "id": "67482",
+        "quantity": 3
+      },
+      {
+        "id": "67272",
+        "quantity": 3
+      },
+      {
+        "id": "67326",
+        "quantity": 1
+      },
+      {
+        "id": "68122",
+        "quantity": 3
+      },
+      {
+        "id": "67464",
+        "quantity": 2
+      },
+      {
+        "id": "67316",
+        "quantity": 2
+      },
+      {
+        "id": "66157",
+        "quantity": 2
+      },
+      {
+        "id": "67292",
+        "quantity": 3
+      },
+      {
+        "id": "67324",
+        "quantity": 3
+      },
+      {
+        "id": "67478",
+        "quantity": 1
+      },
+      {
+        "id": "66901",
+        "quantity": 1
+      },
+      {
+        "id": "66911",
+        "quantity": 1
+      },
+      {
+        "id": "67308",
+        "quantity": 1
+      },
+      {
+        "id": "67320",
+        "quantity": 1
+      },
+      {
+        "id": "66793",
+        "quantity": 1
+      },
+      {
+        "id": "68184",
+        "quantity": 4
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-09-05T00:43:45.9338237Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "a6337781-a35e-499f-a007-d36c147c0e6d",
+    "name": "?=?Loc/Decks/Precon/Precon_NPE_GRN_BR",
+    "description": "Decks/Precon/Precon_NPE_GRN_BR_Desc",
+    "format": "precon",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 66839,
+    "mainDeck": [
+      {
+        "id": "66839",
+        "quantity": 1
+      },
+      {
+        "id": "67964",
+        "quantity": 3
+      },
+      {
+        "id": "68228",
+        "quantity": 10
+      },
+      {
+        "id": "68106",
+        "quantity": 3
+      },
+      {
+        "id": "68220",
+        "quantity": 10
+      },
+      {
+        "id": "66483",
+        "quantity": 1
+      },
+      {
+        "id": "67910",
+        "quantity": 3
+      },
+      {
+        "id": "67866",
+        "quantity": 3
+      },
+      {
+        "id": "67912",
+        "quantity": 2
+      },
+      {
+        "id": "67037",
+        "quantity": 2
+      },
+      {
+        "id": "67968",
+        "quantity": 1
+      },
+      {
+        "id": "68268",
+        "quantity": 1
+      },
+      {
+        "id": "67904",
+        "quantity": 1
+      },
+      {
+        "id": "67862",
+        "quantity": 1
+      },
+      {
+        "id": "67390",
+        "quantity": 1
+      },
+      {
+        "id": "67852",
+        "quantity": 2
+      },
+      {
+        "id": "67900",
+        "quantity": 3
+      },
+      {
+        "id": "67934",
+        "quantity": 4
+      },
+      {
+        "id": "68178",
+        "quantity": 4
+      },
+      {
+        "id": "67876",
+        "quantity": 1
+      },
+      {
+        "id": "67992",
+        "quantity": 3
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-09-04T23:20:20.4761192Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "d99a479f-3657-456e-9266-e8f3be145ff6",
+    "name": "?=?Loc/Decks/Precon/Precon_NPE_GRN_UG",
+    "description": "Decks/Precon/Precon_NPE_GRN_UG_Desc",
+    "format": "precon",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 66945,
+    "mainDeck": [
+      {
+        "id": "66945",
+        "quantity": 1
+      },
+      {
+        "id": "66885",
+        "quantity": 3
+      },
+      {
+        "id": "68236",
+        "quantity": 11
+      },
+      {
+        "id": "67584",
+        "quantity": 1
+      },
+      {
+        "id": "66361",
+        "quantity": 3
+      },
+      {
+        "id": "66101",
+        "quantity": 2
+      },
+      {
+        "id": "68212",
+        "quantity": 9
+      },
+      {
+        "id": "66949",
+        "quantity": 3
+      },
+      {
+        "id": "66723",
+        "quantity": 3
+      },
+      {
+        "id": "66137",
+        "quantity": 3
+      },
+      {
+        "id": "66891",
+        "quantity": 2
+      },
+      {
+        "id": "66135",
+        "quantity": 2
+      },
+      {
+        "id": "66377",
+        "quantity": 3
+      },
+      {
+        "id": "67780",
+        "quantity": 3
+      },
+      {
+        "id": "67828",
+        "quantity": 2
+      },
+      {
+        "id": "66871",
+        "quantity": 1
+      },
+      {
+        "id": "66337",
+        "quantity": 1
+      },
+      {
+        "id": "66889",
+        "quantity": 1
+      },
+      {
+        "id": "66719",
+        "quantity": 1
+      },
+      {
+        "id": "66079",
+        "quantity": 1
+      },
+      {
+        "id": "68202",
+        "quantity": 4
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-09-11T22:42:38.0748505Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "20e340d1-4f92-4679-ba31-d1706f0f2354",
+    "name": "?=?Loc/Decks/Precon/Precon_NPE_GRN_GW",
+    "description": "Decks/Precon/Precon_NPE_GRN_GW_Desc",
+    "format": "precon",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 67146,
+    "mainDeck": [
+      {
+        "id": "67146",
+        "quantity": 1
+      },
+      {
+        "id": "67740",
+        "quantity": 3
+      },
+      {
+        "id": "68204",
+        "quantity": 11
+      },
+      {
+        "id": "66493",
+        "quantity": 1
+      },
+      {
+        "id": "67700",
+        "quantity": 2
+      },
+      {
+        "id": "68054",
+        "quantity": 2
+      },
+      {
+        "id": "68236",
+        "quantity": 9
+      },
+      {
+        "id": "68128",
+        "quantity": 3
+      },
+      {
+        "id": "67128",
+        "quantity": 1
+      },
+      {
+        "id": "68032",
+        "quantity": 3
+      },
+      {
+        "id": "66641",
+        "quantity": 3
+      },
+      {
+        "id": "67708",
+        "quantity": 3
+      },
+      {
+        "id": "66967",
+        "quantity": 1
+      },
+      {
+        "id": "68086",
+        "quantity": 1
+      },
+      {
+        "id": "68068",
+        "quantity": 1
+      },
+      {
+        "id": "67688",
+        "quantity": 1
+      },
+      {
+        "id": "67174",
+        "quantity": 1
+      },
+      {
+        "id": "67720",
+        "quantity": 2
+      },
+      {
+        "id": "67160",
+        "quantity": 1
+      },
+      {
+        "id": "68062",
+        "quantity": 3
+      },
+      {
+        "id": "67718",
+        "quantity": 3
+      },
+      {
+        "id": "68200",
+        "quantity": 4
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-09-04T23:20:31.2844747Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "0d5f6c00-b6a0-40cf-ba5f-47a0fd313f66",
+    "name": "?=?Loc/Decks/Precon/Precon_NPE_GRN_RG",
+    "description": "Decks/Precon/Precon_NPE_GRN_RG_Desc",
+    "format": "precon",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 66325,
+    "mainDeck": [
+      {
+        "id": "66325",
+        "quantity": 1
+      },
+      {
+        "id": "68310",
+        "quantity": 3
+      },
+      {
+        "id": "68236",
+        "quantity": 10
+      },
+      {
+        "id": "66491",
+        "quantity": 1
+      },
+      {
+        "id": "68034",
+        "quantity": 2
+      },
+      {
+        "id": "66275",
+        "quantity": 2
+      },
+      {
+        "id": "68228",
+        "quantity": 9
+      },
+      {
+        "id": "68040",
+        "quantity": 3
+      },
+      {
+        "id": "68110",
+        "quantity": 3
+      },
+      {
+        "id": "66893",
+        "quantity": 2
+      },
+      {
+        "id": "66257",
+        "quantity": 2
+      },
+      {
+        "id": "66811",
+        "quantity": 2
+      },
+      {
+        "id": "66831",
+        "quantity": 1
+      },
+      {
+        "id": "66241",
+        "quantity": 2
+      },
+      {
+        "id": "66847",
+        "quantity": 1
+      },
+      {
+        "id": "66817",
+        "quantity": 1
+      },
+      {
+        "id": "67940",
+        "quantity": 1
+      },
+      {
+        "id": "68064",
+        "quantity": 1
+      },
+      {
+        "id": "68052",
+        "quantity": 1
+      },
+      {
+        "id": "68026",
+        "quantity": 2
+      },
+      {
+        "id": "66263",
+        "quantity": 3
+      },
+      {
+        "id": "67992",
+        "quantity": 3
+      },
+      {
+        "id": "68198",
+        "quantity": 4
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-09-04T23:20:36.8286305Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "4b491a35-03ee-425a-b945-021a74187d08",
+    "name": "?=?Loc/Decks/Precon/Precon_NPE_GRN_RW",
+    "description": "Decks/Precon/Precon_NPE_GRN_RW_Desc",
+    "format": "precon",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 67726,
+    "mainDeck": [
+      {
+        "id": "67726",
+        "quantity": 1
+      },
+      {
+        "id": "67724",
+        "quantity": 3
+      },
+      {
+        "id": "68204",
+        "quantity": 10
+      },
+      {
+        "id": "67582",
+        "quantity": 1
+      },
+      {
+        "id": "67964",
+        "quantity": 3
+      },
+      {
+        "id": "68228",
+        "quantity": 9
+      },
+      {
+        "id": "66645",
+        "quantity": 2
+      },
+      {
+        "id": "67696",
+        "quantity": 2
+      },
+      {
+        "id": "67942",
+        "quantity": 2
+      },
+      {
+        "id": "67738",
+        "quantity": 3
+      },
+      {
+        "id": "68114",
+        "quantity": 3
+      },
+      {
+        "id": "66011",
+        "quantity": 2
+      },
+      {
+        "id": "66235",
+        "quantity": 1
+      },
+      {
+        "id": "67390",
+        "quantity": 1
+      },
+      {
+        "id": "66239",
+        "quantity": 1
+      },
+      {
+        "id": "65997",
+        "quantity": 1
+      },
+      {
+        "id": "67734",
+        "quantity": 1
+      },
+      {
+        "id": "67710",
+        "quantity": 1
+      },
+      {
+        "id": "68010",
+        "quantity": 2
+      },
+      {
+        "id": "67732",
+        "quantity": 1
+      },
+      {
+        "id": "67708",
+        "quantity": 2
+      },
+      {
+        "id": "66263",
+        "quantity": 3
+      },
+      {
+        "id": "67934",
+        "quantity": 1
+      },
+      {
+        "id": "68194",
+        "quantity": 4
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-09-04T23:20:41.0605679Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "cbe2341d-3cff-4cf0-977c-c3a53739349e",
+    "name": "?=?Loc/Decks/Precon/Precon_NPE_GRN_UB",
+    "description": "Decks/Precon/Precon_NPE_GRN_UB_Desc",
+    "format": "precon",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 67276,
+    "mainDeck": [
+      {
+        "id": "67276",
+        "quantity": 1
+      },
+      {
+        "id": "66121",
+        "quantity": 3
+      },
+      {
+        "id": "66765",
+        "quantity": 3
+      },
+      {
+        "id": "66699",
+        "quantity": 3
+      },
+      {
+        "id": "67778",
+        "quantity": 3
+      },
+      {
+        "id": "66185",
+        "quantity": 2
+      },
+      {
+        "id": "66759",
+        "quantity": 2
+      },
+      {
+        "id": "66725",
+        "quantity": 2
+      },
+      {
+        "id": "67790",
+        "quantity": 2
+      },
+      {
+        "id": "66689",
+        "quantity": 2
+      },
+      {
+        "id": "66781",
+        "quantity": 2
+      },
+      {
+        "id": "66753",
+        "quantity": 1
+      },
+      {
+        "id": "66415",
+        "quantity": 1
+      },
+      {
+        "id": "68256",
+        "quantity": 1
+      },
+      {
+        "id": "66069",
+        "quantity": 1
+      },
+      {
+        "id": "66201",
+        "quantity": 1
+      },
+      {
+        "id": "67900",
+        "quantity": 3
+      },
+      {
+        "id": "66057",
+        "quantity": 2
+      },
+      {
+        "id": "68212",
+        "quantity": 10
+      },
+      {
+        "id": "68220",
+        "quantity": 10
+      },
+      {
+        "id": "66485",
+        "quantity": 1
+      },
+      {
+        "id": "68196",
+        "quantity": 4
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-09-04T23:20:04.0607856Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "9f562ea8-5619-432c-9e0c-89cadb9a9159",
+    "name": "?=?Loc/Decks/Precon/Precon_NPE_GRN_UR",
+    "description": "Decks/Precon/Precon_NPE_GRN_UR_Desc",
+    "format": "precon",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 68112,
+    "mainDeck": [
+      {
+        "id": "68112",
+        "quantity": 3
+      },
+      {
+        "id": "67358",
+        "quantity": 3
+      },
+      {
+        "id": "68228",
+        "quantity": 10
+      },
+      {
+        "id": "67598",
+        "quantity": 1
+      },
+      {
+        "id": "67250",
+        "quantity": 3
+      },
+      {
+        "id": "68212",
+        "quantity": 10
+      },
+      {
+        "id": "67970",
+        "quantity": 2
+      },
+      {
+        "id": "67770",
+        "quantity": 2
+      },
+      {
+        "id": "67820",
+        "quantity": 1
+      },
+      {
+        "id": "66277",
+        "quantity": 1
+      },
+      {
+        "id": "67940",
+        "quantity": 1
+      },
+      {
+        "id": "66283",
+        "quantity": 1
+      },
+      {
+        "id": "66071",
+        "quantity": 1
+      },
+      {
+        "id": "66103",
+        "quantity": 1
+      },
+      {
+        "id": "67806",
+        "quantity": 1
+      },
+      {
+        "id": "67780",
+        "quantity": 3
+      },
+      {
+        "id": "66263",
+        "quantity": 2
+      },
+      {
+        "id": "67388",
+        "quantity": 3
+      },
+      {
+        "id": "67824",
+        "quantity": 3
+      },
+      {
+        "id": "67196",
+        "quantity": 2
+      },
+      {
+        "id": "67342",
+        "quantity": 2
+      },
+      {
+        "id": "68186",
+        "quantity": 4
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-09-13T21:17:14.9715362Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "dabbd330-9341-4ff4-bf61-f3d57acaf5a6",
+    "name": "?=?Loc/Decks/Precon/Precon_NPE_GRN_WB",
+    "description": "Decks/Precon/Precon_NPE_GRN_WB_Desc",
+    "format": "precon",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 67690,
+    "mainDeck": [
+      {
+        "id": "67690",
+        "quantity": 3
+      },
+      {
+        "id": "68204",
+        "quantity": 10
+      },
+      {
+        "id": "67586",
+        "quantity": 1
+      },
+      {
+        "id": "65971",
+        "quantity": 3
+      },
+      {
+        "id": "66947",
+        "quantity": 2
+      },
+      {
+        "id": "68220",
+        "quantity": 10
+      },
+      {
+        "id": "66213",
+        "quantity": 3
+      },
+      {
+        "id": "65991",
+        "quantity": 2
+      },
+      {
+        "id": "66407",
+        "quantity": 3
+      },
+      {
+        "id": "67870",
+        "quantity": 2
+      },
+      {
+        "id": "67706",
+        "quantity": 1
+      },
+      {
+        "id": "67930",
+        "quantity": 1
+      },
+      {
+        "id": "67692",
+        "quantity": 2
+      },
+      {
+        "id": "67902",
+        "quantity": 2
+      },
+      {
+        "id": "66647",
+        "quantity": 2
+      },
+      {
+        "id": "67900",
+        "quantity": 3
+      },
+      {
+        "id": "66649",
+        "quantity": 1
+      },
+      {
+        "id": "66223",
+        "quantity": 1
+      },
+      {
+        "id": "67748",
+        "quantity": 1
+      },
+      {
+        "id": "67726",
+        "quantity": 1
+      },
+      {
+        "id": "66205",
+        "quantity": 1
+      },
+      {
+        "id": "66745",
+        "quantity": 1
+      },
+      {
+        "id": "68182",
+        "quantity": 4
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-09-04T23:20:54.5243695Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "95927db5-83b5-4114-91d2-e1d841050cd6",
+    "name": "?=?Loc/Decks/Precon/Precon_NPE_GRN_WU",
+    "description": "Decks/Precon/Precon_NPE_GRN_WU_Desc",
+    "format": "precon",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 66925,
+    "mainDeck": [
+      {
+        "id": "66925",
+        "quantity": 1
+      },
+      {
+        "id": "67794",
+        "quantity": 3
+      },
+      {
+        "id": "68212",
+        "quantity": 11
+      },
+      {
+        "id": "66489",
+        "quantity": 1
+      },
+      {
+        "id": "67228",
+        "quantity": 2
+      },
+      {
+        "id": "68150",
+        "quantity": 4
+      },
+      {
+        "id": "67772",
+        "quantity": 3
+      },
+      {
+        "id": "68172",
+        "quantity": 3
+      },
+      {
+        "id": "67684",
+        "quantity": 2
+      },
+      {
+        "id": "68204",
+        "quantity": 9
+      },
+      {
+        "id": "67548",
+        "quantity": 2
+      },
+      {
+        "id": "68102",
+        "quantity": 3
+      },
+      {
+        "id": "67812",
+        "quantity": 1
+      },
+      {
+        "id": "66707",
+        "quantity": 1
+      },
+      {
+        "id": "65985",
+        "quantity": 1
+      },
+      {
+        "id": "66029",
+        "quantity": 1
+      },
+      {
+        "id": "67176",
+        "quantity": 1
+      },
+      {
+        "id": "67780",
+        "quantity": 2
+      },
+      {
+        "id": "67166",
+        "quantity": 3
+      },
+      {
+        "id": "67646",
+        "quantity": 2
+      },
+      {
+        "id": "68188",
+        "quantity": 4
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-09-04T23:20:58.7966874Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "cb8e5500-70e4-4b92-ba9a-4bcc3238877c",
+    "name": "?=?Loc/Decks/Precon/Precon_Izzet_Spellweaving",
+    "description": "UR Spells",
+    "format": "precon",
+    "resourceId": "78aa4678-c7e3-46fd-8d1f-6df01c99fd4a",
+    "deckTileId": null,
+    "mainDeck": [
+      {
+        "id": "65195",
+        "quantity": 2
+      },
+      {
+        "id": "65643",
+        "quantity": 1
+      },
+      {
+        "id": "65753",
+        "quantity": 2
+      },
+      {
+        "id": "64887",
+        "quantity": 2
+      },
+      {
+        "id": "64891",
+        "quantity": 1
+      },
+      {
+        "id": "64895",
+        "quantity": 2
+      },
+      {
+        "id": "65857",
+        "quantity": 1
+      },
+      {
+        "id": "65863",
+        "quantity": 1
+      },
+      {
+        "id": "66071",
+        "quantity": 1
+      },
+      {
+        "id": "64903",
+        "quantity": 2
+      },
+      {
+        "id": "66487",
+        "quantity": 1
+      },
+      {
+        "id": "66251",
+        "quantity": 1
+      },
+      {
+        "id": "64907",
+        "quantity": 1
+      },
+      {
+        "id": "64913",
+        "quantity": 2
+      },
+      {
+        "id": "67009",
+        "quantity": 4
+      },
+      {
+        "id": "65669",
+        "quantity": 1
+      },
+      {
+        "id": "67017",
+        "quantity": 11
+      },
+      {
+        "id": "64919",
+        "quantity": 1
+      },
+      {
+        "id": "66263",
+        "quantity": 1
+      },
+      {
+        "id": "65081",
+        "quantity": 2
+      },
+      {
+        "id": "65679",
+        "quantity": 1
+      },
+      {
+        "id": "67021",
+        "quantity": 8
+      },
+      {
+        "id": "66705",
+        "quantity": 1
+      },
+      {
+        "id": "66091",
+        "quantity": 2
+      },
+      {
+        "id": "66459",
+        "quantity": 1
+      },
+      {
+        "id": "64929",
+        "quantity": 1
+      },
+      {
+        "id": "65687",
+        "quantity": 1
+      },
+      {
+        "id": "65563",
+        "quantity": 1
+      },
+      {
+        "id": "64937",
+        "quantity": 1
+      },
+      {
+        "id": "66127",
+        "quantity": 1
+      },
+      {
+        "id": "66287",
+        "quantity": 1
+      },
+      {
+        "id": "65575",
+        "quantity": 1
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-06-29T21:19:17.7074919Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "6d06589a-50b0-41c0-b5e9-8f33f7ea6363",
+    "name": "?=?Loc/Decks/Precon/Precon_TwitchCon2018",
+    "description": "Decks/Precon/Precon_TwitchCon2018_desc",
+    "format": "precon",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 68629,
+    "mainDeck": [
+      {
+        "id": "68629",
+        "quantity": 1
+      },
+      {
+        "id": "68467",
+        "quantity": 3
+      },
+      {
+        "id": "68204",
+        "quantity": 3
+      },
+      {
+        "id": "68623",
+        "quantity": 2
+      },
+      {
+        "id": "68236",
+        "quantity": 10
+      },
+      {
+        "id": "68488",
+        "quantity": 4
+      },
+      {
+        "id": "66019",
+        "quantity": 2
+      },
+      {
+        "id": "68491",
+        "quantity": 1
+      },
+      {
+        "id": "68471",
+        "quantity": 1
+      },
+      {
+        "id": "68472",
+        "quantity": 1
+      },
+      {
+        "id": "68584",
+        "quantity": 1
+      },
+      {
+        "id": "68583",
+        "quantity": 1
+      },
+      {
+        "id": "68310",
+        "quantity": 4
+      },
+      {
+        "id": "68618",
+        "quantity": 1
+      },
+      {
+        "id": "68622",
+        "quantity": 2
+      },
+      {
+        "id": "68649",
+        "quantity": 1
+      },
+      {
+        "id": "68669",
+        "quantity": 1
+      },
+      {
+        "id": "68697",
+        "quantity": 4
+      },
+      {
+        "id": "67690",
+        "quantity": 4
+      },
+      {
+        "id": "68475",
+        "quantity": 4
+      },
+      {
+        "id": "68754",
+        "quantity": 1
+      },
+      {
+        "id": "68736",
+        "quantity": 4
+      },
+      {
+        "id": "68200",
+        "quantity": 4
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-10-19T22:46:45.5251658Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "ace05441-d1fc-4c60-84ee-14603c059794",
+    "name": "?=?Loc/Decks/Precon/Precon_TwitchPrime",
+    "description": "Decks/Precon/Precon_TwitchPrime_desc",
+    "format": "precon",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 68614,
+    "mainDeck": [
+      {
+        "id": "68614",
+        "quantity": 1
+      },
+      {
+        "id": "68648",
+        "quantity": 2
+      },
+      {
+        "id": "68204",
+        "quantity": 10
+      },
+      {
+        "id": "68228",
+        "quantity": 11
+      },
+      {
+        "id": "68677",
+        "quantity": 4
+      },
+      {
+        "id": "68617",
+        "quantity": 2
+      },
+      {
+        "id": "68659",
+        "quantity": 2
+      },
+      {
+        "id": "68462",
+        "quantity": 3
+      },
+      {
+        "id": "68670",
+        "quantity": 2
+      },
+      {
+        "id": "68637",
+        "quantity": 2
+      },
+      {
+        "id": "68633",
+        "quantity": 2
+      },
+      {
+        "id": "68663",
+        "quantity": 2
+      },
+      {
+        "id": "68579",
+        "quantity": 2
+      },
+      {
+        "id": "68643",
+        "quantity": 3
+      },
+      {
+        "id": "66641",
+        "quantity": 3
+      },
+      {
+        "id": "68706",
+        "quantity": 1
+      },
+      {
+        "id": "68570",
+        "quantity": 1
+      },
+      {
+        "id": "68664",
+        "quantity": 1
+      },
+      {
+        "id": "68665",
+        "quantity": 1
+      },
+      {
+        "id": "68480",
+        "quantity": 1
+      },
+      {
+        "id": "68724",
+        "quantity": 4
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2019-04-12T22:08:56.991077Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "a310e048-5f62-4edf-bc4f-345ec20458be",
+    "name": "?=?Loc/Decks/Precon/NPE_Black",
+    "description": "Decks/Precon/NPE_Black_Desc",
+    "format": "precon",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 67914,
+    "mainDeck": [
+      {
+        "id": "67914",
+        "quantity": 2
+      },
+      {
+        "id": "67900",
+        "quantity": 1
+      },
+      {
+        "id": "67272",
+        "quantity": 1
+      },
+      {
+        "id": "68164",
+        "quantity": 1
+      },
+      {
+        "id": "67864",
+        "quantity": 1
+      },
+      {
+        "id": "67880",
+        "quantity": 1
+      },
+      {
+        "id": "67882",
+        "quantity": 4
+      },
+      {
+        "id": "66211",
+        "quantity": 2
+      },
+      {
+        "id": "67918",
+        "quantity": 1
+      },
+      {
+        "id": "67866",
+        "quantity": 1
+      },
+      {
+        "id": "67932",
+        "quantity": 3
+      },
+      {
+        "id": "67920",
+        "quantity": 4
+      },
+      {
+        "id": "68150",
+        "quantity": 3
+      },
+      {
+        "id": "67852",
+        "quantity": 2
+      },
+      {
+        "id": "67922",
+        "quantity": 3
+      },
+      {
+        "id": "68220",
+        "quantity": 30
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-09-05T00:43:45.9338237Z",
+    "lockedForUse": false,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "8916f9e5-c8b8-4554-b75a-87eb7f9b98d2",
+    "name": "?=?Loc/Decks/Precon/NPE_Blue",
+    "description": "Decks/Precon/NPE_Blue_Desc",
+    "format": "precon",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 68298,
+    "mainDeck": [
+      {
+        "id": "66739",
+        "quantity": 1
+      },
+      {
+        "id": "67782",
+        "quantity": 4
+      },
+      {
+        "id": "67794",
+        "quantity": 1
+      },
+      {
+        "id": "68212",
+        "quantity": 30
+      },
+      {
+        "id": "68150",
+        "quantity": 4
+      },
+      {
+        "id": "68144",
+        "quantity": 1
+      },
+      {
+        "id": "67772",
+        "quantity": 1
+      },
+      {
+        "id": "67822",
+        "quantity": 2
+      },
+      {
+        "id": "66451",
+        "quantity": 1
+      },
+      {
+        "id": "67780",
+        "quantity": 2
+      },
+      {
+        "id": "68300",
+        "quantity": 1
+      },
+      {
+        "id": "68164",
+        "quantity": 1
+      },
+      {
+        "id": "69112",
+        "quantity": 2
+      },
+      {
+        "id": "68776",
+        "quantity": 4
+      },
+      {
+        "id": "67842",
+        "quantity": 2
+      },
+      {
+        "id": "67816",
+        "quantity": 2
+      },
+      {
+        "id": "67846",
+        "quantity": 1
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-09-05T00:43:45.9338237Z",
+    "lockedForUse": false,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "bb806fbb-c5b3-4c90-ad4f-798afa592016",
+    "name": "?=?Loc/Decks/Precon/NPE_Green",
+    "description": "Decks/Precon/NPE_Green_Desc",
+    "format": "precon",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 68070,
+    "mainDeck": [
+      {
+        "id": "68070",
+        "quantity": 1
+      },
+      {
+        "id": "68040",
+        "quantity": 4
+      },
+      {
+        "id": "68164",
+        "quantity": 1
+      },
+      {
+        "id": "68054",
+        "quantity": 4
+      },
+      {
+        "id": "68020",
+        "quantity": 1
+      },
+      {
+        "id": "68056",
+        "quantity": 3
+      },
+      {
+        "id": "68090",
+        "quantity": 3
+      },
+      {
+        "id": "68150",
+        "quantity": 2
+      },
+      {
+        "id": "68100",
+        "quantity": 4
+      },
+      {
+        "id": "68078",
+        "quantity": 1
+      },
+      {
+        "id": "68028",
+        "quantity": 4
+      },
+      {
+        "id": "68074",
+        "quantity": 2
+      },
+      {
+        "id": "68236",
+        "quantity": 30
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-09-05T00:43:45.9338237Z",
+    "lockedForUse": false,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "5a7e4878-3239-4f16-9081-11a8631c0432",
+    "name": "?=?Loc/Decks/Precon/Precon_NPE_GRN_WU_2",
+    "description": "Decks/Precon/Precon_NPE_GRN_WU_Desc_2",
+    "format": "precon",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 66925,
+    "mainDeck": [
+      {
+        "id": "66925",
+        "quantity": 1
+      },
+      {
+        "id": "66699",
+        "quantity": 3
+      },
+      {
+        "id": "68487",
+        "quantity": 3
+      },
+      {
+        "id": "67744",
+        "quantity": 2
+      },
+      {
+        "id": "68462",
+        "quantity": 2
+      },
+      {
+        "id": "66043",
+        "quantity": 2
+      },
+      {
+        "id": "65987",
+        "quantity": 2
+      },
+      {
+        "id": "67170",
+        "quantity": 2
+      },
+      {
+        "id": "66707",
+        "quantity": 1
+      },
+      {
+        "id": "68475",
+        "quantity": 2
+      },
+      {
+        "id": "65985",
+        "quantity": 1
+      },
+      {
+        "id": "66029",
+        "quantity": 1
+      },
+      {
+        "id": "68480",
+        "quantity": 1
+      },
+      {
+        "id": "66737",
+        "quantity": 1
+      },
+      {
+        "id": "66073",
+        "quantity": 3
+      },
+      {
+        "id": "67780",
+        "quantity": 3
+      },
+      {
+        "id": "67166",
+        "quantity": 3
+      },
+      {
+        "id": "66089",
+        "quantity": 2
+      },
+      {
+        "id": "68188",
+        "quantity": 4
+      },
+      {
+        "id": "68204",
+        "quantity": 10
+      },
+      {
+        "id": "68212",
+        "quantity": 10
+      },
+      {
+        "id": "66489",
+        "quantity": 1
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-11-14T00:58:09.7136032Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "aaf940db-17ff-48f7-8679-5264b8e53742",
+    "name": "?=?Loc/Decks/Precon/NPE_Red",
+    "description": "Decks/Precon/NPE_Red_Desc",
+    "format": "precon",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 67992,
+    "mainDeck": [
+      {
+        "id": "68276",
+        "quantity": 1
+      },
+      {
+        "id": "67992",
+        "quantity": 1
+      },
+      {
+        "id": "68012",
+        "quantity": 2
+      },
+      {
+        "id": "67964",
+        "quantity": 4
+      },
+      {
+        "id": "68228",
+        "quantity": 30
+      },
+      {
+        "id": "67986",
+        "quantity": 4
+      },
+      {
+        "id": "68164",
+        "quantity": 1
+      },
+      {
+        "id": "68002",
+        "quantity": 1
+      },
+      {
+        "id": "67660",
+        "quantity": 2
+      },
+      {
+        "id": "68150",
+        "quantity": 3
+      },
+      {
+        "id": "68784",
+        "quantity": 4
+      },
+      {
+        "id": "67960",
+        "quantity": 2
+      },
+      {
+        "id": "67946",
+        "quantity": 3
+      },
+      {
+        "id": "67980",
+        "quantity": 2
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-09-05T00:43:45.9338237Z",
+    "lockedForUse": false,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "22047ee2-5f09-404d-a584-9179292da92e",
+    "name": "?=?Loc/Decks/Precon/NPE_White",
+    "description": "Decks/Precon/NPE_White_Desc",
+    "format": "precon",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 69110,
+    "mainDeck": [
+      {
+        "id": "68164",
+        "quantity": 1
+      },
+      {
+        "id": "68767",
+        "quantity": 1
+      },
+      {
+        "id": "67700",
+        "quantity": 2
+      },
+      {
+        "id": "67728",
+        "quantity": 2
+      },
+      {
+        "id": "67730",
+        "quantity": 2
+      },
+      {
+        "id": "67742",
+        "quantity": 2
+      },
+      {
+        "id": "68769",
+        "quantity": 3
+      },
+      {
+        "id": "65975",
+        "quantity": 1
+      },
+      {
+        "id": "68804",
+        "quantity": 4
+      },
+      {
+        "id": "68150",
+        "quantity": 2
+      },
+      {
+        "id": "69111",
+        "quantity": 4
+      },
+      {
+        "id": "67692",
+        "quantity": 3
+      },
+      {
+        "id": "67750",
+        "quantity": 3
+      },
+      {
+        "id": "68204",
+        "quantity": 30
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-09-05T00:43:45.9338237Z",
+    "lockedForUse": false,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "8d3f7b2e-cb81-49c2-ad9d-b88b13810075",
+    "name": "?=?Loc/Decks/Precon/Precon_July_BG",
+    "description": "Decks/Precon/Precon_July_Desc_BG",
+    "format": "",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 66401,
+    "mainDeck": [
+      {
+        "id": "66401",
+        "quantity": 4
+      },
+      {
+        "id": "66889",
+        "quantity": 1
+      },
+      {
+        "id": "66187",
+        "quantity": 3
+      },
+      {
+        "id": "67476",
+        "quantity": 1
+      },
+      {
+        "id": "66763",
+        "quantity": 2
+      },
+      {
+        "id": "67286",
+        "quantity": 1
+      },
+      {
+        "id": "66943",
+        "quantity": 1
+      },
+      {
+        "id": "66781",
+        "quantity": 1
+      },
+      {
+        "id": "67266",
+        "quantity": 1
+      },
+      {
+        "id": "68064",
+        "quantity": 1
+      },
+      {
+        "id": "67594",
+        "quantity": 1
+      },
+      {
+        "id": "67600",
+        "quantity": 1
+      },
+      {
+        "id": "65461",
+        "quantity": 4
+      },
+      {
+        "id": "66163",
+        "quantity": 1
+      },
+      {
+        "id": "66207",
+        "quantity": 4
+      },
+      {
+        "id": "66363",
+        "quantity": 2
+      },
+      {
+        "id": "66791",
+        "quantity": 1
+      },
+      {
+        "id": "66391",
+        "quantity": 2
+      },
+      {
+        "id": "66345",
+        "quantity": 1
+      },
+      {
+        "id": "66901",
+        "quantity": 2
+      },
+      {
+        "id": "66467",
+        "quantity": 1
+      },
+      {
+        "id": "67588",
+        "quantity": 1
+      },
+      {
+        "id": "67900",
+        "quantity": 2
+      },
+      {
+        "id": "68072",
+        "quantity": 1
+      },
+      {
+        "id": "68036",
+        "quantity": 2
+      },
+      {
+        "id": "64163",
+        "quantity": 10
+      },
+      {
+        "id": "64151",
+        "quantity": 8
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-06-29T23:21:50.6867692Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "2105c731-b486-4659-86e1-d74286c202ef",
+    "name": "?=?Loc/Decks/Precon/Precon_July_BR",
+    "description": "Decks/Precon/Precon_July_Desc_BR",
+    "format": "",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 66921,
+    "mainDeck": [
+      {
+        "id": "66921",
+        "quantity": 1
+      },
+      {
+        "id": "66449",
+        "quantity": 1
+      },
+      {
+        "id": "66237",
+        "quantity": 1
+      },
+      {
+        "id": "66411",
+        "quantity": 2
+      },
+      {
+        "id": "66251",
+        "quantity": 2
+      },
+      {
+        "id": "66185",
+        "quantity": 2
+      },
+      {
+        "id": "66929",
+        "quantity": 2
+      },
+      {
+        "id": "66761",
+        "quantity": 2
+      },
+      {
+        "id": "66783",
+        "quantity": 1
+      },
+      {
+        "id": "66239",
+        "quantity": 1
+      },
+      {
+        "id": "66457",
+        "quantity": 1
+      },
+      {
+        "id": "66177",
+        "quantity": 1
+      },
+      {
+        "id": "66249",
+        "quantity": 1
+      },
+      {
+        "id": "66827",
+        "quantity": 1
+      },
+      {
+        "id": "66189",
+        "quantity": 1
+      },
+      {
+        "id": "65463",
+        "quantity": 2
+      },
+      {
+        "id": "66819",
+        "quantity": 3
+      },
+      {
+        "id": "66851",
+        "quantity": 1
+      },
+      {
+        "id": "66813",
+        "quantity": 2
+      },
+      {
+        "id": "66765",
+        "quantity": 2
+      },
+      {
+        "id": "66279",
+        "quantity": 2
+      },
+      {
+        "id": "66263",
+        "quantity": 2
+      },
+      {
+        "id": "67900",
+        "quantity": 2
+      },
+      {
+        "id": "64173",
+        "quantity": 2
+      },
+      {
+        "id": "68006",
+        "quantity": 1
+      },
+      {
+        "id": "64151",
+        "quantity": 9
+      },
+      {
+        "id": "64157",
+        "quantity": 12
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-06-29T23:21:54.3041801Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "9a03833d-d464-490f-9770-839660e26883",
+    "name": "?=?Loc/Decks/Precon/Precon_July_GU",
+    "description": "Decks/Precon/Precon_July_Desc_GU",
+    "format": "",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 66083,
+    "mainDeck": [
+      {
+        "id": "66083",
+        "quantity": 1
+      },
+      {
+        "id": "66079",
+        "quantity": 1
+      },
+      {
+        "id": "66933",
+        "quantity": 1
+      },
+      {
+        "id": "66397",
+        "quantity": 1
+      },
+      {
+        "id": "66425",
+        "quantity": 1
+      },
+      {
+        "id": "66363",
+        "quantity": 2
+      },
+      {
+        "id": "66361",
+        "quantity": 2
+      },
+      {
+        "id": "66135",
+        "quantity": 1
+      },
+      {
+        "id": "66101",
+        "quantity": 2
+      },
+      {
+        "id": "66723",
+        "quantity": 2
+      },
+      {
+        "id": "66875",
+        "quantity": 2
+      },
+      {
+        "id": "66719",
+        "quantity": 1
+      },
+      {
+        "id": "66063",
+        "quantity": 2
+      },
+      {
+        "id": "66391",
+        "quantity": 1
+      },
+      {
+        "id": "67216",
+        "quantity": 2
+      },
+      {
+        "id": "66949",
+        "quantity": 2
+      },
+      {
+        "id": "65425",
+        "quantity": 2
+      },
+      {
+        "id": "66909",
+        "quantity": 1
+      },
+      {
+        "id": "66703",
+        "quantity": 2
+      },
+      {
+        "id": "66885",
+        "quantity": 2
+      },
+      {
+        "id": "67516",
+        "quantity": 2
+      },
+      {
+        "id": "67584",
+        "quantity": 1
+      },
+      {
+        "id": "66895",
+        "quantity": 1
+      },
+      {
+        "id": "67802",
+        "quantity": 1
+      },
+      {
+        "id": "67828",
+        "quantity": 1
+      },
+      {
+        "id": "67804",
+        "quantity": 1
+      },
+      {
+        "id": "67824",
+        "quantity": 1
+      },
+      {
+        "id": "64145",
+        "quantity": 11
+      },
+      {
+        "id": "64163",
+        "quantity": 10
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-06-29T23:21:59.9251156Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "df6e8875-05c6-459a-a9e8-7389891ab247",
+    "name": "?=?Loc/Decks/Precon/Precon_July_GW",
+    "description": "Decks/Precon/Precon_July_Desc_GW",
+    "format": "",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 66911,
+    "mainDeck": [
+      {
+        "id": "66911",
+        "quantity": 2
+      },
+      {
+        "id": "67478",
+        "quantity": 1
+      },
+      {
+        "id": "66937",
+        "quantity": 1
+      },
+      {
+        "id": "67440",
+        "quantity": 3
+      },
+      {
+        "id": "67594",
+        "quantity": 1
+      },
+      {
+        "id": "67460",
+        "quantity": 3
+      },
+      {
+        "id": "67466",
+        "quantity": 3
+      },
+      {
+        "id": "67424",
+        "quantity": 1
+      },
+      {
+        "id": "67512",
+        "quantity": 2
+      },
+      {
+        "id": "67174",
+        "quantity": 1
+      },
+      {
+        "id": "67464",
+        "quantity": 2
+      },
+      {
+        "id": "66493",
+        "quantity": 1
+      },
+      {
+        "id": "67462",
+        "quantity": 2
+      },
+      {
+        "id": "66651",
+        "quantity": 2
+      },
+      {
+        "id": "66003",
+        "quantity": 1
+      },
+      {
+        "id": "67592",
+        "quantity": 2
+      },
+      {
+        "id": "67482",
+        "quantity": 2
+      },
+      {
+        "id": "68072",
+        "quantity": 1
+      },
+      {
+        "id": "67702",
+        "quantity": 1
+      },
+      {
+        "id": "67694",
+        "quantity": 1
+      },
+      {
+        "id": "63679",
+        "quantity": 1
+      },
+      {
+        "id": "67692",
+        "quantity": 1
+      },
+      {
+        "id": "67734",
+        "quantity": 1
+      },
+      {
+        "id": "67708",
+        "quantity": 2
+      },
+      {
+        "id": "67760",
+        "quantity": 2
+      },
+      {
+        "id": "64139",
+        "quantity": 8
+      },
+      {
+        "id": "64163",
+        "quantity": 12
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-06-29T23:22:02.7746567Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "badbf9b7-ea49-43e7-af3f-85c14e9a10e2",
+    "name": "?=?Loc/Decks/Precon/Precon_July_RG",
+    "description": "Decks/Precon/Precon_July_Desc_RG",
+    "format": "",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 67496,
+    "mainDeck": [
+      {
+        "id": "67496",
+        "quantity": 2
+      },
+      {
+        "id": "67402",
+        "quantity": 1
+      },
+      {
+        "id": "67494",
+        "quantity": 1
+      },
+      {
+        "id": "67440",
+        "quantity": 3
+      },
+      {
+        "id": "67388",
+        "quantity": 3
+      },
+      {
+        "id": "67334",
+        "quantity": 3
+      },
+      {
+        "id": "67422",
+        "quantity": 3
+      },
+      {
+        "id": "67476",
+        "quantity": 2
+      },
+      {
+        "id": "67342",
+        "quantity": 3
+      },
+      {
+        "id": "67394",
+        "quantity": 2
+      },
+      {
+        "id": "67432",
+        "quantity": 2
+      },
+      {
+        "id": "67472",
+        "quantity": 1
+      },
+      {
+        "id": "67434",
+        "quantity": 1
+      },
+      {
+        "id": "67354",
+        "quantity": 1
+      },
+      {
+        "id": "66491",
+        "quantity": 1
+      },
+      {
+        "id": "67594",
+        "quantity": 1
+      },
+      {
+        "id": "66263",
+        "quantity": 1
+      },
+      {
+        "id": "67940",
+        "quantity": 1
+      },
+      {
+        "id": "67398",
+        "quantity": 1
+      },
+      {
+        "id": "66913",
+        "quantity": 1
+      },
+      {
+        "id": "68110",
+        "quantity": 2
+      },
+      {
+        "id": "67950",
+        "quantity": 1
+      },
+      {
+        "id": "68058",
+        "quantity": 1
+      },
+      {
+        "id": "64157",
+        "quantity": 10
+      },
+      {
+        "id": "64163",
+        "quantity": 12
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-06-29T23:22:06.0515906Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "d0843f1d-d5a2-481c-9565-d2b811a62e5a",
+    "name": "?=?Loc/Decks/Precon/Precon_July_RW",
+    "description": "Decks/Precon/Precon_July_Desc_RW",
+    "format": "",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 67128,
+    "mainDeck": [
+      {
+        "id": "67128",
+        "quantity": 2
+      },
+      {
+        "id": "67396",
+        "quantity": 1
+      },
+      {
+        "id": "67526",
+        "quantity": 1
+      },
+      {
+        "id": "67520",
+        "quantity": 2
+      },
+      {
+        "id": "67400",
+        "quantity": 3
+      },
+      {
+        "id": "67160",
+        "quantity": 2
+      },
+      {
+        "id": "67336",
+        "quantity": 2
+      },
+      {
+        "id": "66641",
+        "quantity": 2
+      },
+      {
+        "id": "66045",
+        "quantity": 1
+      },
+      {
+        "id": "67532",
+        "quantity": 1
+      },
+      {
+        "id": "66659",
+        "quantity": 3
+      },
+      {
+        "id": "67150",
+        "quantity": 1
+      },
+      {
+        "id": "65961",
+        "quantity": 2
+      },
+      {
+        "id": "66427",
+        "quantity": 2
+      },
+      {
+        "id": "66237",
+        "quantity": 1
+      },
+      {
+        "id": "66667",
+        "quantity": 1
+      },
+      {
+        "id": "67562",
+        "quantity": 2
+      },
+      {
+        "id": "66299",
+        "quantity": 1
+      },
+      {
+        "id": "67582",
+        "quantity": 1
+      },
+      {
+        "id": "65415",
+        "quantity": 2
+      },
+      {
+        "id": "64173",
+        "quantity": 2
+      },
+      {
+        "id": "67718",
+        "quantity": 2
+      },
+      {
+        "id": "67752",
+        "quantity": 2
+      },
+      {
+        "id": "64157",
+        "quantity": 10
+      },
+      {
+        "id": "64139",
+        "quantity": 11
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-06-29T23:22:09.8792855Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "641b52a9-e85f-41b2-96f9-e2418f3987ba",
+    "name": "?=?Loc/Decks/Precon/Precon_July_UB",
+    "description": "Decks/Precon/Precon_July_Desc_UB",
+    "format": "",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 67856,
+    "mainDeck": [
+      {
+        "id": "67856",
+        "quantity": 1
+      },
+      {
+        "id": "66789",
+        "quantity": 1
+      },
+      {
+        "id": "66415",
+        "quantity": 1
+      },
+      {
+        "id": "67196",
+        "quantity": 1
+      },
+      {
+        "id": "64887",
+        "quantity": 2
+      },
+      {
+        "id": "64903",
+        "quantity": 2
+      },
+      {
+        "id": "65341",
+        "quantity": 2
+      },
+      {
+        "id": "66487",
+        "quantity": 1
+      },
+      {
+        "id": "66763",
+        "quantity": 1
+      },
+      {
+        "id": "67212",
+        "quantity": 1
+      },
+      {
+        "id": "66091",
+        "quantity": 2
+      },
+      {
+        "id": "65935",
+        "quantity": 4
+      },
+      {
+        "id": "64235",
+        "quantity": 1
+      },
+      {
+        "id": "66477",
+        "quantity": 1
+      },
+      {
+        "id": "67294",
+        "quantity": 1
+      },
+      {
+        "id": "67238",
+        "quantity": 2
+      },
+      {
+        "id": "67590",
+        "quantity": 2
+      },
+      {
+        "id": "67252",
+        "quantity": 1
+      },
+      {
+        "id": "67266",
+        "quantity": 2
+      },
+      {
+        "id": "67286",
+        "quantity": 1
+      },
+      {
+        "id": "66721",
+        "quantity": 1
+      },
+      {
+        "id": "66695",
+        "quantity": 1
+      },
+      {
+        "id": "66781",
+        "quantity": 1
+      },
+      {
+        "id": "66485",
+        "quantity": 1
+      },
+      {
+        "id": "67542",
+        "quantity": 1
+      },
+      {
+        "id": "66051",
+        "quantity": 1
+      },
+      {
+        "id": "67900",
+        "quantity": 2
+      },
+      {
+        "id": "67824",
+        "quantity": 2
+      },
+      {
+        "id": "68124",
+        "quantity": 2
+      },
+      {
+        "id": "67808",
+        "quantity": 2
+      },
+      {
+        "id": "64145",
+        "quantity": 7
+      },
+      {
+        "id": "64151",
+        "quantity": 9
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-06-29T23:22:13.1717456Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "214eb582-1c90-4303-86f4-201bcff76721",
+    "name": "?=?Loc/Decks/Precon/Precon_July_UR",
+    "description": "Decks/Precon/Precon_July_Desc_UR",
+    "format": "",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 67484,
+    "mainDeck": [
+      {
+        "id": "67484",
+        "quantity": 2
+      },
+      {
+        "id": "67222",
+        "quantity": 1
+      },
+      {
+        "id": "66459",
+        "quantity": 1
+      },
+      {
+        "id": "66057",
+        "quantity": 1
+      },
+      {
+        "id": "67388",
+        "quantity": 2
+      },
+      {
+        "id": "66263",
+        "quantity": 2
+      },
+      {
+        "id": "66071",
+        "quantity": 1
+      },
+      {
+        "id": "66277",
+        "quantity": 1
+      },
+      {
+        "id": "67196",
+        "quantity": 2
+      },
+      {
+        "id": "67408",
+        "quantity": 1
+      },
+      {
+        "id": "67238",
+        "quantity": 1
+      },
+      {
+        "id": "67368",
+        "quantity": 1
+      },
+      {
+        "id": "67218",
+        "quantity": 2
+      },
+      {
+        "id": "67358",
+        "quantity": 2
+      },
+      {
+        "id": "67250",
+        "quantity": 3
+      },
+      {
+        "id": "66287",
+        "quantity": 1
+      },
+      {
+        "id": "67208",
+        "quantity": 2
+      },
+      {
+        "id": "66091",
+        "quantity": 2
+      },
+      {
+        "id": "65467",
+        "quantity": 3
+      },
+      {
+        "id": "67598",
+        "quantity": 1
+      },
+      {
+        "id": "67824",
+        "quantity": 2
+      },
+      {
+        "id": "65195",
+        "quantity": 3
+      },
+      {
+        "id": "67954",
+        "quantity": 1
+      },
+      {
+        "id": "67820",
+        "quantity": 1
+      },
+      {
+        "id": "64145",
+        "quantity": 12
+      },
+      {
+        "id": "64157",
+        "quantity": 9
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-06-29T23:22:16.5245809Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "8eab5bb8-f878-4979-aec6-9bc31a675f6c",
+    "name": "?=?Loc/Decks/Precon/Precon_July_WB",
+    "description": "Decks/Precon/Precon_July_Desc_WB",
+    "format": "",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 66793,
+    "mainDeck": [
+      {
+        "id": "66793",
+        "quantity": 1
+      },
+      {
+        "id": "67136",
+        "quantity": 1
+      },
+      {
+        "id": "68126",
+        "quantity": 2
+      },
+      {
+        "id": "65991",
+        "quantity": 1
+      },
+      {
+        "id": "66013",
+        "quantity": 2
+      },
+      {
+        "id": "67158",
+        "quantity": 2
+      },
+      {
+        "id": "66633",
+        "quantity": 2
+      },
+      {
+        "id": "67160",
+        "quantity": 1
+      },
+      {
+        "id": "67266",
+        "quantity": 1
+      },
+      {
+        "id": "67148",
+        "quantity": 1
+      },
+      {
+        "id": "67166",
+        "quantity": 2
+      },
+      {
+        "id": "65993",
+        "quantity": 1
+      },
+      {
+        "id": "67690",
+        "quantity": 4
+      },
+      {
+        "id": "67164",
+        "quantity": 1
+      },
+      {
+        "id": "66775",
+        "quantity": 3
+      },
+      {
+        "id": "66223",
+        "quantity": 1
+      },
+      {
+        "id": "67586",
+        "quantity": 1
+      },
+      {
+        "id": "65465",
+        "quantity": 4
+      },
+      {
+        "id": "67900",
+        "quantity": 1
+      },
+      {
+        "id": "67692",
+        "quantity": 1
+      },
+      {
+        "id": "67750",
+        "quantity": 2
+      },
+      {
+        "id": "67700",
+        "quantity": 1
+      },
+      {
+        "id": "67724",
+        "quantity": 2
+      },
+      {
+        "id": "67754",
+        "quantity": 1
+      },
+      {
+        "id": "67706",
+        "quantity": 2
+      },
+      {
+        "id": "67748",
+        "quantity": 1
+      },
+      {
+        "id": "64139",
+        "quantity": 10
+      },
+      {
+        "id": "64151",
+        "quantity": 8
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-06-29T23:22:20.8364001Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "78472250-cb43-4b2c-a1ca-a383a8b89884",
+    "name": "?=?Loc/Decks/Precon/Precon_July_WU",
+    "description": "Decks/Precon/Precon_July_Desc_WU",
+    "format": "",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 67572,
+    "mainDeck": [
+      {
+        "id": "67572",
+        "quantity": 1
+      },
+      {
+        "id": "67508",
+        "quantity": 2
+      },
+      {
+        "id": "67188",
+        "quantity": 2
+      },
+      {
+        "id": "67544",
+        "quantity": 2
+      },
+      {
+        "id": "67120",
+        "quantity": 1
+      },
+      {
+        "id": "67130",
+        "quantity": 1
+      },
+      {
+        "id": "67526",
+        "quantity": 1
+      },
+      {
+        "id": "67576",
+        "quantity": 2
+      },
+      {
+        "id": "67542",
+        "quantity": 2
+      },
+      {
+        "id": "66979",
+        "quantity": 1
+      },
+      {
+        "id": "66477",
+        "quantity": 1
+      },
+      {
+        "id": "66473",
+        "quantity": 1
+      },
+      {
+        "id": "67564",
+        "quantity": 2
+      },
+      {
+        "id": "66695",
+        "quantity": 1
+      },
+      {
+        "id": "66127",
+        "quantity": 1
+      },
+      {
+        "id": "66985",
+        "quantity": 1
+      },
+      {
+        "id": "66489",
+        "quantity": 1
+      },
+      {
+        "id": "67590",
+        "quantity": 1
+      },
+      {
+        "id": "66487",
+        "quantity": 1
+      },
+      {
+        "id": "67166",
+        "quantity": 2
+      },
+      {
+        "id": "67176",
+        "quantity": 1
+      },
+      {
+        "id": "65469",
+        "quantity": 2
+      },
+      {
+        "id": "65851",
+        "quantity": 2
+      },
+      {
+        "id": "67762",
+        "quantity": 1
+      },
+      {
+        "id": "67684",
+        "quantity": 1
+      },
+      {
+        "id": "67772",
+        "quantity": 2
+      },
+      {
+        "id": "67826",
+        "quantity": 1
+      },
+      {
+        "id": "67818",
+        "quantity": 1
+      },
+      {
+        "id": "68172",
+        "quantity": 2
+      },
+      {
+        "id": "68102",
+        "quantity": 2
+      },
+      {
+        "id": "64145",
+        "quantity": 9
+      },
+      {
+        "id": "64139",
+        "quantity": 9
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-06-29T23:22:23.687626Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "db50d287-ee33-4db6-a53c-301558092c60",
+    "name": "?=?Loc/Decks/Precon/Precon_PW_RNA_1",
+    "description": "Decks/Precon/Precon_PW_RNA_1_Desc",
+    "format": "precon",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 69417,
+    "mainDeck": [
+      {
+        "id": "69417",
+        "quantity": 1
+      },
+      {
+        "id": "69252",
+        "quantity": 1
+      },
+      {
+        "id": "69381",
+        "quantity": 1
+      },
+      {
+        "id": "69420",
+        "quantity": 2
+      },
+      {
+        "id": "69224",
+        "quantity": 2
+      },
+      {
+        "id": "69228",
+        "quantity": 2
+      },
+      {
+        "id": "69233",
+        "quantity": 2
+      },
+      {
+        "id": "69249",
+        "quantity": 1
+      },
+      {
+        "id": "69263",
+        "quantity": 1
+      },
+      {
+        "id": "69272",
+        "quantity": 2
+      },
+      {
+        "id": "69278",
+        "quantity": 1
+      },
+      {
+        "id": "69287",
+        "quantity": 1
+      },
+      {
+        "id": "69301",
+        "quantity": 3
+      },
+      {
+        "id": "69343",
+        "quantity": 3
+      },
+      {
+        "id": "69419",
+        "quantity": 3
+      },
+      {
+        "id": "69397",
+        "quantity": 4
+      },
+      {
+        "id": "69221",
+        "quantity": 2
+      },
+      {
+        "id": "69271",
+        "quantity": 2
+      },
+      {
+        "id": "69418",
+        "quantity": 4
+      },
+      {
+        "id": "69411",
+        "quantity": 11
+      },
+      {
+        "id": "69412",
+        "quantity": 11
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2019-01-10T01:44:18.6206376Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "d010a1e0-c5ab-4fdd-ac20-2237608fb7c5",
+    "name": "?=?Loc/Decks/Precon/Precon_PW_RNA_2",
+    "description": "Decks/Precon/Precon_PW_RNA_2_Desc",
+    "format": "precon",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 69413,
+    "mainDeck": [
+      {
+        "id": "69413",
+        "quantity": 1
+      },
+      {
+        "id": "69157",
+        "quantity": 1
+      },
+      {
+        "id": "69186",
+        "quantity": 1
+      },
+      {
+        "id": "69415",
+        "quantity": 2
+      },
+      {
+        "id": "69135",
+        "quantity": 3
+      },
+      {
+        "id": "69145",
+        "quantity": 2
+      },
+      {
+        "id": "69151",
+        "quantity": 2
+      },
+      {
+        "id": "69154",
+        "quantity": 1
+      },
+      {
+        "id": "69161",
+        "quantity": 1
+      },
+      {
+        "id": "69178",
+        "quantity": 2
+      },
+      {
+        "id": "69188",
+        "quantity": 2
+      },
+      {
+        "id": "69282",
+        "quantity": 1
+      },
+      {
+        "id": "69414",
+        "quantity": 4
+      },
+      {
+        "id": "69416",
+        "quantity": 3
+      },
+      {
+        "id": "69391",
+        "quantity": 4
+      },
+      {
+        "id": "69132",
+        "quantity": 3
+      },
+      {
+        "id": "69152",
+        "quantity": 2
+      },
+      {
+        "id": "69163",
+        "quantity": 2
+      },
+      {
+        "id": "69337",
+        "quantity": 1
+      },
+      {
+        "id": "69409",
+        "quantity": 10
+      },
+      {
+        "id": "69408",
+        "quantity": 12
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-12-20T22:50:06.0938416Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "647c232c-de6c-4241-9571-c54c1fe0378a",
+    "name": "?=?Loc/Decks/Precon/Precon_PW_WAR_UG",
+    "description": "Decks/Precon/Precon_PW_WAR_UG_Desc",
+    "format": "precon",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 69721,
+    "mainDeck": [
+      {
+        "id": "69721",
+        "quantity": 1
+      },
+      {
+        "id": "69519",
+        "quantity": 1
+      },
+      {
+        "id": "69637",
+        "quantity": 1
+      },
+      {
+        "id": "69724",
+        "quantity": 2
+      },
+      {
+        "id": "69683",
+        "quantity": 1
+      },
+      {
+        "id": "69509",
+        "quantity": 2
+      },
+      {
+        "id": "69605",
+        "quantity": 3
+      },
+      {
+        "id": "69624",
+        "quantity": 3
+      },
+      {
+        "id": "69625",
+        "quantity": 1
+      },
+      {
+        "id": "69634",
+        "quantity": 2
+      },
+      {
+        "id": "69654",
+        "quantity": 2
+      },
+      {
+        "id": "69722",
+        "quantity": 4
+      },
+      {
+        "id": "69723",
+        "quantity": 3
+      },
+      {
+        "id": "69406",
+        "quantity": 4
+      },
+      {
+        "id": "69704",
+        "quantity": 4
+      },
+      {
+        "id": "69705",
+        "quantity": 3
+      },
+      {
+        "id": "69706",
+        "quantity": 3
+      },
+      {
+        "id": "69713",
+        "quantity": 3
+      },
+      {
+        "id": "69714",
+        "quantity": 4
+      },
+      {
+        "id": "69715",
+        "quantity": 4
+      },
+      {
+        "id": "69506",
+        "quantity": 1
+      },
+      {
+        "id": "69521",
+        "quantity": 2
+      },
+      {
+        "id": "69604",
+        "quantity": 2
+      },
+      {
+        "id": "69609",
+        "quantity": 2
+      },
+      {
+        "id": "69619",
+        "quantity": 2
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2019-04-17T18:50:16.6340838Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "26ef22fc-af37-432a-b67e-ea531c9dc29e",
+    "name": "?=?Loc/Decks/Precon/Precon_PW_WAR_WB",
+    "description": "Decks/Precon/Precon_PW_WAR_WB_Desc",
+    "format": "precon",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 69716,
+    "mainDeck": [
+      {
+        "id": "69716",
+        "quantity": 1
+      },
+      {
+        "id": "69533",
+        "quantity": 1
+      },
+      {
+        "id": "69658",
+        "quantity": 1
+      },
+      {
+        "id": "69718",
+        "quantity": 2
+      },
+      {
+        "id": "69682",
+        "quantity": 1
+      },
+      {
+        "id": "69455",
+        "quantity": 3
+      },
+      {
+        "id": "69459",
+        "quantity": 4
+      },
+      {
+        "id": "69462",
+        "quantity": 2
+      },
+      {
+        "id": "69473",
+        "quantity": 3
+      },
+      {
+        "id": "69487",
+        "quantity": 2
+      },
+      {
+        "id": "69490",
+        "quantity": 1
+      },
+      {
+        "id": "69561",
+        "quantity": 1
+      },
+      {
+        "id": "69639",
+        "quantity": 3
+      },
+      {
+        "id": "69719",
+        "quantity": 3
+      },
+      {
+        "id": "69401",
+        "quantity": 4
+      },
+      {
+        "id": "69701",
+        "quantity": 4
+      },
+      {
+        "id": "69702",
+        "quantity": 4
+      },
+      {
+        "id": "69703",
+        "quantity": 4
+      },
+      {
+        "id": "69707",
+        "quantity": 3
+      },
+      {
+        "id": "69708",
+        "quantity": 3
+      },
+      {
+        "id": "69709",
+        "quantity": 2
+      },
+      {
+        "id": "69457",
+        "quantity": 1
+      },
+      {
+        "id": "69552",
+        "quantity": 3
+      },
+      {
+        "id": "69717",
+        "quantity": 4
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2019-04-17T18:50:27.0791865Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "46c6d352-81d6-4da9-8593-7136ac6c662d",
+    "name": "?=?Loc/Decks/Precon/Precon_Primal_Sorcery",
+    "description": "Community Decklist",
+    "format": "precon",
+    "resourceId": "95c925e6-5345-48a0-951e-a7af557f3ad2",
+    "deckTileId": null,
+    "mainDeck": [
+      {
+        "id": "66091",
+        "quantity": 4
+      },
+      {
+        "id": "66057",
+        "quantity": 4
+      },
+      {
+        "id": "66095",
+        "quantity": 2
+      },
+      {
+        "id": "66109",
+        "quantity": 3
+      },
+      {
+        "id": "66263",
+        "quantity": 4
+      },
+      {
+        "id": "66055",
+        "quantity": 2
+      },
+      {
+        "id": "66251",
+        "quantity": 3
+      },
+      {
+        "id": "66311",
+        "quantity": 2
+      },
+      {
+        "id": "66459",
+        "quantity": 4
+      },
+      {
+        "id": "66127",
+        "quantity": 1
+      },
+      {
+        "id": "66295",
+        "quantity": 1
+      },
+      {
+        "id": "66093",
+        "quantity": 1
+      },
+      {
+        "id": "66071",
+        "quantity": 3
+      },
+      {
+        "id": "66513",
+        "quantity": 14
+      },
+      {
+        "id": "66529",
+        "quantity": 12
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-06-29T21:19:18.4164594Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "fdabc2fd-dc2e-419d-97ea-8bbaa2064047",
+    "name": "?=?Loc/Decks/Precon/Precon_PW_GRN_BG",
+    "description": "Decks/Precon/Precon_PW_GRN_BG-Desc",
+    "format": "precon",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 68750,
+    "mainDeck": [
+      {
+        "id": "68750",
+        "quantity": 1
+      },
+      {
+        "id": "68584",
+        "quantity": 1
+      },
+      {
+        "id": "68585",
+        "quantity": 1
+      },
+      {
+        "id": "68753",
+        "quantity": 2
+      },
+      {
+        "id": "68523",
+        "quantity": 2
+      },
+      {
+        "id": "68531",
+        "quantity": 1
+      },
+      {
+        "id": "68751",
+        "quantity": 4
+      },
+      {
+        "id": "68535",
+        "quantity": 1
+      },
+      {
+        "id": "68547",
+        "quantity": 3
+      },
+      {
+        "id": "68588",
+        "quantity": 1
+      },
+      {
+        "id": "68595",
+        "quantity": 2
+      },
+      {
+        "id": "68596",
+        "quantity": 1
+      },
+      {
+        "id": "68611",
+        "quantity": 1
+      },
+      {
+        "id": "68752",
+        "quantity": 3
+      },
+      {
+        "id": "68634",
+        "quantity": 2
+      },
+      {
+        "id": "68657",
+        "quantity": 2
+      },
+      {
+        "id": "68662",
+        "quantity": 1
+      },
+      {
+        "id": "68729",
+        "quantity": 2
+      },
+      {
+        "id": "68730",
+        "quantity": 2
+      },
+      {
+        "id": "68528",
+        "quantity": 3
+      },
+      {
+        "id": "68604",
+        "quantity": 2
+      },
+      {
+        "id": "68743",
+        "quantity": 12
+      },
+      {
+        "id": "68745",
+        "quantity": 10
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-12-20T23:05:17.0540297Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "b7393b3d-573f-4d82-a6e7-03ac611b76f2",
+    "name": "?=?Loc/Decks/Precon/Precon_PW_GRN_UR",
+    "description": "Decks/Precon/Precon_PW_GRN_UR_Desc",
+    "format": "precon",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 68746,
+    "mainDeck": [
+      {
+        "id": "68746",
+        "quantity": 1
+      },
+      {
+        "id": "68559",
+        "quantity": 1
+      },
+      {
+        "id": "68510",
+        "quantity": 1
+      },
+      {
+        "id": "68747",
+        "quantity": 2
+      },
+      {
+        "id": "68503",
+        "quantity": 1
+      },
+      {
+        "id": "68507",
+        "quantity": 1
+      },
+      {
+        "id": "68518",
+        "quantity": 1
+      },
+      {
+        "id": "68561",
+        "quantity": 3
+      },
+      {
+        "id": "68562",
+        "quantity": 2
+      },
+      {
+        "id": "68567",
+        "quantity": 2
+      },
+      {
+        "id": "68575",
+        "quantity": 1
+      },
+      {
+        "id": "68635",
+        "quantity": 2
+      },
+      {
+        "id": "68749",
+        "quantity": 3
+      },
+      {
+        "id": "68675",
+        "quantity": 2
+      },
+      {
+        "id": "68732",
+        "quantity": 2
+      },
+      {
+        "id": "68733",
+        "quantity": 2
+      },
+      {
+        "id": "68493",
+        "quantity": 1
+      },
+      {
+        "id": "68504",
+        "quantity": 1
+      },
+      {
+        "id": "68555",
+        "quantity": 2
+      },
+      {
+        "id": "68557",
+        "quantity": 1
+      },
+      {
+        "id": "68748",
+        "quantity": 4
+      },
+      {
+        "id": "68660",
+        "quantity": 1
+      },
+      {
+        "id": "68511",
+        "quantity": 1
+      },
+      {
+        "id": "68744",
+        "quantity": 12
+      },
+      {
+        "id": "68742",
+        "quantity": 10
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-12-20T23:05:13.6481502Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "f9b76071-06c3-4877-808e-ce72dca5eb96",
+    "name": "?=?Loc/Decks/Precon/Precon_Black",
+    "description": "Decks/Precon/Precon_July_B",
+    "format": "",
+    "resourceId": "00000000-0000-0000-0000-000000000000",
+    "deckTileId": 67904,
+    "mainDeck": [
+      {
+        "id": "67904",
+        "quantity": 1
+      },
+      {
+        "id": "68268",
+        "quantity": 1
+      },
+      {
+        "id": "67860",
+        "quantity": 2
+      },
+      {
+        "id": "68164",
+        "quantity": 1
+      },
+      {
+        "id": "67914",
+        "quantity": 1
+      },
+      {
+        "id": "67330",
+        "quantity": 1
+      },
+      {
+        "id": "67864",
+        "quantity": 2
+      },
+      {
+        "id": "67876",
+        "quantity": 2
+      },
+      {
+        "id": "67880",
+        "quantity": 2
+      },
+      {
+        "id": "67882",
+        "quantity": 2
+      },
+      {
+        "id": "66211",
+        "quantity": 2
+      },
+      {
+        "id": "66213",
+        "quantity": 2
+      },
+      {
+        "id": "67924",
+        "quantity": 2
+      },
+      {
+        "id": "67930",
+        "quantity": 2
+      },
+      {
+        "id": "67272",
+        "quantity": 3
+      },
+      {
+        "id": "67866",
+        "quantity": 3
+      },
+      {
+        "id": "67900",
+        "quantity": 3
+      },
+      {
+        "id": "67932",
+        "quantity": 3
+      },
+      {
+        "id": "68220",
+        "quantity": 25
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-09-04T20:48:40.6529949Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "28d6c177-0cdf-4ed0-9276-2f2b0efbebad",
+    "name": "?=?Loc/Decks/Precon/Precon_Selesnya_Pride",
+    "description": "GW Cats",
+    "format": "precon",
+    "resourceId": "6c31149c-05c5-41df-9c61-4516c6002862",
+    "deckTileId": null,
+    "mainDeck": [
+      {
+        "id": "64847",
+        "quantity": 2
+      },
+      {
+        "id": "65481",
+        "quantity": 1
+      },
+      {
+        "id": "65187",
+        "quantity": 1
+      },
+      {
+        "id": "65697",
+        "quantity": 1
+      },
+      {
+        "id": "64803",
+        "quantity": 1
+      },
+      {
+        "id": "64805",
+        "quantity": 1
+      },
+      {
+        "id": "65797",
+        "quantity": 1
+      },
+      {
+        "id": "66619",
+        "quantity": 1
+      },
+      {
+        "id": "65115",
+        "quantity": 1
+      },
+      {
+        "id": "64815",
+        "quantity": 1
+      },
+      {
+        "id": "65489",
+        "quantity": 1
+      },
+      {
+        "id": "65861",
+        "quantity": 1
+      },
+      {
+        "id": "65865",
+        "quantity": 1
+      },
+      {
+        "id": "65493",
+        "quantity": 1
+      },
+      {
+        "id": "65707",
+        "quantity": 3
+      },
+      {
+        "id": "67023",
+        "quantity": 7
+      },
+      {
+        "id": "65871",
+        "quantity": 2
+      },
+      {
+        "id": "65987",
+        "quantity": 1
+      },
+      {
+        "id": "65145",
+        "quantity": 3
+      },
+      {
+        "id": "65993",
+        "quantity": 1
+      },
+      {
+        "id": "67015",
+        "quantity": 8
+      },
+      {
+        "id": "66369",
+        "quantity": 1
+      },
+      {
+        "id": "65157",
+        "quantity": 3
+      },
+      {
+        "id": "65729",
+        "quantity": 2
+      },
+      {
+        "id": "66653",
+        "quantity": 1
+      },
+      {
+        "id": "64853",
+        "quantity": 3
+      },
+      {
+        "id": "65883",
+        "quantity": 2
+      },
+      {
+        "id": "66907",
+        "quantity": 1
+      },
+      {
+        "id": "65529",
+        "quantity": 1
+      },
+      {
+        "id": "66913",
+        "quantity": 1
+      },
+      {
+        "id": "65475",
+        "quantity": 4
+      },
+      {
+        "id": "65335",
+        "quantity": 1
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-06-29T21:19:18.5384807Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "1f583d6e-9758-4f48-ad79-48818d153d5d",
+    "name": "?=?Loc/Decks/Precon/Precon_The_Brazen_Coalition",
+    "description": "BR Pirates",
+    "format": "precon",
+    "resourceId": "d3c38c21-1f60-43a2-b061-be19348c8a8d",
+    "deckTileId": null,
+    "mainDeck": [
+      {
+        "id": "66237",
+        "quantity": 1
+      },
+      {
+        "id": "65643",
+        "quantity": 1
+      },
+      {
+        "id": "66809",
+        "quantity": 1
+      },
+      {
+        "id": "66239",
+        "quantity": 1
+      },
+      {
+        "id": "65463",
+        "quantity": 2
+      },
+      {
+        "id": "66813",
+        "quantity": 2
+      },
+      {
+        "id": "66411",
+        "quantity": 2
+      },
+      {
+        "id": "66929",
+        "quantity": 2
+      },
+      {
+        "id": "66753",
+        "quantity": 1
+      },
+      {
+        "id": "66173",
+        "quantity": 1
+      },
+      {
+        "id": "66819",
+        "quantity": 2
+      },
+      {
+        "id": "66177",
+        "quantity": 1
+      },
+      {
+        "id": "66249",
+        "quantity": 1
+      },
+      {
+        "id": "66449",
+        "quantity": 1
+      },
+      {
+        "id": "66251",
+        "quantity": 2
+      },
+      {
+        "id": "66761",
+        "quantity": 2
+      },
+      {
+        "id": "66827",
+        "quantity": 1
+      },
+      {
+        "id": "66765",
+        "quantity": 2
+      },
+      {
+        "id": "66185",
+        "quantity": 1
+      },
+      {
+        "id": "66263",
+        "quantity": 1
+      },
+      {
+        "id": "65081",
+        "quantity": 2
+      },
+      {
+        "id": "66189",
+        "quantity": 1
+      },
+      {
+        "id": "67021",
+        "quantity": 12
+      },
+      {
+        "id": "66457",
+        "quantity": 1
+      },
+      {
+        "id": "65687",
+        "quantity": 1
+      },
+      {
+        "id": "66783",
+        "quantity": 1
+      },
+      {
+        "id": "66279",
+        "quantity": 2
+      },
+      {
+        "id": "66289",
+        "quantity": 1
+      },
+      {
+        "id": "66851",
+        "quantity": 1
+      },
+      {
+        "id": "67019",
+        "quantity": 9
+      },
+      {
+        "id": "66225",
+        "quantity": 1
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-06-29T21:19:18.6109448Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "9a5e68a5-9712-4762-8792-f1343e0d7a61",
+    "name": "?=?Loc/Decks/Precon/Precon_The_Legion_of_Dusk",
+    "description": "WB Vampires",
+    "format": "precon",
+    "resourceId": "919076ad-f0b0-454e-a8fd-35bb38c61622",
+    "deckTileId": null,
+    "mainDeck": [
+      {
+        "id": "66407",
+        "quantity": 1
+      },
+      {
+        "id": "65961",
+        "quantity": 1
+      },
+      {
+        "id": "66141",
+        "quantity": 1
+      },
+      {
+        "id": "66619",
+        "quantity": 1
+      },
+      {
+        "id": "66621",
+        "quantity": 1
+      },
+      {
+        "id": "65971",
+        "quantity": 1
+      },
+      {
+        "id": "64815",
+        "quantity": 1
+      },
+      {
+        "id": "66745",
+        "quantity": 1
+      },
+      {
+        "id": "65859",
+        "quantity": 1
+      },
+      {
+        "id": "65865",
+        "quantity": 1
+      },
+      {
+        "id": "65493",
+        "quantity": 1
+      },
+      {
+        "id": "66757",
+        "quantity": 2
+      },
+      {
+        "id": "65977",
+        "quantity": 1
+      },
+      {
+        "id": "66633",
+        "quantity": 1
+      },
+      {
+        "id": "66635",
+        "quantity": 2
+      },
+      {
+        "id": "64825",
+        "quantity": 1
+      },
+      {
+        "id": "67005",
+        "quantity": 2
+      },
+      {
+        "id": "65993",
+        "quantity": 1
+      },
+      {
+        "id": "66947",
+        "quantity": 1
+      },
+      {
+        "id": "66645",
+        "quantity": 2
+      },
+      {
+        "id": "66009",
+        "quantity": 1
+      },
+      {
+        "id": "66777",
+        "quantity": 1
+      },
+      {
+        "id": "67015",
+        "quantity": 9
+      },
+      {
+        "id": "66651",
+        "quantity": 1
+      },
+      {
+        "id": "66019",
+        "quantity": 2
+      },
+      {
+        "id": "66783",
+        "quantity": 1
+      },
+      {
+        "id": "66787",
+        "quantity": 1
+      },
+      {
+        "id": "66205",
+        "quantity": 1
+      },
+      {
+        "id": "65883",
+        "quantity": 2
+      },
+      {
+        "id": "66213",
+        "quantity": 1
+      },
+      {
+        "id": "66659",
+        "quantity": 2
+      },
+      {
+        "id": "66667",
+        "quantity": 1
+      },
+      {
+        "id": "67019",
+        "quantity": 10
+      },
+      {
+        "id": "66481",
+        "quantity": 1
+      },
+      {
+        "id": "66221",
+        "quantity": 1
+      },
+      {
+        "id": "66431",
+        "quantity": 1
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-06-29T21:19:18.6731113Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "e88e6c6a-5109-4ed1-8b3b-b4cfb8c9090a",
+    "name": "?=?Loc/Decks/Precon/Precon_The_River_Heralds",
+    "description": "UG Merfolk",
+    "format": "precon",
+    "resourceId": "00c327c0-c70d-4ab8-87b2-e12bda46ac58",
+    "deckTileId": null,
+    "mainDeck": [
+      {
+        "id": "66101",
+        "quantity": 2
+      },
+      {
+        "id": "66057",
+        "quantity": 1
+      },
+      {
+        "id": "66063",
+        "quantity": 1
+      },
+      {
+        "id": "66067",
+        "quantity": 2
+      },
+      {
+        "id": "66875",
+        "quantity": 2
+      },
+      {
+        "id": "67023",
+        "quantity": 11
+      },
+      {
+        "id": "66933",
+        "quantity": 1
+      },
+      {
+        "id": "66079",
+        "quantity": 1
+      },
+      {
+        "id": "67017",
+        "quantity": 11
+      },
+      {
+        "id": "66885",
+        "quantity": 1
+      },
+      {
+        "id": "66357",
+        "quantity": 2
+      },
+      {
+        "id": "66359",
+        "quantity": 1
+      },
+      {
+        "id": "66083",
+        "quantity": 1
+      },
+      {
+        "id": "66361",
+        "quantity": 1
+      },
+      {
+        "id": "66363",
+        "quantity": 1
+      },
+      {
+        "id": "66949",
+        "quantity": 1
+      },
+      {
+        "id": "66703",
+        "quantity": 2
+      },
+      {
+        "id": "66089",
+        "quantity": 2
+      },
+      {
+        "id": "66377",
+        "quantity": 2
+      },
+      {
+        "id": "66719",
+        "quantity": 1
+      },
+      {
+        "id": "66425",
+        "quantity": 1
+      },
+      {
+        "id": "66723",
+        "quantity": 1
+      },
+      {
+        "id": "66909",
+        "quantity": 1
+      },
+      {
+        "id": "66135",
+        "quantity": 1
+      },
+      {
+        "id": "66429",
+        "quantity": 1
+      },
+      {
+        "id": "66391",
+        "quantity": 2
+      },
+      {
+        "id": "66397",
+        "quantity": 2
+      },
+      {
+        "id": "66399",
+        "quantity": 1
+      },
+      {
+        "id": "66139",
+        "quantity": 1
+      },
+      {
+        "id": "67013",
+        "quantity": 2
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-06-29T21:19:18.7391392Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "6c4f8638-4268-4305-828e-7495143e49fa",
+    "name": "?=?Loc/Decks/Precon/Precon_The_Sun_Empire",
+    "description": "RG Dinos",
+    "format": "precon",
+    "resourceId": "2a2c2f06-9f23-4bbe-bb86-ab30ad6870f8",
+    "deckTileId": null,
+    "mainDeck": [
+      {
+        "id": "66235",
+        "quantity": 1
+      },
+      {
+        "id": "65643",
+        "quantity": 1
+      },
+      {
+        "id": "65119",
+        "quantity": 1
+      },
+      {
+        "id": "66241",
+        "quantity": 1
+      },
+      {
+        "id": "66329",
+        "quantity": 2
+      },
+      {
+        "id": "66341",
+        "quantity": 1
+      },
+      {
+        "id": "66817",
+        "quantity": 1
+      },
+      {
+        "id": "66821",
+        "quantity": 2
+      },
+      {
+        "id": "67023",
+        "quantity": 10
+      },
+      {
+        "id": "66825",
+        "quantity": 1
+      },
+      {
+        "id": "65871",
+        "quantity": 1
+      },
+      {
+        "id": "66263",
+        "quantity": 1
+      },
+      {
+        "id": "67021",
+        "quantity": 9
+      },
+      {
+        "id": "65243",
+        "quantity": 1
+      },
+      {
+        "id": "65151",
+        "quantity": 1
+      },
+      {
+        "id": "66831",
+        "quantity": 2
+      },
+      {
+        "id": "66271",
+        "quantity": 1
+      },
+      {
+        "id": "65687",
+        "quantity": 1
+      },
+      {
+        "id": "66961",
+        "quantity": 2
+      },
+      {
+        "id": "66421",
+        "quantity": 2
+      },
+      {
+        "id": "66371",
+        "quantity": 2
+      },
+      {
+        "id": "66275",
+        "quantity": 1
+      },
+      {
+        "id": "66281",
+        "quantity": 1
+      },
+      {
+        "id": "65209",
+        "quantity": 1
+      },
+      {
+        "id": "66379",
+        "quantity": 2
+      },
+      {
+        "id": "66843",
+        "quantity": 1
+      },
+      {
+        "id": "66385",
+        "quantity": 1
+      },
+      {
+        "id": "66913",
+        "quantity": 1
+      },
+      {
+        "id": "66915",
+        "quantity": 1
+      },
+      {
+        "id": "66389",
+        "quantity": 1
+      },
+      {
+        "id": "65473",
+        "quantity": 4
+      },
+      {
+        "id": "66495",
+        "quantity": 1
+      },
+      {
+        "id": "66395",
+        "quantity": 1
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-06-29T21:19:18.8038486Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "beef51ab-0023-0000-0000-123456789abc",
+    "name": "?=?Loc/Decks/Precon/Precon_XLN-UG-Merfolk2",
+    "description": "",
+    "format": "precon",
+    "resourceId": "beef51ab-0023-0001-0000-123456789abc",
+    "deckTileId": null,
+    "mainDeck": [
+      {
+        "id": "66121",
+        "quantity": 2
+      },
+      {
+        "id": "66367",
+        "quantity": 1
+      },
+      {
+        "id": "66101",
+        "quantity": 3
+      },
+      {
+        "id": "66339",
+        "quantity": 2
+      },
+      {
+        "id": "66137",
+        "quantity": 1
+      },
+      {
+        "id": "66391",
+        "quantity": 3
+      },
+      {
+        "id": "66083",
+        "quantity": 2
+      },
+      {
+        "id": "66079",
+        "quantity": 2
+      },
+      {
+        "id": "66133",
+        "quantity": 3
+      },
+      {
+        "id": "66139",
+        "quantity": 1
+      },
+      {
+        "id": "66385",
+        "quantity": 2
+      },
+      {
+        "id": "66429",
+        "quantity": 2
+      },
+      {
+        "id": "66349",
+        "quantity": 2
+      },
+      {
+        "id": "66321",
+        "quantity": 2
+      },
+      {
+        "id": "66369",
+        "quantity": 3
+      },
+      {
+        "id": "66377",
+        "quantity": 2
+      },
+      {
+        "id": "66063",
+        "quantity": 2
+      },
+      {
+        "id": "66073",
+        "quantity": 1
+      },
+      {
+        "id": "66513",
+        "quantity": 13
+      },
+      {
+        "id": "66537",
+        "quantity": 11
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-06-29T21:19:18.869278Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "beef51ab-0022-0000-0000-123456789abc",
+    "name": "?=?Loc/Decks/Precon/Precon_XLN-WB-Vampires2",
+    "description": "",
+    "format": "precon",
+    "resourceId": "beef51ab-0022-0001-0000-123456789abc",
+    "deckTileId": null,
+    "mainDeck": [
+      {
+        "id": "66221",
+        "quantity": 1
+      },
+      {
+        "id": "65977",
+        "quantity": 2
+      },
+      {
+        "id": "65971",
+        "quantity": 3
+      },
+      {
+        "id": "66035",
+        "quantity": 2
+      },
+      {
+        "id": "65991",
+        "quantity": 1
+      },
+      {
+        "id": "66213",
+        "quantity": 2
+      },
+      {
+        "id": "66009",
+        "quantity": 3
+      },
+      {
+        "id": "66205",
+        "quantity": 2
+      },
+      {
+        "id": "66011",
+        "quantity": 3
+      },
+      {
+        "id": "65983",
+        "quantity": 2
+      },
+      {
+        "id": "66147",
+        "quantity": 1
+      },
+      {
+        "id": "65969",
+        "quantity": 1
+      },
+      {
+        "id": "66165",
+        "quantity": 1
+      },
+      {
+        "id": "66047",
+        "quantity": 3
+      },
+      {
+        "id": "66003",
+        "quantity": 6
+      },
+      {
+        "id": "66019",
+        "quantity": 1
+      },
+      {
+        "id": "66407",
+        "quantity": 2
+      },
+      {
+        "id": "66521",
+        "quantity": 9
+      },
+      {
+        "id": "66505",
+        "quantity": 15
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-06-29T21:19:18.9194403Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  },
+  {
+    "id": "beef51ab-0024-0000-0000-123456789abc",
+    "name": "?=?Loc/Decks/Precon/Precon_XLN-WRG-Dinosaur",
+    "description": "",
+    "format": "precon",
+    "resourceId": "beef51ab-0024-0001-0000-123456789abc",
+    "deckTileId": null,
+    "mainDeck": [
+      {
+        "id": "65989",
+        "quantity": 1
+      },
+      {
+        "id": "65995",
+        "quantity": 1
+      },
+      {
+        "id": "66279",
+        "quantity": 1
+      },
+      {
+        "id": "66427",
+        "quantity": 1
+      },
+      {
+        "id": "66023",
+        "quantity": 1
+      },
+      {
+        "id": "66269",
+        "quantity": 1
+      },
+      {
+        "id": "66303",
+        "quantity": 1
+      },
+      {
+        "id": "66275",
+        "quantity": 1
+      },
+      {
+        "id": "66373",
+        "quantity": 1
+      },
+      {
+        "id": "66335",
+        "quantity": 1
+      },
+      {
+        "id": "66371",
+        "quantity": 1
+      },
+      {
+        "id": "66257",
+        "quantity": 1
+      },
+      {
+        "id": "66323",
+        "quantity": 1
+      },
+      {
+        "id": "66285",
+        "quantity": 1
+      },
+      {
+        "id": "66017",
+        "quantity": 1
+      },
+      {
+        "id": "66375",
+        "quantity": 1
+      },
+      {
+        "id": "65987",
+        "quantity": 1
+      },
+      {
+        "id": "66231",
+        "quantity": 1
+      },
+      {
+        "id": "66347",
+        "quantity": 1
+      },
+      {
+        "id": "66387",
+        "quantity": 1
+      },
+      {
+        "id": "66033",
+        "quantity": 1
+      },
+      {
+        "id": "66049",
+        "quantity": 1
+      },
+      {
+        "id": "66325",
+        "quantity": 1
+      },
+      {
+        "id": "65967",
+        "quantity": 1
+      },
+      {
+        "id": "66379",
+        "quantity": 1
+      },
+      {
+        "id": "66477",
+        "quantity": 1
+      },
+      {
+        "id": "66247",
+        "quantity": 1
+      },
+      {
+        "id": "66251",
+        "quantity": 1
+      },
+      {
+        "id": "66037",
+        "quantity": 1
+      },
+      {
+        "id": "66441",
+        "quantity": 1
+      },
+      {
+        "id": "66245",
+        "quantity": 1
+      },
+      {
+        "id": "66329",
+        "quantity": 1
+      },
+      {
+        "id": "66459",
+        "quantity": 1
+      },
+      {
+        "id": "66463",
+        "quantity": 1
+      },
+      {
+        "id": "65973",
+        "quantity": 1
+      },
+      {
+        "id": "66255",
+        "quantity": 1
+      },
+      {
+        "id": "66493",
+        "quantity": 3
+      },
+      {
+        "id": "66491",
+        "quantity": 3
+      },
+      {
+        "id": "66505",
+        "quantity": 6
+      },
+      {
+        "id": "66529",
+        "quantity": 6
+      },
+      {
+        "id": "66537",
+        "quantity": 6
+      }
+    ],
+    "sideboard": [],
+    "lastUpdated": "2018-06-29T21:19:18.9715399Z",
+    "lockedForUse": true,
+    "lockedForEdit": true,
+    "cardBack": null,
+    "isValid": true
+  }
+]
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+<== Event.GetSeasonAndRankDetail(20)
+{
+  "currentSeason": {
+    "seasonOrdinal": 5,
+    "seasonStartTime": "2019-04-30T19:05:00Z",
+    "seasonEndTime": "2019-05-31T19:00:00Z",
+    "seasonLimitedRewards": {
+      "Bronze": {
+        "image1": "ObjectiveIcon_Pack_RNA",
+        "image2": null,
+        "image3": null,
+        "prefab": "RewardPopup3DIcon_Pack",
+        "referenceId": "100010",
+        "headerLocKey": "MainNav/EventRewards/Booster_Pack_Generic",
+        "descriptionLocKey": "MainNav/General/Empty_String",
+        "quantity": "1",
+        "locParams": {},
+        "availableDate": "0001-01-01T00:00:00"
+      },
+      "Silver": {
+        "image1": "ObjectiveEventIcon_Coin3",
+        "image2": "ObjectiveIcon_Pack_RNA",
+        "image3": null,
+        "prefab": "RewardPopup3DIcon_CoinPack",
+        "referenceId": "100010",
+        "headerLocKey": "MainNav/EventRewards/Gold_And_Pack",
+        "descriptionLocKey": "MainNav/General/Empty_String",
+        "quantity": "1",
+        "locParams": {
+          "number1": 500
+        },
+        "availableDate": "0001-01-01T00:00:00"
+      },
+      "Gold": {
+        "image1": "ObjectiveEventIcon_Coin6",
+        "image2": "ObjectiveIcon_Pack_WAR",
+        "image3": null,
+        "prefab": "RewardPopup3DIcon_CoinPack",
+        "referenceId": "100013",
+        "headerLocKey": "MainNav/EventRewards/Gold_And_Packs",
+        "descriptionLocKey": "MainNav/General/Empty_String",
+        "quantity": "2",
+        "locParams": {
+          "number1": 1000,
+          "number2": 2
+        },
+        "availableDate": "0001-01-01T00:00:00"
+      },
+      "Platinum": {
+        "image1": "ObjectiveEventIcon_Coin6",
+        "image2": "ObjectiveIcon_Pack_WAR",
+        "image3": null,
+        "prefab": "RewardPopup3DIcon_CoinPack",
+        "referenceId": "100013",
+        "headerLocKey": "MainNav/EventRewards/Gold_And_Packs",
+        "descriptionLocKey": "MainNav/General/Empty_String",
+        "quantity": "3",
+        "locParams": {
+          "number1": 1000,
+          "number2": 3
+        },
+        "availableDate": "0001-01-01T00:00:00"
+      },
+      "Diamond": {
+        "image1": "ObjectiveEventIcon_Coin6",
+        "image2": "ObjectiveIcon_Pack_WAR",
+        "image3": null,
+        "prefab": "RewardPopup3DIcon_CoinPack",
+        "referenceId": "100013",
+        "headerLocKey": "MainNav/EventRewards/Gold_And_Packs",
+        "descriptionLocKey": "MainNav/General/Empty_String",
+        "quantity": "4",
+        "locParams": {
+          "number1": 1000,
+          "number2": 4
+        },
+        "availableDate": "0001-01-01T00:00:00"
+      },
+      "Mythic": {
+        "image1": "ObjectiveEventIcon_Coin6",
+        "image2": "ObjectiveIcon_Pack_WAR",
+        "image3": null,
+        "prefab": "RewardPopup3DIcon_CoinPack",
+        "referenceId": "100013",
+        "headerLocKey": "MainNav/EventRewards/Gold_And_Packs",
+        "descriptionLocKey": "MainNav/General/Empty_String",
+        "quantity": "5",
+        "locParams": {
+          "number1": 1000,
+          "number2": 5
+        },
+        "availableDate": "0001-01-01T00:00:00"
+      }
+    },
+    "seasonConstructedRewards": {
+      "Bronze": {
+        "image1": "ObjectiveIcon_Pack_RNA",
+        "image2": null,
+        "image3": null,
+        "prefab": "RewardPopup3DIcon_Pack",
+        "referenceId": "100010",
+        "headerLocKey": "MainNav/EventRewards/Booster_Pack_Generic",
+        "descriptionLocKey": "MainNav/General/Empty_String",
+        "quantity": "1",
+        "locParams": {},
+        "availableDate": "0001-01-01T00:00:00"
+      },
+      "Silver": {
+        "image1": "ObjectiveEventIcon_Coin3",
+        "image2": "ObjectiveIcon_Pack_RNA",
+        "image3": null,
+        "prefab": "RewardPopup3DIcon_CoinPack",
+        "referenceId": "100010",
+        "headerLocKey": "MainNav/EventRewards/Gold_And_Pack",
+        "descriptionLocKey": "MainNav/General/Empty_String",
+        "quantity": "1",
+        "locParams": {
+          "number1": 500
+        },
+        "availableDate": "0001-01-01T00:00:00"
+      },
+      "Gold": {
+        "image1": "ObjectiveEventIcon_Coin6",
+        "image2": "ObjectiveIcon_Pack_WAR",
+        "image3": null,
+        "prefab": "RewardPopup3DIcon_CoinPack",
+        "referenceId": "100013",
+        "headerLocKey": "MainNav/EventRewards/Gold_And_Packs",
+        "descriptionLocKey": "MainNav/General/Empty_String",
+        "quantity": "2",
+        "locParams": {
+          "number1": 1000,
+          "number2": 2
+        },
+        "availableDate": "0001-01-01T00:00:00"
+      },
+      "Platinum": {
+        "image1": "ObjectiveEventIcon_Coin6",
+        "image2": "ObjectiveIcon_Pack_WAR",
+        "image3": null,
+        "prefab": "RewardPopup3DIcon_CoinPack",
+        "referenceId": "100013",
+        "headerLocKey": "MainNav/EventRewards/Gold_And_Packs",
+        "descriptionLocKey": "MainNav/General/Empty_String",
+        "quantity": "3",
+        "locParams": {
+          "number1": 1000,
+          "number2": 3
+        },
+        "availableDate": "0001-01-01T00:00:00"
+      },
+      "Diamond": {
+        "image1": "ObjectiveEventIcon_Coin6",
+        "image2": "ObjectiveIcon_Pack_WAR",
+        "image3": null,
+        "prefab": "RewardPopup3DIcon_CoinPack",
+        "referenceId": "100013",
+        "headerLocKey": "MainNav/EventRewards/Gold_And_Packs",
+        "descriptionLocKey": "MainNav/General/Empty_String",
+        "quantity": "4",
+        "locParams": {
+          "number1": 1000,
+          "number2": 4
+        },
+        "availableDate": "0001-01-01T00:00:00"
+      },
+      "Mythic": {
+        "image1": "ObjectiveEventIcon_Coin6",
+        "image2": "ObjectiveIcon_Pack_WAR",
+        "image3": null,
+        "prefab": "RewardPopup3DIcon_CoinPack",
+        "referenceId": "100013",
+        "headerLocKey": "MainNav/EventRewards/Gold_And_Packs",
+        "descriptionLocKey": "MainNav/General/Empty_String",
+        "quantity": "5",
+        "locParams": {
+          "number1": 1000,
+          "number2": 5
+        },
+        "availableDate": "0001-01-01T00:00:00"
+      }
+    }
+  },
+  "limitedRankInfo": [
+    {
+      "rankClass": "Bronze",
+      "level": 4,
+      "steps": 4
+    },
+    {
+      "rankClass": "Bronze",
+      "level": 3,
+      "steps": 4
+    },
+    {
+      "rankClass": "Bronze",
+      "level": 2,
+      "steps": 4
+    },
+    {
+      "rankClass": "Bronze",
+      "level": 1,
+      "steps": 4
+    },
+    {
+      "rankClass": "Silver",
+      "level": 4,
+      "steps": 5
+    },
+    {
+      "rankClass": "Silver",
+      "level": 3,
+      "steps": 5
+    },
+    {
+      "rankClass": "Silver",
+      "level": 2,
+      "steps": 5
+    },
+    {
+      "rankClass": "Silver",
+      "level": 1,
+      "steps": 5
+    },
+    {
+      "rankClass": "Gold",
+      "level": 4,
+      "steps": 5
+    },
+    {
+      "rankClass": "Gold",
+      "level": 3,
+      "steps": 5
+    },
+    {
+      "rankClass": "Gold",
+      "level": 2,
+      "steps": 5
+    },
+    {
+      "rankClass": "Gold",
+      "level": 1,
+      "steps": 5
+    },
+    {
+      "rankClass": "Platinum",
+      "level": 4,
+      "steps": 5
+    },
+    {
+      "rankClass": "Platinum",
+      "level": 3,
+      "steps": 5
+    },
+    {
+      "rankClass": "Platinum",
+      "level": 2,
+      "steps": 5
+    },
+    {
+      "rankClass": "Platinum",
+      "level": 1,
+      "steps": 5
+    },
+    {
+      "rankClass": "Diamond",
+      "level": 4,
+      "steps": 5
+    },
+    {
+      "rankClass": "Diamond",
+      "level": 3,
+      "steps": 5
+    },
+    {
+      "rankClass": "Diamond",
+      "level": 2,
+      "steps": 5
+    },
+    {
+      "rankClass": "Diamond",
+      "level": 1,
+      "steps": 5
+    },
+    {
+      "rankClass": "Mythic",
+      "level": 1,
+      "steps": 1
+    }
+  ],
+  "constructedRankInfo": [
+    {
+      "rankClass": "Bronze",
+      "level": 4,
+      "steps": 6
+    },
+    {
+      "rankClass": "Bronze",
+      "level": 3,
+      "steps": 6
+    },
+    {
+      "rankClass": "Bronze",
+      "level": 2,
+      "steps": 6
+    },
+    {
+      "rankClass": "Bronze",
+      "level": 1,
+      "steps": 6
+    },
+    {
+      "rankClass": "Silver",
+      "level": 4,
+      "steps": 6
+    },
+    {
+      "rankClass": "Silver",
+      "level": 3,
+      "steps": 6
+    },
+    {
+      "rankClass": "Silver",
+      "level": 2,
+      "steps": 6
+    },
+    {
+      "rankClass": "Silver",
+      "level": 1,
+      "steps": 6
+    },
+    {
+      "rankClass": "Gold",
+      "level": 4,
+      "steps": 6
+    },
+    {
+      "rankClass": "Gold",
+      "level": 3,
+      "steps": 6
+    },
+    {
+      "rankClass": "Gold",
+      "level": 2,
+      "steps": 6
+    },
+    {
+      "rankClass": "Gold",
+      "level": 1,
+      "steps": 6
+    },
+    {
+      "rankClass": "Platinum",
+      "level": 4,
+      "steps": 6
+    },
+    {
+      "rankClass": "Platinum",
+      "level": 3,
+      "steps": 6
+    },
+    {
+      "rankClass": "Platinum",
+      "level": 2,
+      "steps": 6
+    },
+    {
+      "rankClass": "Platinum",
+      "level": 1,
+      "steps": 6
+    },
+    {
+      "rankClass": "Diamond",
+      "level": 4,
+      "steps": 6
+    },
+    {
+      "rankClass": "Diamond",
+      "level": 3,
+      "steps": 6
+    },
+    {
+      "rankClass": "Diamond",
+      "level": 2,
+      "steps": 6
+    },
+    {
+      "rankClass": "Diamond",
+      "level": 1,
+      "steps": 6
+    },
+    {
+      "rankClass": "Mythic",
+      "level": 1,
+      "steps": 1
+    }
+  ]
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+<== Progression.GetPlayerProgress(21)
+{
+  "activeTracks": [],
+  "inactiveTracks": [
+    {
+      "trackName": "EarlyPlayerProgression",
+      "currentLevel": 23,
+      "currentExp": 600,
+      "currentOrbCount": 0,
+      "unlockedNodeIds": [
+        1,
+        2,
+        4,
+        0,
+        3
+      ],
+      "availableNodesToUnlock": [
+        5,
+        6,
+        7,
+        8,
+        9
+      ]
+    }
+  ]
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+<== Progression.GetAllTracks(22)
+[
+  {
+    "name": "EarlyPlayerProgression",
+    "trackLevels": [
+      {
+        "chest": null,
+        "xpToComplete": 75,
+        "orbsRewarded": 1
+      },
+      {
+        "chest": null,
+        "xpToComplete": 300,
+        "orbsRewarded": 1
+      },
+      {
+        "chest": null,
+        "xpToComplete": 300,
+        "orbsRewarded": 1
+      },
+      {
+        "chest": {
+          "image1": "ObjectiveEventIcon_Coin6",
+          "image2": "ObjectiveIcon_MasteryOrb",
+          "image3": null,
+          "prefab": "RewardPopup3DIcon_OrbAndCoin",
+          "referenceId": null,
+          "headerLocKey": "EPP/RewardTrack/Gold_And_Orb",
+          "descriptionLocKey": "",
+          "quantity": "1000",
+          "locParams": {
+            "number1": 1000,
+            "number2": 1
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        "xpToComplete": 300,
+        "orbsRewarded": 1
+      },
+      {
+        "chest": null,
+        "xpToComplete": 400,
+        "orbsRewarded": 1
+      },
+      {
+        "chest": null,
+        "xpToComplete": 400,
+        "orbsRewarded": 1
+      },
+      {
+        "chest": null,
+        "xpToComplete": 400,
+        "orbsRewarded": 1
+      },
+      {
+        "chest": null,
+        "xpToComplete": 400,
+        "orbsRewarded": 1
+      },
+      {
+        "chest": {
+          "image1": "ObjectiveIcon_OrbAndPremium",
+          "image2": null,
+          "image3": null,
+          "prefab": "RewardPopup3DIcon_OrbAndPremium",
+          "referenceId": "68164",
+          "headerLocKey": "EPP/RewardTrack/Style_And_Orb",
+          "descriptionLocKey": "",
+          "quantity": null,
+          "locParams": {
+            "number1": 1,
+            "number2": 1
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        "xpToComplete": 400,
+        "orbsRewarded": 1
+      },
+      {
+        "chest": null,
+        "xpToComplete": 400,
+        "orbsRewarded": 1
+      },
+      {
+        "chest": null,
+        "xpToComplete": 400,
+        "orbsRewarded": 1
+      },
+      {
+        "chest": null,
+        "xpToComplete": 400,
+        "orbsRewarded": 1
+      },
+      {
+        "chest": null,
+        "xpToComplete": 400,
+        "orbsRewarded": 1
+      },
+      {
+        "chest": null,
+        "xpToComplete": 400,
+        "orbsRewarded": 3
+      },
+      {
+        "chest": null,
+        "xpToComplete": 500,
+        "orbsRewarded": 1
+      },
+      {
+        "chest": null,
+        "xpToComplete": 500,
+        "orbsRewarded": 1
+      },
+      {
+        "chest": null,
+        "xpToComplete": 500,
+        "orbsRewarded": 1
+      },
+      {
+        "chest": null,
+        "xpToComplete": 500,
+        "orbsRewarded": 1
+      },
+      {
+        "chest": {
+          "image1": "ObjectiveIcon_OrbAndCardback",
+          "image2": null,
+          "image3": null,
+          "prefab": "RewardPopup3DIcon_OrbAndCardback",
+          "referenceId": "",
+          "headerLocKey": "EPP/RewardTrack/Sleeve_And_Orbs",
+          "descriptionLocKey": "",
+          "quantity": "5",
+          "locParams": {
+            "number1": 1,
+            "number2": 5
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        "xpToComplete": 500,
+        "orbsRewarded": 5
+      },
+      {
+        "chest": {
+          "image1": "ObjectiveIcon_Wildcard_Common",
+          "image2": null,
+          "image3": null,
+          "prefab": "RewardPopup3DIcon_Wildcard_Common",
+          "referenceId": null,
+          "headerLocKey": "EPP/RewardTrack/RewardCommonWildcards",
+          "descriptionLocKey": "",
+          "quantity": "8",
+          "locParams": {},
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        "xpToComplete": 600,
+        "orbsRewarded": 0
+      },
+      {
+        "chest": {
+          "image1": "ObjectiveIcon_Wildcard_Uncommon",
+          "image2": null,
+          "image3": null,
+          "prefab": "RewardPopup3DIcon_Wildcard_Uncommon",
+          "referenceId": null,
+          "headerLocKey": "EPP/RewardTrack/RewardUncommonWildcards",
+          "descriptionLocKey": "",
+          "quantity": "4",
+          "locParams": {},
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        "xpToComplete": 600,
+        "orbsRewarded": 0
+      },
+      {
+        "chest": {
+          "image1": "ObjectiveIcon_Wildcard_Rare",
+          "image2": null,
+          "image3": null,
+          "prefab": "RewardPopup3DIcon_WildCard_Rare",
+          "referenceId": null,
+          "headerLocKey": "EPP/RewardTrack/RewardRareWildcards",
+          "descriptionLocKey": "",
+          "quantity": "2",
+          "locParams": {},
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        "xpToComplete": 600,
+        "orbsRewarded": 0
+      },
+      {
+        "chest": {
+          "image1": "ObjectiveIcon_Wildcard_MythicRare",
+          "image2": null,
+          "image3": null,
+          "prefab": "RewardPopup3DIcon_WildCard_MythicRare",
+          "referenceId": null,
+          "headerLocKey": "EPP/RewardTrack/RewardMythicWildcards",
+          "descriptionLocKey": "",
+          "quantity": "",
+          "locParams": {},
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        "xpToComplete": 600,
+        "orbsRewarded": 0
+      },
+      {
+        "chest": {
+          "image1": "ObjectiveEventIcon_DeckBox",
+          "image2": null,
+          "image3": null,
+          "prefab": "RewardPopup3DIcon_Deckbox",
+          "referenceId": "",
+          "headerLocKey": "MainNav/QuestRewards/NPE_MonoDecks",
+          "descriptionLocKey": null,
+          "quantity": "5",
+          "locParams": {},
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        "xpToComplete": 600,
+        "orbsRewarded": 0
+      }
+    ],
+    "rewardWeb": {
+      "allNodes": [
+        {
+          "id": 0,
+          "unlockQuestMetric": "WhiteCardsInDeck",
+          "unlockMetricCount": 1,
+          "chest": {
+            "image1": null,
+            "image2": null,
+            "image3": null,
+            "prefab": null,
+            "referenceId": null,
+            "headerLocKey": null,
+            "descriptionLocKey": null,
+            "quantity": null,
+            "locParams": {},
+            "availableDate": "0001-01-01T00:00:00"
+          },
+          "upgradePacket": {
+            "targetDeckDescription": "Decks/Precon/Precon_July_W",
+            "cardsAdded": [
+              68409
+            ]
+          },
+          "childIds": [
+            5
+          ]
+        },
+        {
+          "id": 1,
+          "unlockQuestMetric": "BlueCardsInDeck",
+          "unlockMetricCount": 1,
+          "chest": {
+            "image1": null,
+            "image2": null,
+            "image3": null,
+            "prefab": null,
+            "referenceId": null,
+            "headerLocKey": null,
+            "descriptionLocKey": "",
+            "quantity": null,
+            "locParams": {},
+            "availableDate": "0001-01-01T00:00:00"
+          },
+          "upgradePacket": {
+            "targetDeckDescription": "Decks/Precon/Precon_July_U",
+            "cardsAdded": [
+              68410
+            ]
+          },
+          "childIds": [
+            6
+          ]
+        },
+        {
+          "id": 2,
+          "unlockQuestMetric": "BlackCardsInDeck",
+          "unlockMetricCount": 1,
+          "chest": {
+            "image1": null,
+            "image2": null,
+            "image3": null,
+            "prefab": null,
+            "referenceId": null,
+            "headerLocKey": null,
+            "descriptionLocKey": "",
+            "quantity": null,
+            "locParams": {},
+            "availableDate": "0001-01-01T00:00:00"
+          },
+          "upgradePacket": {
+            "targetDeckDescription": "Decks/Precon/Precon_July_B",
+            "cardsAdded": [
+              68411
+            ]
+          },
+          "childIds": [
+            7
+          ]
+        },
+        {
+          "id": 3,
+          "unlockQuestMetric": "RedCardsInDeck",
+          "unlockMetricCount": 1,
+          "chest": {
+            "image1": null,
+            "image2": null,
+            "image3": null,
+            "prefab": null,
+            "referenceId": null,
+            "headerLocKey": null,
+            "descriptionLocKey": "",
+            "quantity": null,
+            "locParams": {},
+            "availableDate": "0001-01-01T00:00:00"
+          },
+          "upgradePacket": {
+            "targetDeckDescription": "Decks/Precon/Precon_July_R",
+            "cardsAdded": [
+              68412
+            ]
+          },
+          "childIds": [
+            8
+          ]
+        },
+        {
+          "id": 4,
+          "unlockQuestMetric": "GreenCardsInDeck",
+          "unlockMetricCount": 1,
+          "chest": {
+            "image1": null,
+            "image2": null,
+            "image3": null,
+            "prefab": null,
+            "referenceId": null,
+            "headerLocKey": null,
+            "descriptionLocKey": "",
+            "quantity": null,
+            "locParams": {},
+            "availableDate": "0001-01-01T00:00:00"
+          },
+          "upgradePacket": {
+            "targetDeckDescription": "Decks/Precon/Precon_July_G",
+            "cardsAdded": [
+              68413
+            ]
+          },
+          "childIds": [
+            9
+          ]
+        },
+        {
+          "id": 5,
+          "unlockQuestMetric": null,
+          "unlockMetricCount": 0,
+          "chest": {
+            "image1": null,
+            "image2": null,
+            "image3": null,
+            "prefab": null,
+            "referenceId": null,
+            "headerLocKey": null,
+            "descriptionLocKey": "",
+            "quantity": null,
+            "locParams": {},
+            "availableDate": "0001-01-01T00:00:00"
+          },
+          "upgradePacket": {
+            "targetDeckDescription": "Decks/Precon/Precon_July_W",
+            "cardsAdded": [
+              68246,
+              67170,
+              67730
+            ]
+          },
+          "childIds": [
+            10,
+            15
+          ]
+        },
+        {
+          "id": 6,
+          "unlockQuestMetric": null,
+          "unlockMetricCount": 0,
+          "chest": {
+            "image1": null,
+            "image2": null,
+            "image3": null,
+            "prefab": null,
+            "referenceId": null,
+            "headerLocKey": null,
+            "descriptionLocKey": "",
+            "quantity": null,
+            "locParams": {},
+            "availableDate": "0001-01-01T00:00:00"
+          },
+          "upgradePacket": {
+            "targetDeckDescription": "Decks/Precon/Precon_July_U",
+            "cardsAdded": [
+              68256,
+              66051,
+              67782
+            ]
+          },
+          "childIds": [
+            11,
+            16
+          ]
+        },
+        {
+          "id": 7,
+          "unlockQuestMetric": null,
+          "unlockMetricCount": 0,
+          "chest": {
+            "image1": null,
+            "image2": null,
+            "image3": null,
+            "prefab": null,
+            "referenceId": null,
+            "headerLocKey": null,
+            "descriptionLocKey": "",
+            "quantity": null,
+            "locParams": {},
+            "availableDate": "0001-01-01T00:00:00"
+          },
+          "upgradePacket": {
+            "targetDeckDescription": "Decks/Precon/Precon_July_B",
+            "cardsAdded": [
+              68270,
+              67930,
+              67866
+            ]
+          },
+          "childIds": [
+            12,
+            17
+          ]
+        },
+        {
+          "id": 8,
+          "unlockQuestMetric": null,
+          "unlockMetricCount": 0,
+          "chest": {
+            "image1": null,
+            "image2": null,
+            "image3": null,
+            "prefab": null,
+            "referenceId": null,
+            "headerLocKey": null,
+            "descriptionLocKey": "",
+            "quantity": null,
+            "locParams": {},
+            "availableDate": "0001-01-01T00:00:00"
+          },
+          "upgradePacket": {
+            "targetDeckDescription": "Decks/Precon/Precon_July_R",
+            "cardsAdded": [
+              68000,
+              68564,
+              68012
+            ]
+          },
+          "childIds": [
+            13,
+            18
+          ]
+        },
+        {
+          "id": 9,
+          "unlockQuestMetric": null,
+          "unlockMetricCount": 0,
+          "chest": {
+            "image1": null,
+            "image2": null,
+            "image3": null,
+            "prefab": null,
+            "referenceId": null,
+            "headerLocKey": null,
+            "descriptionLocKey": "",
+            "quantity": null,
+            "locParams": {},
+            "availableDate": "0001-01-01T00:00:00"
+          },
+          "upgradePacket": {
+            "targetDeckDescription": "Decks/Precon/Precon_July_G",
+            "cardsAdded": [
+              68068,
+              68018,
+              67440
+            ]
+          },
+          "childIds": [
+            14,
+            19
+          ]
+        },
+        {
+          "id": 10,
+          "unlockQuestMetric": null,
+          "unlockMetricCount": 0,
+          "chest": {
+            "image1": null,
+            "image2": null,
+            "image3": null,
+            "prefab": null,
+            "referenceId": null,
+            "headerLocKey": null,
+            "descriptionLocKey": "",
+            "quantity": null,
+            "locParams": {},
+            "availableDate": "0001-01-01T00:00:00"
+          },
+          "upgradePacket": {
+            "targetDeckDescription": "Decks/Precon/Precon_July_W",
+            "cardsAdded": [
+              68250,
+              67160,
+              67128
+            ]
+          },
+          "childIds": [
+            20
+          ]
+        },
+        {
+          "id": 11,
+          "unlockQuestMetric": null,
+          "unlockMetricCount": 0,
+          "chest": {
+            "image1": null,
+            "image2": null,
+            "image3": null,
+            "prefab": null,
+            "referenceId": null,
+            "headerLocKey": null,
+            "descriptionLocKey": "",
+            "quantity": null,
+            "locParams": {},
+            "availableDate": "0001-01-01T00:00:00"
+          },
+          "upgradePacket": {
+            "targetDeckDescription": "Decks/Precon/Precon_July_U",
+            "cardsAdded": [
+              68260,
+              67778,
+              67828
+            ]
+          },
+          "childIds": [
+            21
+          ]
+        },
+        {
+          "id": 12,
+          "unlockQuestMetric": null,
+          "unlockMetricCount": 0,
+          "chest": {
+            "image1": null,
+            "image2": null,
+            "image3": null,
+            "prefab": null,
+            "referenceId": null,
+            "headerLocKey": null,
+            "descriptionLocKey": "",
+            "quantity": null,
+            "locParams": {},
+            "availableDate": "0001-01-01T00:00:00"
+          },
+          "upgradePacket": {
+            "targetDeckDescription": "Decks/Precon/Precon_July_B",
+            "cardsAdded": [
+              68268,
+              67272,
+              68543
+            ]
+          },
+          "childIds": [
+            22
+          ]
+        },
+        {
+          "id": 13,
+          "unlockQuestMetric": null,
+          "unlockMetricCount": 0,
+          "chest": {
+            "image1": null,
+            "image2": null,
+            "image3": null,
+            "prefab": null,
+            "referenceId": null,
+            "headerLocKey": null,
+            "descriptionLocKey": "",
+            "quantity": null,
+            "locParams": {},
+            "availableDate": "0001-01-01T00:00:00"
+          },
+          "upgradePacket": {
+            "targetDeckDescription": "Decks/Precon/Precon_July_R",
+            "cardsAdded": [
+              68278,
+              67956,
+              68014
+            ]
+          },
+          "childIds": [
+            23
+          ]
+        },
+        {
+          "id": 14,
+          "unlockQuestMetric": null,
+          "unlockMetricCount": 0,
+          "chest": {
+            "image1": null,
+            "image2": null,
+            "image3": null,
+            "prefab": null,
+            "referenceId": null,
+            "headerLocKey": null,
+            "descriptionLocKey": "",
+            "quantity": null,
+            "locParams": {},
+            "availableDate": "0001-01-01T00:00:00"
+          },
+          "upgradePacket": {
+            "targetDeckDescription": "Decks/Precon/Precon_July_G",
+            "cardsAdded": [
+              68288,
+              68036,
+              68034
+            ]
+          },
+          "childIds": [
+            24
+          ]
+        },
+        {
+          "id": 15,
+          "unlockQuestMetric": null,
+          "unlockMetricCount": 0,
+          "chest": {
+            "image1": null,
+            "image2": null,
+            "image3": null,
+            "prefab": null,
+            "referenceId": null,
+            "headerLocKey": null,
+            "descriptionLocKey": "",
+            "quantity": null,
+            "locParams": {},
+            "availableDate": "0001-01-01T00:00:00"
+          },
+          "upgradePacket": {
+            "targetDeckDescription": "Decks/Precon/Precon_July_W",
+            "cardsAdded": [
+              66677,
+              66619,
+              67738
+            ]
+          },
+          "childIds": [
+            20
+          ]
+        },
+        {
+          "id": 16,
+          "unlockQuestMetric": null,
+          "unlockMetricCount": 0,
+          "chest": {
+            "image1": null,
+            "image2": null,
+            "image3": null,
+            "prefab": null,
+            "referenceId": null,
+            "headerLocKey": null,
+            "descriptionLocKey": "",
+            "quantity": null,
+            "locParams": {},
+            "availableDate": "0001-01-01T00:00:00"
+          },
+          "upgradePacket": {
+            "targetDeckDescription": "Decks/Precon/Precon_July_U",
+            "cardsAdded": [
+              67818,
+              68174,
+              68168
+            ]
+          },
+          "childIds": [
+            21
+          ]
+        },
+        {
+          "id": 17,
+          "unlockQuestMetric": null,
+          "unlockMetricCount": 0,
+          "chest": {
+            "image1": null,
+            "image2": null,
+            "image3": null,
+            "prefab": null,
+            "referenceId": null,
+            "headerLocKey": null,
+            "descriptionLocKey": "",
+            "quantity": null,
+            "locParams": {},
+            "availableDate": "0001-01-01T00:00:00"
+          },
+          "upgradePacket": {
+            "targetDeckDescription": "Decks/Precon/Precon_July_B",
+            "cardsAdded": [
+              67904,
+              67864,
+              66757
+            ]
+          },
+          "childIds": [
+            22
+          ]
+        },
+        {
+          "id": 18,
+          "unlockQuestMetric": null,
+          "unlockMetricCount": 0,
+          "chest": {
+            "image1": null,
+            "image2": null,
+            "image3": null,
+            "prefab": null,
+            "referenceId": null,
+            "headerLocKey": null,
+            "descriptionLocKey": "",
+            "quantity": null,
+            "locParams": {},
+            "availableDate": "0001-01-01T00:00:00"
+          },
+          "upgradePacket": {
+            "targetDeckDescription": "Decks/Precon/Precon_July_R",
+            "cardsAdded": [
+              66235,
+              66241,
+              66275
+            ]
+          },
+          "childIds": [
+            23
+          ]
+        },
+        {
+          "id": 19,
+          "unlockQuestMetric": null,
+          "unlockMetricCount": 0,
+          "chest": {
+            "image1": null,
+            "image2": null,
+            "image3": null,
+            "prefab": null,
+            "referenceId": null,
+            "headerLocKey": null,
+            "descriptionLocKey": "",
+            "quantity": null,
+            "locParams": {},
+            "availableDate": "0001-01-01T00:00:00"
+          },
+          "upgradePacket": {
+            "targetDeckDescription": "Decks/Precon/Precon_July_G",
+            "cardsAdded": [
+              68286,
+              66913,
+              68024
+            ]
+          },
+          "childIds": [
+            24
+          ]
+        },
+        {
+          "id": 20,
+          "unlockQuestMetric": null,
+          "unlockMetricCount": 0,
+          "chest": {
+            "image1": "ObjectiveIcon_PremiumSkin",
+            "image2": null,
+            "image3": null,
+            "prefab": "",
+            "referenceId": "67730",
+            "headerLocKey": "",
+            "descriptionLocKey": "",
+            "quantity": null,
+            "locParams": {
+              "number1": 1
+            },
+            "availableDate": "0001-01-01T00:00:00"
+          },
+          "upgradePacket": null,
+          "childIds": [
+            25,
+            26
+          ]
+        },
+        {
+          "id": 21,
+          "unlockQuestMetric": null,
+          "unlockMetricCount": 0,
+          "chest": {
+            "image1": "ObjectiveIcon_PremiumSkin",
+            "image2": null,
+            "image3": null,
+            "prefab": "",
+            "referenceId": "67782",
+            "headerLocKey": "",
+            "descriptionLocKey": "",
+            "quantity": null,
+            "locParams": {
+              "number1": 1
+            },
+            "availableDate": "0001-01-01T00:00:00"
+          },
+          "upgradePacket": null,
+          "childIds": [
+            26,
+            27
+          ]
+        },
+        {
+          "id": 22,
+          "unlockQuestMetric": null,
+          "unlockMetricCount": 0,
+          "chest": {
+            "image1": "ObjectiveIcon_PremiumSkin",
+            "image2": null,
+            "image3": null,
+            "prefab": "",
+            "referenceId": "67866",
+            "headerLocKey": "",
+            "descriptionLocKey": "",
+            "quantity": null,
+            "locParams": {
+              "number1": 1
+            },
+            "availableDate": "0001-01-01T00:00:00"
+          },
+          "upgradePacket": null,
+          "childIds": [
+            27,
+            28
+          ]
+        },
+        {
+          "id": 23,
+          "unlockQuestMetric": null,
+          "unlockMetricCount": 0,
+          "chest": {
+            "image1": "ObjectiveIcon_PremiumSkin",
+            "image2": null,
+            "image3": null,
+            "prefab": "",
+            "referenceId": "68012",
+            "headerLocKey": "",
+            "descriptionLocKey": "",
+            "quantity": null,
+            "locParams": {
+              "number1": 1
+            },
+            "availableDate": "0001-01-01T00:00:00"
+          },
+          "upgradePacket": null,
+          "childIds": [
+            28,
+            29
+          ]
+        },
+        {
+          "id": 24,
+          "unlockQuestMetric": null,
+          "unlockMetricCount": 0,
+          "chest": {
+            "image1": "ObjectiveIcon_PremiumSkin",
+            "image2": null,
+            "image3": null,
+            "prefab": "",
+            "referenceId": "68310",
+            "headerLocKey": "MainNav/EventRewards/Card",
+            "descriptionLocKey": "",
+            "quantity": null,
+            "locParams": {
+              "number1": 1
+            },
+            "availableDate": "0001-01-01T00:00:00"
+          },
+          "upgradePacket": null,
+          "childIds": [
+            25,
+            29
+          ]
+        },
+        {
+          "id": 25,
+          "unlockQuestMetric": null,
+          "unlockMetricCount": 0,
+          "chest": {
+            "image1": "ObjectiveEventIcon_DeckBox",
+            "image2": null,
+            "image3": null,
+            "prefab": "RewardPopup3DIcon_Deckbox",
+            "referenceId": "67146",
+            "headerLocKey": "MainNav/QuestRewards/Deck_GW",
+            "descriptionLocKey": "Decks/Precon/Precon_NPE_GRN_GW_Desc",
+            "quantity": null,
+            "locParams": {},
+            "availableDate": "0001-01-01T00:00:00"
+          },
+          "upgradePacket": null,
+          "childIds": []
+        },
+        {
+          "id": 26,
+          "unlockQuestMetric": null,
+          "unlockMetricCount": 0,
+          "chest": {
+            "image1": "ObjectiveEventIcon_DeckBox",
+            "image2": null,
+            "image3": null,
+            "prefab": "RewardPopup3DIcon_Deckbox",
+            "referenceId": "66925",
+            "headerLocKey": "MainNav/QuestRewards/Deck_UW",
+            "descriptionLocKey": "Decks/Precon/Precon_NPE_GRN_UW_Desc_2",
+            "quantity": null,
+            "locParams": {},
+            "availableDate": "0001-01-01T00:00:00"
+          },
+          "upgradePacket": null,
+          "childIds": []
+        },
+        {
+          "id": 27,
+          "unlockQuestMetric": null,
+          "unlockMetricCount": 0,
+          "chest": {
+            "image1": "ObjectiveEventIcon_DeckBox",
+            "image2": null,
+            "image3": null,
+            "prefab": "RewardPopup3DIcon_Deckbox",
+            "referenceId": "67276",
+            "headerLocKey": "MainNav/QuestRewards/Deck_UB",
+            "descriptionLocKey": "Decks/Precon/Precon_NPE_GRN_UB_Desc",
+            "quantity": null,
+            "locParams": {},
+            "availableDate": "0001-01-01T00:00:00"
+          },
+          "upgradePacket": null,
+          "childIds": []
+        },
+        {
+          "id": 28,
+          "unlockQuestMetric": null,
+          "unlockMetricCount": 0,
+          "chest": {
+            "image1": "ObjectiveEventIcon_DeckBox",
+            "image2": null,
+            "image3": null,
+            "prefab": "RewardPopup3DIcon_Deckbox",
+            "referenceId": "66839",
+            "headerLocKey": "MainNav/QuestRewards/Deck_BR",
+            "descriptionLocKey": "Decks/Precon/Precon_NPE_GRN_BR_Desc",
+            "quantity": null,
+            "locParams": {},
+            "availableDate": "0001-01-01T00:00:00"
+          },
+          "upgradePacket": null,
+          "childIds": []
+        },
+        {
+          "id": 29,
+          "unlockQuestMetric": null,
+          "unlockMetricCount": 0,
+          "chest": {
+            "image1": "ObjectiveEventIcon_DeckBox",
+            "image2": null,
+            "image3": null,
+            "prefab": "RewardPopup3DIcon_Deckbox",
+            "referenceId": "66325",
+            "headerLocKey": "MainNav/QuestRewards/Deck_RG",
+            "descriptionLocKey": "Decks/Precon/Precon_NPE_GRN_RG_Desc",
+            "quantity": null,
+            "locParams": {},
+            "availableDate": "0001-01-01T00:00:00"
+          },
+          "upgradePacket": null,
+          "childIds": []
+        }
+      ],
+      "topLevelNodeIds": [
+        0,
+        1,
+        2,
+        3,
+        4
+      ],
+      "enabled": true
+    },
+    "enabled": true
+  }
+]
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+<== Log.Info(23)
+True
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+<== Log.Info(24)
+True
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+==> Log.Info(25):
+{
+  "jsonrpc": "2.0",
+  "method": "Log.Info",
+  "params": {
+    "messageName": "Client.InventoryReport",
+    "humanContext": "Summary of inventory.",
+    "payloadObject": {
+      "gold": 12750,
+      "gems": 625,
+      "wcCommon": 15,
+      "wcUncommon": 6,
+      "wcRare": 0,
+      "wcMythic": 1,
+      "draftTokens": 0,
+      "sealedTokens": 0,
+      "playerId": "ANNON"
+    },
+    "transactionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "id": "25"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+==> Mercantile.GetAllProducts(26):
+{
+  "jsonrpc": "2.0",
+  "method": "Mercantile.GetAllProducts",
+  "params": {},
+  "id": "26"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:57 AM
+==> Log.Info(27):
+{
+  "jsonrpc": "2.0",
+  "method": "Log.Info",
+  "params": {
+    "messageName": "Client.PurchaseFunnel",
+    "humanContext": "Updated available store SKUs",
+    "payloadObject": {
+      "Context": "Client.PlayerUpdateStoreSku",
+      "playerId": "ANNON"
+    },
+    "transactionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "id": "27"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[Store - Auth - Get SKUs] 5/13/2019 10:09:57 AM Sending www message to https://api.platform.wizards.com/eco/store/skus/?currency=USD&country=US&locale=en-US with header Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IjM0NmM4YTY1NTBlZGI5MDRjM2IyNWI3ODlmOTllNjU3ODA4MGJiOTUiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiJOOFFGRzhORUJKNVQzNUZCIiwiZXhwIjoxNTU3NzY4Mjk1LCJpYXQiOjE1NTc3NjczOTUsImlzcyI6IkVaRlNWVVFUMkZGVFBNNVpMNkNCWFRXV01JIiwic3ViIjoiWEZIWEtKVVZWSkE3M0szUTRBU05FNlNMQ00iLCJ3b3RjLW5hbWUiOiJ2ZWxvY2ljb3B0ZXIjODM1MzgiLCJ3b3RjLWRvbW4iOiJ3aXphcmRzIiwid290Yy1nYW1lIjoiYXJlbmEiLCJ3b3RjLWZsZ3MiOjAsIndvdGMtcm9scyI6WyJNRE5BTFBIQSJdLCJ3b3RjLXBybXMiOltdLCJ3b3RjLXNjcHMiOlsiZmlyc3QtcGFydHkiXX0.GyGhhDkuX-bVqnDeE94_kO-75miQCTOomYXJDd2N20VZ8oXfX9TZOycIBiNu2QQq7ay2jtEnSkK66JLnan3MzIMnH0EbAS2JI31OKW51HU9sLdRy_HxNPy-zAD2v9zMccjlYmNaPV7Kvd_SBM1e8_HqGoSrQN57uVOCG6IvLgRXysst36OmfMuPPiWgCUjuLkKRKtdUldT1Go7IiKr6QoYE4MmOyMe2fvukMrVUcpbs5YB2vY2X9rnGg8Dx7Na41Zq33hOUTCeJrnpgbQ5-4tVktmCKyAuxZ_n1lHH0oxroq4UkbYTFl99unf79XaD6TD-Fj6B6-PWqYo1_ipItgZQ
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:58 AM
+<== Log.Info(25)
+True
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:58 AM
+<== Mercantile.GetAllProducts(26)
+[
+  {
+    "Id": "15bf8901-76fd-474c-be2c-78b3861d896a",
+    "SKU": "DAR-Gold",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 1000,
+    "UnitCount": 1,
+    "PurchaseCurrencyType": "Gold",
+    "StoreSection": "Packs",
+    "StoreSubSection": "DAR",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "3462e7c8-8be9-4089-af8d-7daf7a849357",
+    "SKU": "DAR-Gems-001",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 600,
+    "UnitCount": 3,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "DAR",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "58c3321e-3b76-43e4-a375-e172e9bfea29",
+    "SKU": "DAR-Gems-002",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 1200,
+    "UnitCount": 6,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "DAR",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "bb7284b3-13a0-4005-9991-0bf8038c9ac8",
+    "SKU": "DAR-Gems-003",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 3000,
+    "UnitCount": 15,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "DAR",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "70bd2941-291b-46dc-b6df-b8f07d6d5061",
+    "SKU": "GRN-Gold",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 1000,
+    "UnitCount": 1,
+    "PurchaseCurrencyType": "Gold",
+    "StoreSection": "Packs",
+    "StoreSubSection": "GRN",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "a6bff06a-1ba0-44ed-8b80-e740d01f553d",
+    "SKU": "GRN-Gems-001",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 600,
+    "UnitCount": 3,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "GRN",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "79dbce6d-382d-4593-afb8-26a7427a16c3",
+    "SKU": "GRN-Gems-002",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 1200,
+    "UnitCount": 6,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "GRN",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "618f0278-e777-4d56-aa85-7a8390e99d2b",
+    "SKU": "GRN-Gems-003",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 3000,
+    "UnitCount": 15,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "GRN",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "412e5cbc-b269-4b23-a4b5-268ce020bd78",
+    "SKU": "M19-Gold",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 1000,
+    "UnitCount": 1,
+    "PurchaseCurrencyType": "Gold",
+    "StoreSection": "Packs",
+    "StoreSubSection": "M19",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "86f7974f-a158-4008-bbb7-dfadf3ae3e41",
+    "SKU": "M19-Gems-001",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 600,
+    "UnitCount": 3,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "M19",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "d7820620-619c-46c2-a5e8-daed92bf0932",
+    "SKU": "M19-Gems-002",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 1200,
+    "UnitCount": 6,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "M19",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "9b010473-602d-4ac2-8213-9283c1ba439c",
+    "SKU": "M19-Gems-003",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 3000,
+    "UnitCount": 15,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "M19",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "6662cfe6-e3e8-41f9-840d-acf4ef729851",
+    "SKU": "RIX-Gold",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 1000,
+    "UnitCount": 1,
+    "PurchaseCurrencyType": "Gold",
+    "StoreSection": "Packs",
+    "StoreSubSection": "RIX",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "deddc6b1-97c0-4743-8423-94ce7a427db3",
+    "SKU": "RIX-Gems-001",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 600,
+    "UnitCount": 3,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "RIX",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "f7e248e2-bb68-4546-9199-548505249b7f",
+    "SKU": "RIX-Gems-002",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 1200,
+    "UnitCount": 6,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "RIX",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "ea60ab18-031e-40a2-998e-30f1f09dcab7",
+    "SKU": "RIX-Gems-003",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 3000,
+    "UnitCount": 15,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "RIX",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "5c0164a7-9e32-462f-9983-3eeaa2c422a2",
+    "SKU": "RIX-Gems-004",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 9000,
+    "UnitCount": 45,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "RIX",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "f0369403-dcb5-41c7-8797-8d655a991430",
+    "SKU": "RIX-Gems-005",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 18000,
+    "UnitCount": 90,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "RIX",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "3817bf08-aab1-4c45-8c84-9e19bf64fd8b",
+    "SKU": "RNA-Gold",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 1000,
+    "UnitCount": 1,
+    "PurchaseCurrencyType": "Gold",
+    "StoreSection": "Packs",
+    "StoreSubSection": "RNA",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "895aded4-e01e-4271-858e-2806c8959241",
+    "SKU": "RNA-Gems-001",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 600,
+    "UnitCount": 3,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "RNA",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "52024080-9118-4611-b09e-5e88b3ff64c0",
+    "SKU": "RNA-Gems-002",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 1200,
+    "UnitCount": 6,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "RNA",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "a495fd18-f8d0-42eb-b7cf-ee77e3fb7e15",
+    "SKU": "RNA-Gems-003",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 3000,
+    "UnitCount": 15,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "RNA",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "27c2f4eb-b676-48be-a778-55fcc67d15c3",
+    "SKU": "WAR-Gold",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 1000,
+    "UnitCount": 1,
+    "PurchaseCurrencyType": "Gold",
+    "StoreSection": "Packs",
+    "StoreSubSection": "WAR",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "b2cd5c89-8aa4-4d95-ba5c-bb41441c460f",
+    "SKU": "WAR-Gems-001",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 600,
+    "UnitCount": 3,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "WAR",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "76564e0e-aaeb-4efc-88b2-9dca1d6c298c",
+    "SKU": "WAR-Gems-002",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 1200,
+    "UnitCount": 6,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "WAR",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "6fb7d468-7236-4b04-97e9-a2fa3afb0e20",
+    "SKU": "WAR-Gems-003",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 3000,
+    "UnitCount": 15,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "WAR",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "b12227db-9a95-4e50-9d11-b1e230532598",
+    "SKU": "XLN-Gold",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 1000,
+    "UnitCount": 1,
+    "PurchaseCurrencyType": "Gold",
+    "StoreSection": "Packs",
+    "StoreSubSection": "XLN",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "ce066c2d-6f43-4f75-aebf-0e8d1bf7c1a8",
+    "SKU": "XLN-Gems-001",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 600,
+    "UnitCount": 3,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "XLN",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "f362cdf7-b07c-4a25-b5da-ed89f8e3d9b3",
+    "SKU": "XLN-Gems-002",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 1200,
+    "UnitCount": 6,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "XLN",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "c4843dad-d163-4979-80d7-28ab75bd07d4",
+    "SKU": "XLN-Gems-003",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 3000,
+    "UnitCount": 15,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "XLN",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "35ba84e3-1429-4db2-a291-ccf0890acd6f",
+    "SKU": "XLN-Gems-004",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 9000,
+    "UnitCount": 45,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "XLN",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "be6d4b85-673a-402a-9c79-d9d2367d6d0e",
+    "SKU": "XLN-Gems-005",
+    "MaxPurchaseQuantity": 99,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 18000,
+    "UnitCount": 90,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "XLN",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "cd496d3c-6bf7-4484-a341-2f142637e8d4",
+    "SKU": "MTGA-Gems-001",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 0,
+    "UnitCount": 750,
+    "PurchaseCurrencyType": "RMT",
+    "StoreSection": "Gems",
+    "StoreSubSection": null,
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "b408b65f-7d00-454a-8374-fd0c27159406",
+    "SKU": "MTGA-Gems-002",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 0,
+    "UnitCount": 1600,
+    "PurchaseCurrencyType": "RMT",
+    "StoreSection": "Gems",
+    "StoreSubSection": null,
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "8ae9ddeb-7d30-4022-a1fa-fc42e8242dcc",
+    "SKU": "MTGA-Gems-003",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 0,
+    "UnitCount": 3400,
+    "PurchaseCurrencyType": "RMT",
+    "StoreSection": "Gems",
+    "StoreSubSection": null,
+    "FeaturedIndex": 10,
+    "Enabled": true
+  },
+  {
+    "Id": "30c903d2-f979-4cc2-aa48-ce8256b73258",
+    "SKU": "MTGA-Gems-004",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 0,
+    "UnitCount": 9200,
+    "PurchaseCurrencyType": "RMT",
+    "StoreSection": "Gems",
+    "StoreSubSection": null,
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "3139ee90-f0a4-4511-b0f5-a92190a9f96e",
+    "SKU": "MTGA-Gems-005",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 0,
+    "UnitCount": 20000,
+    "PurchaseCurrencyType": "RMT",
+    "StoreSection": "Gems",
+    "StoreSubSection": null,
+    "FeaturedIndex": 30,
+    "Enabled": true
+  },
+  {
+    "Id": "c25d9120-9807-42a9-a223-9788fdf0538f",
+    "SKU": "Bundle_Draft_WAR_Black",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": 1,
+    "AccountRemainingFulfillments": 1,
+    "Price": 4000,
+    "UnitCount": 1,
+    "PurchaseCurrencyType": "Gold",
+    "StoreSection": "Bundles",
+    "StoreSubSection": null,
+    "FeaturedIndex": 48,
+    "Enabled": true
+  },
+  {
+    "Id": "3e68eab4-f19e-4e5c-ae3c-0a90522ca12e",
+    "SKU": "Bundle_Draft_WAR_Blue",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": 1,
+    "AccountRemainingFulfillments": 1,
+    "Price": 4000,
+    "UnitCount": 1,
+    "PurchaseCurrencyType": "Gold",
+    "StoreSection": "Bundles",
+    "StoreSubSection": null,
+    "FeaturedIndex": 49,
+    "Enabled": true
+  },
+  {
+    "Id": "73e5d33e-f773-4fea-b1be-b3ef00f273c7",
+    "SKU": "Bundle_Draft_WAR_Green",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": 1,
+    "AccountRemainingFulfillments": 1,
+    "Price": 4000,
+    "UnitCount": 1,
+    "PurchaseCurrencyType": "Gold",
+    "StoreSection": "Bundles",
+    "StoreSubSection": null,
+    "FeaturedIndex": 46,
+    "Enabled": true
+  },
+  {
+    "Id": "d4adecd2-ab93-49aa-bf32-c14c2b0612b0",
+    "SKU": "Bundle_Draft_WAR_Red",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": 1,
+    "AccountRemainingFulfillments": 1,
+    "Price": 4000,
+    "UnitCount": 1,
+    "PurchaseCurrencyType": "Gold",
+    "StoreSection": "Bundles",
+    "StoreSubSection": null,
+    "FeaturedIndex": 47,
+    "Enabled": true
+  },
+  {
+    "Id": "ce8b9faa-7161-42b0-998d-fc3e66e31673",
+    "SKU": "Bundle_Draft_WAR_White",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": 1,
+    "AccountRemainingFulfillments": 1,
+    "Price": 4000,
+    "UnitCount": 1,
+    "PurchaseCurrencyType": "Gold",
+    "StoreSection": "Bundles",
+    "StoreSubSection": null,
+    "FeaturedIndex": 50,
+    "Enabled": true
+  },
+  {
+    "Id": "0106410b-9add-4738-8645-e2fc0e793246",
+    "SKU": "Bundle_EssentialBolas",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": 1,
+    "AccountRemainingFulfillments": 1,
+    "Price": 4000,
+    "UnitCount": 1,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Bundles",
+    "StoreSubSection": null,
+    "FeaturedIndex": 80,
+    "Enabled": true
+  },
+  {
+    "Id": "64da6670-90e3-48d8-95d0-512511718b65",
+    "SKU": "Bundle_Explorer",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": 1,
+    "AccountRemainingFulfillments": 1,
+    "Price": 0,
+    "UnitCount": 1,
+    "PurchaseCurrencyType": "RMT",
+    "StoreSection": "Bundles",
+    "StoreSubSection": null,
+    "FeaturedIndex": 90,
+    "Enabled": true
+  },
+  {
+    "Id": "66805310-6d55-495d-9a4f-68e9c31b1688",
+    "SKU": "Bundle_GatewatchsTriumph",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": 1,
+    "AccountRemainingFulfillments": 1,
+    "Price": 1000,
+    "UnitCount": 1,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Bundles",
+    "StoreSubSection": null,
+    "FeaturedIndex": 70,
+    "Enabled": true
+  },
+  {
+    "Id": "87a7abc6-486f-43ff-94e9-c44022fdceca",
+    "SKU": "Bundle_Guild_Azorius",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": 1,
+    "AccountRemainingFulfillments": 1,
+    "Price": 3000,
+    "UnitCount": 1,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "GuildBundles",
+    "StoreSubSection": null,
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "8e9f1b18-39e8-4fe1-a66a-3253aa34f96d",
+    "SKU": "Bundle_Guild_Boros",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": 1,
+    "AccountRemainingFulfillments": 1,
+    "Price": 3000,
+    "UnitCount": 1,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "GuildBundles",
+    "StoreSubSection": null,
+    "FeaturedIndex": 60,
+    "Enabled": true
+  },
+  {
+    "Id": "24ae4c05-cacf-42f4-8d85-73f0e8f8c5b6",
+    "SKU": "Bundle_Guild_Dimir",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": 1,
+    "AccountRemainingFulfillments": 1,
+    "Price": 3000,
+    "UnitCount": 1,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "GuildBundles",
+    "StoreSubSection": null,
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "e3988000-cd24-4061-bab1-a627ffb21e44",
+    "SKU": "Bundle_Guild_Golgari",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": 1,
+    "AccountRemainingFulfillments": 1,
+    "Price": 3000,
+    "UnitCount": 1,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "GuildBundles",
+    "StoreSubSection": null,
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "dde13f86-d6ff-4cba-b603-8a12a33f8f70",
+    "SKU": "Bundle_Guild_Gruul",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": 1,
+    "AccountRemainingFulfillments": 1,
+    "Price": 3000,
+    "UnitCount": 1,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "GuildBundles",
+    "StoreSubSection": null,
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "58302305-1302-43ce-99e2-4d26220d8b41",
+    "SKU": "Bundle_Guild_Izzet",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": 1,
+    "AccountRemainingFulfillments": 1,
+    "Price": 3000,
+    "UnitCount": 1,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "GuildBundles",
+    "StoreSubSection": null,
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "90c2e70f-ee00-48b2-b1bf-d1ebb11dab5d",
+    "SKU": "Bundle_Guild_Orzhov",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": 1,
+    "AccountRemainingFulfillments": 1,
+    "Price": 3000,
+    "UnitCount": 1,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "GuildBundles",
+    "StoreSubSection": null,
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "010bdf54-422d-4f6e-b5a2-a552eb3984ad",
+    "SKU": "Bundle_Guild_Rakdos",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": 1,
+    "AccountRemainingFulfillments": 1,
+    "Price": 3000,
+    "UnitCount": 1,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "GuildBundles",
+    "StoreSubSection": null,
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "f7af3060-8d88-44e3-b3a1-fd70049a7c9f",
+    "SKU": "Bundle_Guild_Selesnya",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": 1,
+    "AccountRemainingFulfillments": 1,
+    "Price": 3000,
+    "UnitCount": 1,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "GuildBundles",
+    "StoreSubSection": null,
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "74895aab-926b-4da9-abbc-f270050394b6",
+    "SKU": "Bundle_Guild_Simic",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": 1,
+    "AccountRemainingFulfillments": 1,
+    "Price": 3000,
+    "UnitCount": 1,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "GuildBundles",
+    "StoreSubSection": null,
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "876e7bb4-616d-4007-b9cd-665d350a2c17",
+    "SKU": "Bundle_Sleeves_Mana",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": 1,
+    "AccountRemainingFulfillments": 0,
+    "Price": 10000,
+    "UnitCount": 1,
+    "PurchaseCurrencyType": "Gold",
+    "StoreSection": "Bundles",
+    "StoreSubSection": null,
+    "FeaturedIndex": 40,
+    "Enabled": true
+  },
+  {
+    "Id": "73cb6204-28ee-4690-8ef8-193d89426456",
+    "SKU": "DAR-Packs-004",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 9000,
+    "UnitCount": 45,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "DAR",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "9e63067c-590a-48a9-b6eb-78398876e387",
+    "SKU": "DAR-Packs-005",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 18000,
+    "UnitCount": 90,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "DAR",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "4f48f028-26a9-471e-8f4c-68a3f7b2149a",
+    "SKU": "GRN-Packs-004",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 9000,
+    "UnitCount": 45,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "GRN",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "6b940990-5fbe-4ad8-bf2d-09cfd46142ac",
+    "SKU": "GRN-Packs-005",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 18000,
+    "UnitCount": 90,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "GRN",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "3f7ab75c-6d13-4374-9902-bb697888b75f",
+    "SKU": "M19-Gems-004",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 9000,
+    "UnitCount": 45,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "M19",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "d700e5b9-0840-4e9e-a226-db9c30886be6",
+    "SKU": "M19-Gems-005",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 18000,
+    "UnitCount": 90,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "M19",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "64da6670-90e3-48d8-95d0-512511718b65",
+    "SKU": "MTGA-StarterBundle",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": 1,
+    "AccountRemainingFulfillments": 1,
+    "Price": 0,
+    "UnitCount": 1,
+    "PurchaseCurrencyType": "RMT",
+    "StoreSection": "Bundles",
+    "StoreSubSection": null,
+    "FeaturedIndex": 100,
+    "Enabled": true
+  },
+  {
+    "Id": "ed81de1d-f1a9-4b01-85a5-b04ff254bb43",
+    "SKU": "RNA-Packs-004",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 9000,
+    "UnitCount": 45,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "RNA",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "edec07c5-e072-4ef0-b226-b6ffc0d1ce09",
+    "SKU": "RNA-Packs-005",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 18000,
+    "UnitCount": 90,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "RNA",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "9af937f9-16bc-4d88-86ad-5665a6b8759f",
+    "SKU": "WAR-Packs-004",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 9000,
+    "UnitCount": 45,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "WAR",
+    "FeaturedIndex": -1,
+    "Enabled": true
+  },
+  {
+    "Id": "29cc5d68-ca32-498b-b3b7-2fc20b463f5e",
+    "SKU": "WAR-Packs-005",
+    "MaxPurchaseQuantity": 1,
+    "AccountMax": -1,
+    "AccountRemainingFulfillments": -1,
+    "Price": 18000,
+    "UnitCount": 90,
+    "PurchaseCurrencyType": "Gem",
+    "StoreSection": "Packs",
+    "StoreSubSection": "WAR",
+    "FeaturedIndex": 20,
+    "Enabled": true
+  }
+]
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:58 AM
+<== Log.Info(27)
+True
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[Store - Get SKUs] Successfully retrieved Ecom SKUs.
+5/13/2019 10:09:58 AM | Response: {"skus":[{"id":"fb31641a-6abe-4cc2-9054-dcd475eaaf75","name":"Bundle_Explorer","variants":[{"id":1,"name":"Bundle_Explorer","price":{"currencyCode":"USD","price":"14.99","priceWithCurrencySymbol":"$14.99"},"purchaseLimit":1,"remainingLimit":0}]},{"id":"1df686b4-deee-4729-8677-563416f168a0","name":"Gems","variants":[{"id":1,"name":"MTGA-Gems-001","price":{"currencyCode":"USD","price":"4.99","priceWithCurrencySymbol":"$4.99"},"purchaseLimit":-1,"remainingLimit":0},{"id":2,"name":"MTGA-Gems-002","price":{"currencyCode":"USD","price":"9.99","priceWithCurrencySymbol":"$9.99"},"purchaseLimit":-1,"remainingLimit":0},{"id":3,"name":"MTGA-Gems-003","price":{"currencyCode":"USD","price":"19.99","priceWithCurrencySymbol":"$19.99"},"purchaseLimit":-1,"remainingLimit":0},{"id":4,"name":"MTGA-Gems-004","price":{"currencyCode":"USD","price":"49.99","priceWithCurrencySymbol":"$49.99"},"purchaseLimit":-1,"remainingLimit":0},{"id":5,"name":"MTGA-Gems-005","price":{"currencyCode":"USD","price":"99.99","priceWithCurrencySymbol":"$99.99"},"purchaseLimit":-1,"remainingLimit":0}]},{"id":"b25541ff-94aa-4185-ac95-12beefa50e90","name":"MTGA-StarterBundle","variants":[{"id":1,"name":"MTGA-StarterBundle","price":{"currencyCode":"USD","price":"4.99","priceWithCurrencySymbol":"$4.99"},"purchaseLimit":1,"remainingLimit":0}]}],"card":null,"offset":0,"count":0,"total":0,"message":null}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:58 AM
+==> MotD.GetMotD(28):
+{
+  "jsonrpc": "2.0",
+  "method": "MotD.GetMotD",
+  "params": {},
+  "id": "28"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:58 AM
+<== MotD.GetMotD(28)
+{
+  "Message": null,
+  "Title": null,
+  "ImageId": "00000000-0000-0000-0000-000000000000"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:58 AM
+==> Log.Info(29):
+{
+  "jsonrpc": "2.0",
+  "method": "Log.Info",
+  "params": {
+    "messageName": "Client.SceneChange",
+    "humanContext": "Client changed scenes to Home, duration 00:00:04.9258134",
+    "payloadObject": {
+      "fromSceneName": "Splash",
+      "toSceneName": "Home",
+      "timestamp": "2019-05-13T17:09:58.4719131Z",
+      "duration": "00:00:04.9258134",
+      "initiator": "System",
+      "context": "Landing Page 'Home'",
+      "playerId": "ANNON"
+    },
+    "transactionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "id": "29"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:58 AM
+<== Log.Info(29)
+True
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:58 AM
+==> Event.GetActiveEventsV2(30):
+{
+  "jsonrpc": "2.0",
+  "method": "Event.GetActiveEventsV2",
+  "params": {},
+  "id": "30"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:58 AM
+==> Config.JoinEventQueueStatus(31):
+{
+  "jsonrpc": "2.0",
+  "method": "Config.JoinEventQueueStatus",
+  "params": {},
+  "id": "31"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:58 AM
+==> Quest.GetPlayerQuests(32):
+{
+  "jsonrpc": "2.0",
+  "method": "Quest.GetPlayerQuests",
+  "params": {},
+  "id": "32"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:58 AM
+==> Quest.GetTrackDetail(33):
+{
+  "jsonrpc": "2.0",
+  "method": "Quest.GetTrackDetail",
+  "params": {
+    "trackName": "Promotional"
+  },
+  "id": "33"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:58 AM
+==> PlayerInventory.GetPlayerSequenceData(34):
+{
+  "jsonrpc": "2.0",
+  "method": "PlayerInventory.GetPlayerSequenceData",
+  "params": {},
+  "id": "34"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+EnableLoadingIndicator.  shouldEnable = True _loadingGameObject=121238
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:58 AM
+<== Event.GetActiveEventsV2(30)
+[
+  {
+    "PublicEventName": "AIBotMatch",
+    "InternalEventName": "AIBotMatch",
+    "EventState": "Active",
+    "EventType": "Constructed",
+    "ModuleGlobalData": {
+      "DeckSelect": "Standard"
+    },
+    "StartTime": "2018-04-30T15:40:22.4181124Z",
+    "LockedTime": "2118-01-01T15:40:21.4181124Z",
+    "ClosedTime": "2118-01-01T15:40:21.4181124Z",
+    "Parameters": {},
+    "Group": "",
+    "PastEntries": null,
+    "DisplayPriority": -1,
+    "IsArenaPlayModeEvent": true,
+    "Emblems": null,
+    "UsePlayerCourse": false
+  },
+  {
+    "PublicEventName": "WAR_Comp_Draft",
+    "InternalEventName": "CompDraft_WAR_20190425",
+    "EventState": "Active",
+    "EventType": "Limited",
+    "ModuleGlobalData": {
+      "EntryFees": [
+        {
+          "CurrencyType": "Gem",
+          "Quantity": 1500,
+          "MaxUses": null
+        },
+        {
+          "CurrencyType": "DraftToken",
+          "Quantity": 1,
+          "MaxUses": null
+        }
+      ],
+      "CollationIds": [
+        200013,
+        200013,
+        200013
+      ],
+      "DeckSelect": "Draft",
+      "MaxWins": 5,
+      "MaxLosses": 2,
+      "Prizes": [
+        "d8bdd219-13c7-4cb7-b8d0-5127e8c7c051",
+        "1eed4b91-cd78-4eb1-8b80-6535032ae855",
+        "1903dcd7-2021-4113-a8e0-29a2af59a09a",
+        "d2a403cc-dbcd-4e46-a221-f03c48b10057",
+        "8c6c732d-5f2d-4715-93c9-14525736c5e2",
+        "970f5f3b-e038-4e55-8c14-1b6f878b76db"
+      ],
+      "ChestDescriptions": [
+        {
+          "image1": "ObjectiveIcon_Pack_WAR",
+          "image2": null,
+          "image3": null,
+          "prefab": "RewardPopup3DIcon_Pack",
+          "referenceId": "100013",
+          "headerLocKey": "MainNav/EventRewards/Pack",
+          "descriptionLocKey": "MainNav/General/Empty_String",
+          "quantity": "0",
+          "locParams": {},
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveIcon_Pack_WAR",
+          "image2": null,
+          "image3": null,
+          "prefab": "RewardPopup3DIcon_Pack",
+          "referenceId": "100013",
+          "headerLocKey": "MainNav/EventRewards/Packs",
+          "descriptionLocKey": "MainNav/General/Empty_String",
+          "quantity": "2",
+          "locParams": {
+            "number1": 2
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Gem5",
+          "image2": null,
+          "image3": "ObjectiveIcon_Pack_WAR",
+          "prefab": "RewardPopup3DIcon_GemPack",
+          "referenceId": "100013",
+          "headerLocKey": "MainNav/EventRewards/Gems_And_Packs",
+          "descriptionLocKey": "MainNav/General/Empty_String",
+          "quantity": "3",
+          "locParams": {
+            "number1": 800,
+            "number2": 3
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Gem5",
+          "image2": null,
+          "image3": "ObjectiveIcon_Pack_WAR",
+          "prefab": "RewardPopup3DIcon_GemPack",
+          "referenceId": "100013",
+          "headerLocKey": "MainNav/EventRewards/Gems_And_Packs",
+          "descriptionLocKey": "MainNav/General/Empty_String",
+          "quantity": "4",
+          "locParams": {
+            "number1": 1500,
+            "number2": 4
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Gem7",
+          "image2": null,
+          "image3": "ObjectiveIcon_Pack_WAR",
+          "prefab": "RewardPopup3DIcon_GemPack",
+          "referenceId": "100013",
+          "headerLocKey": "MainNav/EventRewards/Gems_And_Packs",
+          "descriptionLocKey": "MainNav/General/Empty_String",
+          "quantity": "5",
+          "locParams": {
+            "number1": 1800,
+            "number2": 5
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Gem8",
+          "image2": null,
+          "image3": "ObjectiveIcon_Pack_WAR",
+          "prefab": "RewardPopup3DIcon_GemPack",
+          "referenceId": "100013",
+          "headerLocKey": "MainNav/EventRewards/Gems_And_Packs",
+          "descriptionLocKey": "MainNav/General/Empty_String",
+          "quantity": "6",
+          "locParams": {
+            "number1": 2100,
+            "number2": 6
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        }
+      ]
+    },
+    "StartTime": "2019-04-29T15:00:00Z",
+    "LockedTime": "2019-07-08T15:00:00Z",
+    "ClosedTime": "2019-07-08T18:00:00Z",
+    "Parameters": {},
+    "Group": "",
+    "PastEntries": null,
+    "DisplayPriority": 64,
+    "IsArenaPlayModeEvent": true,
+    "Emblems": null,
+    "UsePlayerCourse": true
+  },
+  {
+    "PublicEventName": "ConstructedBestOf3",
+    "InternalEventName": "Constructed_BestOf3",
+    "EventState": "Active",
+    "EventType": "Constructed",
+    "ModuleGlobalData": {
+      "DeckSelect": "TraditionalStandard"
+    },
+    "StartTime": "2018-01-20T18:00:00Z",
+    "LockedTime": "2118-12-20T18:00:00Z",
+    "ClosedTime": "2118-12-20T18:00:00Z",
+    "Parameters": {},
+    "Group": "",
+    "PastEntries": null,
+    "DisplayPriority": -1,
+    "IsArenaPlayModeEvent": false,
+    "Emblems": null,
+    "UsePlayerCourse": true
+  },
+  {
+    "PublicEventName": "Constructed_Event",
+    "InternalEventName": "Constructed_Event",
+    "EventState": "Active",
+    "EventType": "Constructed",
+    "ModuleGlobalData": {
+      "EntryFees": [
+        {
+          "CurrencyType": "Gold",
+          "Quantity": 500,
+          "MaxUses": null
+        },
+        {
+          "CurrencyType": "Gem",
+          "Quantity": 95,
+          "MaxUses": null
+        }
+      ],
+      "DeckSelect": "Standard",
+      "MaxWins": 7,
+      "MaxLosses": 3,
+      "Prizes": [
+        "732b07cd-1da9-407d-9f4a-0234c74e0aae",
+        "da62c8f2-c6df-4037-9e80-2113eae03ccd",
+        "76c2c941-1ef3-45c1-b320-f2b392ae1ee3",
+        "262c6553-de23-41f5-a9da-c1e64f327db2",
+        "b8d6867a-5838-4356-88f9-1e232ec9a38d",
+        "eae07b94-2021-4338-b59a-ec68e2b78f88",
+        "9b7e2295-5ae8-405d-96f7-94a6e563a00f",
+        "585e5a86-0a76-43e3-9bc8-1d89ef20e254"
+      ],
+      "ChestDescriptions": [
+        {
+          "image1": "ObjectiveEventIcon_Coin1",
+          "image2": "ObjectiveEventIcon_CardsA3B0",
+          "image3": null,
+          "prefab": "RewardPopup3DIcon_CoinCard",
+          "referenceId": "0",
+          "headerLocKey": "MainNav/EventRewards/Gold_And_Cards",
+          "descriptionLocKey": "MainNav/EventPage/Event_Popup_Text_Constructed_Zero_To_Three_Win",
+          "quantity": "0",
+          "locParams": {
+            "number1": 100,
+            "number2": 3
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Coin2",
+          "image2": "ObjectiveEventIcon_CardsA3B0",
+          "image3": null,
+          "prefab": "RewardPopup3DIcon_CoinCard",
+          "referenceId": "0",
+          "headerLocKey": "MainNav/EventRewards/Gold_And_Cards",
+          "descriptionLocKey": "MainNav/EventPage/Event_Popup_Text_Constructed_Zero_To_Three_Win",
+          "quantity": "0",
+          "locParams": {
+            "number1": 200,
+            "number2": 3
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Coin3",
+          "image2": "ObjectiveEventIcon_CardsA3B0",
+          "image3": null,
+          "prefab": "RewardPopup3DIcon_CoinCard",
+          "referenceId": "0",
+          "headerLocKey": "MainNav/EventRewards/Gold_And_Cards",
+          "descriptionLocKey": "MainNav/EventPage/Event_Popup_Text_Constructed_Zero_To_Three_Win",
+          "quantity": "0",
+          "locParams": {
+            "number1": 300,
+            "number2": 3
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Coin4",
+          "image2": "ObjectiveEventIcon_CardsA3B0",
+          "image3": null,
+          "prefab": "RewardPopup3DIcon_CoinCard",
+          "referenceId": "0",
+          "headerLocKey": "MainNav/EventRewards/Gold_And_Cards",
+          "descriptionLocKey": "MainNav/EventPage/Event_Popup_Text_Constructed_Zero_To_Three_Win",
+          "quantity": "0",
+          "locParams": {
+            "number1": 400,
+            "number2": 3
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Coin5",
+          "image2": "ObjectiveEventIcon_CardsA3B0",
+          "image3": null,
+          "prefab": "RewardPopup3DIcon_CoinCard",
+          "referenceId": "0",
+          "headerLocKey": "MainNav/EventRewards/Gold_And_Cards",
+          "descriptionLocKey": "MainNav/EventPage/Event_Popup_Text_Constructed_Zero_To_Three_Win",
+          "quantity": "0",
+          "locParams": {
+            "number1": 500,
+            "number2": 3
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Coin6",
+          "image2": "ObjectiveEventIcon_CardsA2B1",
+          "image3": null,
+          "prefab": "RewardPopup3DIcon_CoinCard",
+          "referenceId": "0",
+          "headerLocKey": "MainNav/EventRewards/Gold_And_Cards",
+          "descriptionLocKey": "MainNav/EventPage/Event_Popup_Text_Constructed_Four_To_Five_Win",
+          "quantity": "0",
+          "locParams": {
+            "number1": 600,
+            "number2": 3
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Coin7",
+          "image2": "ObjectiveEventIcon_CardsA1B2",
+          "image3": null,
+          "prefab": "RewardPopup3DIcon_CoinCard",
+          "referenceId": "0",
+          "headerLocKey": "MainNav/EventRewards/Gold_And_Cards",
+          "descriptionLocKey": "MainNav/EventPage/Event_Popup_Text_Constructed_Six_To_Seven_Win",
+          "quantity": "0",
+          "locParams": {
+            "number1": 800,
+            "number2": 3
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Coin8",
+          "image2": "ObjectiveEventIcon_CardsA1B2",
+          "image3": null,
+          "prefab": "RewardPopup3DIcon_CoinCard",
+          "referenceId": "0",
+          "headerLocKey": "MainNav/EventRewards/Gold_And_Cards",
+          "descriptionLocKey": "MainNav/EventPage/Event_Popup_Text_Constructed_Six_To_Seven_Win",
+          "quantity": "0",
+          "locParams": {
+            "number1": 1000,
+            "number2": 3
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        }
+      ]
+    },
+    "StartTime": "2018-12-14T16:00:22Z",
+    "LockedTime": "2020-04-01T16:00:22Z",
+    "ClosedTime": "2020-04-01T19:00:22Z",
+    "Parameters": {},
+    "Group": "",
+    "PastEntries": null,
+    "DisplayPriority": 94,
+    "IsArenaPlayModeEvent": false,
+    "Emblems": [],
+    "UsePlayerCourse": true
+  },
+  {
+    "PublicEventName": "Constructed_Ravnica",
+    "InternalEventName": "Constructed_Ravnica_20190509",
+    "EventState": "Active",
+    "EventType": "Constructed",
+    "ModuleGlobalData": {
+      "EntryFees": [
+        {
+          "CurrencyType": "Gold",
+          "Quantity": 250,
+          "MaxUses": null
+        },
+        {
+          "CurrencyType": "Gem",
+          "Quantity": 50,
+          "MaxUses": null
+        }
+      ],
+      "DeckSelect": "Ravnica",
+      "MaxWins": 5,
+      "MaxLosses": 2,
+      "Prizes": [
+        "edff49e1-8cb6-4ff7-81dc-008a45fc4c83",
+        "78c70efd-07ec-423a-b9c1-bfb67928faac",
+        "c65c7664-2b83-452a-96c2-8bdb79b1c342",
+        "5e033552-f111-46af-905a-d4f0b4e0097d",
+        "fe16b1fa-837e-4e16-946b-15c7c511327c",
+        "a5b172ba-1a0f-4b56-b09c-ee9e396c8cc5"
+      ],
+      "ChestDescriptions": [
+        {
+          "image1": "ObjectiveEventIcon_Coin1",
+          "image2": "ObjectiveEventIcon_CardsA2B0",
+          "image3": null,
+          "prefab": "RewardPopup3DIcon_CoinCard",
+          "referenceId": null,
+          "headerLocKey": "MainNav/EventRewards/Gold_And_Cards",
+          "descriptionLocKey": "MainNav/EventRewards/2U",
+          "quantity": "",
+          "locParams": {
+            "number1": 50,
+            "number2": 2
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Coin2",
+          "image2": "ObjectiveEventIcon_CardsA2B0",
+          "image3": null,
+          "prefab": "RewardPopup3DIcon_CoinCard",
+          "referenceId": null,
+          "headerLocKey": "MainNav/EventRewards/Gold_And_Cards",
+          "descriptionLocKey": "MainNav/EventRewards/2U",
+          "quantity": "",
+          "locParams": {
+            "number1": 100,
+            "number2": 2
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Coin3",
+          "image2": "ObjectiveEventIcon_CardsA2B0",
+          "image3": null,
+          "prefab": "RewardPopup3DIcon_CoinCard",
+          "referenceId": null,
+          "headerLocKey": "MainNav/EventRewards/Gold_And_Cards",
+          "descriptionLocKey": "MainNav/EventRewards/2U",
+          "quantity": "",
+          "locParams": {
+            "number1": 150,
+            "number2": 2
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Coin4",
+          "image2": "ObjectiveEventIcon_CardsA2B0",
+          "image3": null,
+          "prefab": "RewardPopup3DIcon_CoinCard",
+          "referenceId": null,
+          "headerLocKey": "MainNav/EventRewards/Gold_And_Cards",
+          "descriptionLocKey": "MainNav/EventRewards/2U",
+          "quantity": "",
+          "locParams": {
+            "number1": 200,
+            "number2": 2
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Coin5",
+          "image2": "ObjectiveEventIcon_CardsA1B1",
+          "image3": null,
+          "prefab": "RewardPopup3DIcon_CoinCard",
+          "referenceId": null,
+          "headerLocKey": "MainNav/EventRewards/Gold_And_Cards",
+          "descriptionLocKey": "MainNav/EventRewards/1R_1U",
+          "quantity": "",
+          "locParams": {
+            "number1": 250,
+            "number2": 2
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Coin6",
+          "image2": "ObjectiveEventIcon_CardsA1B1",
+          "image3": null,
+          "prefab": "RewardPopup3DIcon_CoinCard",
+          "referenceId": null,
+          "headerLocKey": "MainNav/EventRewards/Gold_And_Cards",
+          "descriptionLocKey": "MainNav/EventRewards/1R_1U",
+          "quantity": "",
+          "locParams": {
+            "number1": 300,
+            "number2": 2
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        }
+      ]
+    },
+    "StartTime": "2019-05-10T15:00:00Z",
+    "LockedTime": "2019-05-13T15:00:00Z",
+    "ClosedTime": "2019-05-13T18:00:00Z",
+    "Parameters": {},
+    "Group": "",
+    "PastEntries": null,
+    "DisplayPriority": 21,
+    "IsArenaPlayModeEvent": true,
+    "Emblems": null,
+    "UsePlayerCourse": true
+  },
+  {
+    "PublicEventName": "DirectGame",
+    "InternalEventName": "DirectGame",
+    "EventState": "Active",
+    "EventType": "Constructed",
+    "ModuleGlobalData": {
+      "DeckSelect": "DirectGame"
+    },
+    "StartTime": "2018-10-15T07:00:12Z",
+    "LockedTime": "2243-01-01T00:00:11Z",
+    "ClosedTime": "2243-01-01T00:00:11Z",
+    "Parameters": {},
+    "Group": "",
+    "PastEntries": null,
+    "DisplayPriority": -1,
+    "IsArenaPlayModeEvent": true,
+    "Emblems": [],
+    "UsePlayerCourse": false
+  },
+  {
+    "PublicEventName": "Ladder",
+    "InternalEventName": "Ladder",
+    "EventState": "Active",
+    "EventType": "Constructed",
+    "ModuleGlobalData": {
+      "DeckSelect": "Standard",
+      "RankUpdateType": "Constructed"
+    },
+    "StartTime": "2018-11-14T18:00:00Z",
+    "LockedTime": "2118-12-20T18:00:00Z",
+    "ClosedTime": "2118-12-20T18:00:00Z",
+    "Parameters": {},
+    "Group": "",
+    "PastEntries": null,
+    "DisplayPriority": -1,
+    "IsArenaPlayModeEvent": true,
+    "Emblems": null,
+    "UsePlayerCourse": true
+  },
+  {
+    "PublicEventName": "NPE",
+    "InternalEventName": "NPE",
+    "EventState": "Active",
+    "EventType": "Constructed",
+    "ModuleGlobalData": {},
+    "StartTime": "2018-04-30T15:40:22.4181124Z",
+    "LockedTime": "2118-01-01T15:40:21.4181124Z",
+    "ClosedTime": "2118-01-01T15:40:21.4181124Z",
+    "Parameters": {},
+    "Group": "NPE",
+    "PastEntries": null,
+    "DisplayPriority": -1,
+    "IsArenaPlayModeEvent": true,
+    "Emblems": null,
+    "UsePlayerCourse": true
+  },
+  {
+    "PublicEventName": "Play",
+    "InternalEventName": "Play",
+    "EventState": "Active",
+    "EventType": "Constructed",
+    "ModuleGlobalData": {
+      "DeckSelect": "Standard"
+    },
+    "StartTime": "2018-11-14T18:00:00Z",
+    "LockedTime": "2118-12-20T18:00:00Z",
+    "ClosedTime": "2118-12-20T18:00:00Z",
+    "Parameters": {},
+    "Group": "",
+    "PastEntries": null,
+    "DisplayPriority": -1,
+    "IsArenaPlayModeEvent": true,
+    "Emblems": null,
+    "UsePlayerCourse": true
+  },
+  {
+    "PublicEventName": "WAR_Quick_Draft",
+    "InternalEventName": "QuickDraft_WAR_20190510",
+    "EventState": "Active",
+    "EventType": "Limited",
+    "ModuleGlobalData": {
+      "EntryFees": [
+        {
+          "CurrencyType": "Gold",
+          "Quantity": 5000,
+          "MaxUses": null
+        },
+        {
+          "CurrencyType": "Gem",
+          "Quantity": 750,
+          "MaxUses": null
+        }
+      ],
+      "CollationIds": [
+        200013,
+        200013,
+        200013
+      ],
+      "DeckSelect": "Draft",
+      "RankUpdateType": "Limited",
+      "MaxWins": 7,
+      "MaxLosses": 3,
+      "Prizes": [
+        "f85d40a5-8347-471e-a39a-e09a3e68697e",
+        "a631cc1e-4f4b-4130-89db-d55c56508ca9",
+        "461074e2-6857-40f0-b832-89a4b83b6a5a",
+        "b60bbc45-9a20-4d84-a854-a611ff07bb31",
+        "b4a396ec-2971-4f14-aa35-b9048050e148",
+        "1365fe99-a803-4160-a395-9a0e85ff2a49",
+        "66bb2315-749c-476e-a860-c0a5dbcfb77e",
+        "8c69232c-945f-4971-b7ee-edeeba413d86"
+      ],
+      "ChestDescriptions": [
+        {
+          "image1": "ObjectiveEventIcon_Gem1",
+          "image2": null,
+          "image3": "ObjectiveIcon_Pack_WAR",
+          "prefab": "RewardPopup3DIcon_GemPack",
+          "referenceId": "100013",
+          "headerLocKey": "MainNav/EventRewards/Gems_And_Pack",
+          "descriptionLocKey": "MainNav/EventsPage/Event_Popup_Text_Draft_Prize1",
+          "quantity": "0",
+          "locParams": {
+            "number1": 50
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Gem2",
+          "image2": null,
+          "image3": "ObjectiveIcon_Pack_WAR",
+          "prefab": "RewardPopup3DIcon_GemPack",
+          "referenceId": "100013",
+          "headerLocKey": "MainNav/EventRewards/Gems_And_Pack",
+          "descriptionLocKey": "MainNav/EventsPage/Event_Popup_Text_Draft_Prize2",
+          "quantity": "0",
+          "locParams": {
+            "number1": 100
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Gem3",
+          "image2": null,
+          "image3": "ObjectiveIcon_Pack_WAR",
+          "prefab": "RewardPopup3DIcon_GemPack",
+          "referenceId": "100013",
+          "headerLocKey": "MainNav/EventRewards/Gems_And_Pack",
+          "descriptionLocKey": "MainNav/EventsPage/Event_Popup_Text_Draft_Prize3",
+          "quantity": "0",
+          "locParams": {
+            "number1": 200
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Gem4",
+          "image2": null,
+          "image3": "ObjectiveIcon_Pack_WAR",
+          "prefab": "RewardPopup3DIcon_GemPack",
+          "referenceId": "100013",
+          "headerLocKey": "MainNav/EventRewards/Gems_And_Pack",
+          "descriptionLocKey": "MainNav/EventsPage/Event_Popup_Text_Draft_Prize4",
+          "quantity": "0",
+          "locParams": {
+            "number1": 300
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Gem5",
+          "image2": null,
+          "image3": "ObjectiveIcon_Pack_WAR",
+          "prefab": "RewardPopup3DIcon_GemPack",
+          "referenceId": "100013",
+          "headerLocKey": "MainNav/EventRewards/Gems_And_Pack",
+          "descriptionLocKey": "MainNav/EventsPage/Event_Popup_Text_Draft_Prize5",
+          "quantity": "0",
+          "locParams": {
+            "number1": 450
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Gem6",
+          "image2": null,
+          "image3": "ObjectiveIcon_Pack_WAR",
+          "prefab": "RewardPopup3DIcon_GemPack",
+          "referenceId": "100013",
+          "headerLocKey": "MainNav/EventRewards/Gems_And_Pack",
+          "descriptionLocKey": "MainNav/EventsPage/Event_Popup_Text_Draft_Prize6",
+          "quantity": "0",
+          "locParams": {
+            "number1": 650
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Gem7",
+          "image2": null,
+          "image3": "ObjectiveIcon_Pack_WAR",
+          "prefab": "RewardPopup3DIcon_GemPack",
+          "referenceId": "100013",
+          "headerLocKey": "MainNav/EventRewards/Gems_And_Pack",
+          "descriptionLocKey": "MainNav/EventsPage/Event_Popup_Text_Draft_Prize7",
+          "quantity": "0",
+          "locParams": {
+            "number1": 850
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Gem8",
+          "image2": null,
+          "image3": "ObjectiveIcon_Pack_WAR",
+          "prefab": "RewardPopup3DIcon_GemPack",
+          "referenceId": "100013",
+          "headerLocKey": "MainNav/EventRewards/Gems_And_Packs",
+          "descriptionLocKey": "MainNav/General/Empty_String",
+          "quantity": "2",
+          "locParams": {
+            "number1": 950,
+            "number2": 2
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        }
+      ]
+    },
+    "StartTime": "2019-05-10T15:00:00Z",
+    "LockedTime": "2019-05-24T15:00:00Z",
+    "ClosedTime": "2019-05-24T18:00:00Z",
+    "Parameters": {},
+    "Group": "",
+    "PastEntries": null,
+    "DisplayPriority": 73,
+    "IsArenaPlayModeEvent": true,
+    "Emblems": null,
+    "UsePlayerCourse": true
+  },
+  {
+    "PublicEventName": "Sealed_WAR",
+    "InternalEventName": "Sealed_WAR_20190422",
+    "EventState": "Active",
+    "EventType": "Limited",
+    "ModuleGlobalData": {
+      "EntryFees": [
+        {
+          "CurrencyType": "Gem",
+          "Quantity": 2000,
+          "MaxUses": null
+        },
+        {
+          "CurrencyType": "SealedToken",
+          "Quantity": 1,
+          "MaxUses": null
+        }
+      ],
+      "CollationIds": [
+        200013,
+        200013,
+        200013,
+        200013,
+        200013,
+        200013
+      ],
+      "DeckSelect": "Sealed",
+      "MaxWins": 7,
+      "MaxLosses": 3,
+      "Prizes": [
+        "40dc06b7-5408-493a-b631-4cf8a95f1aeb",
+        "f910cc52-bc8c-438a-91d3-c28007fe0495",
+        "068d5e31-aabb-4cd1-98fc-4777d6dacb89",
+        "7d2276df-6cd7-42dc-970d-0309e6317efb",
+        "d6a304ab-4885-42e5-a99b-ad6928383057",
+        "255c1939-aeb4-461a-b782-c5322929c81e",
+        "242ac239-1a2c-441a-96d3-e9c391063cd1",
+        "bce730c6-b71b-471e-b0b8-fcc4b4f155bb"
+      ],
+      "ChestDescriptions": [
+        {
+          "image1": "ObjectiveEventIcon_Gem1",
+          "image2": null,
+          "image3": "ObjectiveIcon_Pack_WAR",
+          "prefab": "RewardPopup3DIcon_GemPack",
+          "referenceId": "100013",
+          "headerLocKey": "MainNav/EventRewards/Gems_And_Packs",
+          "descriptionLocKey": "MainNav/General/Empty_String",
+          "quantity": "3",
+          "locParams": {
+            "number1": 200,
+            "number2": 3
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Gem2",
+          "image2": null,
+          "image3": "ObjectiveIcon_Pack_WAR",
+          "prefab": "RewardPopup3DIcon_GemPack",
+          "referenceId": "100013",
+          "headerLocKey": "MainNav/EventRewards/Gems_And_Packs",
+          "descriptionLocKey": "MainNav/General/Empty_String",
+          "quantity": "3",
+          "locParams": {
+            "number1": 400,
+            "number2": 3
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Gem3",
+          "image2": null,
+          "image3": "ObjectiveIcon_Pack_WAR",
+          "prefab": "RewardPopup3DIcon_GemPack",
+          "referenceId": "100013",
+          "headerLocKey": "MainNav/EventRewards/Gems_And_Packs",
+          "descriptionLocKey": "MainNav/General/Empty_String",
+          "quantity": "3",
+          "locParams": {
+            "number1": 600,
+            "number2": 3
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Gem4",
+          "image2": null,
+          "image3": "ObjectiveIcon_Pack_WAR",
+          "prefab": "RewardPopup3DIcon_GemPack",
+          "referenceId": "100013",
+          "headerLocKey": "MainNav/EventRewards/Gems_And_Packs",
+          "descriptionLocKey": "MainNav/General/Empty_String",
+          "quantity": "3",
+          "locParams": {
+            "number1": 1200,
+            "number2": 3
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Gem5",
+          "image2": null,
+          "image3": "ObjectiveIcon_Pack_WAR",
+          "prefab": "RewardPopup3DIcon_GemPack",
+          "referenceId": "100013",
+          "headerLocKey": "MainNav/EventRewards/Gems_And_Packs",
+          "descriptionLocKey": "MainNav/General/Empty_String",
+          "quantity": "3",
+          "locParams": {
+            "number1": 1400,
+            "number2": 3
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Gem6",
+          "image2": null,
+          "image3": "ObjectiveIcon_Pack_WAR",
+          "prefab": "RewardPopup3DIcon_GemPack",
+          "referenceId": "100013",
+          "headerLocKey": "MainNav/EventRewards/Gems_And_Packs",
+          "descriptionLocKey": "MainNav/General/Empty_String",
+          "quantity": "3",
+          "locParams": {
+            "number1": 1600,
+            "number2": 3
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Gem7",
+          "image2": null,
+          "image3": "ObjectiveIcon_Pack_WAR",
+          "prefab": "RewardPopup3DIcon_GemPack",
+          "referenceId": "100013",
+          "headerLocKey": "MainNav/EventRewards/Gems_And_Packs",
+          "descriptionLocKey": "MainNav/General/Empty_String",
+          "quantity": "3",
+          "locParams": {
+            "number1": 2000,
+            "number2": 3
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Gem8",
+          "image2": null,
+          "image3": "ObjectiveIcon_Pack_WAR",
+          "prefab": "RewardPopup3DIcon_GemPack",
+          "referenceId": "100013",
+          "headerLocKey": "MainNav/EventRewards/Gems_And_Packs",
+          "descriptionLocKey": "MainNav/General/Empty_String",
+          "quantity": "3",
+          "locParams": {
+            "number1": 2200,
+            "number2": 3
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        }
+      ]
+    },
+    "StartTime": "2019-04-22T15:00:00Z",
+    "LockedTime": "2019-05-20T15:00:00Z",
+    "ClosedTime": "2019-05-20T18:00:00Z",
+    "Parameters": {},
+    "Group": "",
+    "PastEntries": null,
+    "DisplayPriority": 52,
+    "IsArenaPlayModeEvent": true,
+    "Emblems": null,
+    "UsePlayerCourse": true
+  },
+  {
+    "PublicEventName": "Traditional_Cons_Event",
+    "InternalEventName": "Traditional_Cons_Event",
+    "EventState": "Active",
+    "EventType": "Constructed",
+    "ModuleGlobalData": {
+      "EntryFees": [
+        {
+          "CurrencyType": "Gold",
+          "Quantity": 1000,
+          "MaxUses": null
+        },
+        {
+          "CurrencyType": "Gem",
+          "Quantity": 190,
+          "MaxUses": null
+        }
+      ],
+      "DeckSelect": "TraditionalStandard",
+      "MaxWins": 5,
+      "MaxLosses": 2,
+      "Prizes": [
+        "39fcc53a-8976-4c6c-b27c-3885408dd242",
+        "93e0d7bb-0829-406f-9e66-0110325f12f9",
+        "56af91db-a3ef-4358-ad39-cc85868f1f87",
+        "23665c3b-7797-4cd1-8c92-1bedc9d69a06",
+        "1acb411e-d4aa-4bd9-a72a-38bc3b0497b9",
+        "4aa49d9a-1adb-4eaf-8013-4d71b308a39f"
+      ],
+      "ChestDescriptions": [
+        {
+          "image1": "ObjectiveEventIcon_CardsA3B0",
+          "image2": null,
+          "image3": null,
+          "prefab": "RewardPopup3DIcon_Card_Uncommon",
+          "referenceId": "0",
+          "headerLocKey": "MainNav/EventRewards/Cards",
+          "descriptionLocKey": "MainNav/EventRewards/CompetitiveConstructedPrize_0Wins",
+          "quantity": "0",
+          "locParams": {
+            "number1": 3
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Coin2",
+          "image2": "ObjectiveEventIcon_CardsA3B0",
+          "image3": null,
+          "prefab": "RewardPopup3DIcon_CoinCard",
+          "referenceId": "0",
+          "headerLocKey": "MainNav/EventRewards/Gold_And_Cards",
+          "descriptionLocKey": "MainNav/EventRewards/CompetitiveConstructedPrize_1Wins",
+          "quantity": "0",
+          "locParams": {
+            "number1": 500,
+            "number2": 3
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Coin4",
+          "image2": "ObjectiveEventIcon_CardsA3B0",
+          "image3": null,
+          "prefab": "RewardPopup3DIcon_CoinCard",
+          "referenceId": "0",
+          "headerLocKey": "MainNav/EventRewards/Gold_And_Cards",
+          "descriptionLocKey": "MainNav/EventRewards/CompetitiveConstructedPrize_2Wins",
+          "quantity": "0",
+          "locParams": {
+            "number1": 1000,
+            "number2": 3
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Coin5",
+          "image2": "ObjectiveEventIcon_CardsA2B1",
+          "image3": null,
+          "prefab": "RewardPopup3DIcon_CoinCard",
+          "referenceId": "0",
+          "headerLocKey": "MainNav/EventRewards/Gold_And_Cards",
+          "descriptionLocKey": "MainNav/EventRewards/CompetitiveConstructedPrize_3Wins",
+          "quantity": "0",
+          "locParams": {
+            "number1": 1500,
+            "number2": 3
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Coin6",
+          "image2": "ObjectiveEventIcon_CardsA2B1",
+          "image3": null,
+          "prefab": "RewardPopup3DIcon_CoinCard",
+          "referenceId": "0",
+          "headerLocKey": "MainNav/EventRewards/Gold_And_Cards",
+          "descriptionLocKey": "MainNav/EventRewards/CompetitiveConstructedPrize_4Wins",
+          "quantity": "0",
+          "locParams": {
+            "number1": 1700,
+            "number2": 3
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        },
+        {
+          "image1": "ObjectiveEventIcon_Coin8",
+          "image2": "ObjectiveEventIcon_CardsA1B2",
+          "image3": null,
+          "prefab": "RewardPopup3DIcon_CoinCard",
+          "referenceId": "0",
+          "headerLocKey": "MainNav/EventRewards/Gold_And_Cards",
+          "descriptionLocKey": "MainNav/EventRewards/CompetitiveConstructedPrize_5Wins",
+          "quantity": "0",
+          "locParams": {
+            "number1": 2100,
+            "number2": 3
+          },
+          "availableDate": "0001-01-01T00:00:00"
+        }
+      ]
+    },
+    "StartTime": "2018-12-14T16:00:22Z",
+    "LockedTime": "2020-04-01T16:00:22Z",
+    "ClosedTime": "2020-04-01T16:00:22Z",
+    "Parameters": {},
+    "Group": "",
+    "PastEntries": null,
+    "DisplayPriority": 93,
+    "IsArenaPlayModeEvent": false,
+    "Emblems": [],
+    "UsePlayerCourse": true
+  },
+  {
+    "PublicEventName": "Traditional_Ladder",
+    "InternalEventName": "Traditional_Ladder",
+    "EventState": "Active",
+    "EventType": "Constructed",
+    "ModuleGlobalData": {
+      "DeckSelect": "TraditionalStandard",
+      "RankUpdateType": "Constructed"
+    },
+    "StartTime": "2019-01-31T20:05:00Z",
+    "LockedTime": "2118-12-20T18:00:00Z",
+    "ClosedTime": "2118-12-20T18:00:00Z",
+    "Parameters": {},
+    "Group": "",
+    "PastEntries": null,
+    "DisplayPriority": -1,
+    "IsArenaPlayModeEvent": false,
+    "Emblems": null,
+    "UsePlayerCourse": true
+  }
+]
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:58 AM
+==> Event.GetPlayerCoursesV2(35):
+{
+  "jsonrpc": "2.0",
+  "method": "Event.GetPlayerCoursesV2",
+  "params": {},
+  "id": "35"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:58 AM
+<== Config.JoinEventQueueStatus(31)
+true
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:58 AM
+<== Quest.GetPlayerQuests(32)
+[
+  {
+    "questId": "27ca3d82-d417-4d47-99ae-1d64840db46c",
+    "goal": 30,
+    "locKey": "Quests/Quest_Orzhov_Domination",
+    "tileResourceId": "d7552d4b-d413-42ee-9edc-21e61b98e52b",
+    "treasureResourceId": "83b335e3-673c-4ce7-975d-c6dd974b43de",
+    "questTrack": "Default",
+    "isNewQuest": false,
+    "endingProgress": 0,
+    "startingProgress": 0,
+    "canSwap": false,
+    "inventoryUpdate": null,
+    "chestDescription": {
+      "image1": "ObjectiveIcon_CoinsLarge",
+      "image2": null,
+      "image3": null,
+      "prefab": "RewardPopup3DIcon_Coin",
+      "referenceId": null,
+      "headerLocKey": "MainNav/EventRewards/Gold_Reward",
+      "descriptionLocKey": null,
+      "quantity": "750",
+      "locParams": {
+        "number1": 750
+      },
+      "availableDate": "0001-01-01T00:00:00"
+    },
+    "hoursWaitAfterComplete": 0
+  }
+]
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:58 AM
+<== Quest.GetTrackDetail(33)
+{
+  "ActiveQuestDetails": [],
+  "CompletedQuestDetails": [
+    {
+      "LocName": "OB-NPE-A-14",
+      "ChainName": "NPE-A-OB",
+      "ChainIndex": 14,
+      "ChainMax": 14
+    }
+  ],
+  "DontReplenishBeforeTime": "0001-01-01T00:00:00"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:58 AM
+<== PlayerInventory.GetPlayerSequenceData(34)
+{
+  "playerId": "ANNON",
+  "dailySequence": 0,
+  "weeklySequence": 4,
+  "dailyLastAwarded": "2019-05-13T05:48:47.6829631",
+  "weeklyLastAwarded": "2019-05-13T05:48:47.6829631"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:58 AM
+<== Event.GetPlayerCoursesV2(35)
+[
+  {
+    "Id": "00000000-0000-0000-0000-000000000000",
+    "InternalEventName": "AIBotMatch",
+    "PlayerId": null,
+    "ModuleInstanceData": {},
+    "CurrentEventState": "PreMatch",
+    "CurrentModule": "Join",
+    "CardPool": null,
+    "CourseDeck": null,
+    "PreviousOpponents": []
+  },
+  {
+    "Id": "00000000-0000-0000-0000-000000000000",
+    "InternalEventName": "CompDraft_WAR_20190425",
+    "PlayerId": null,
+    "ModuleInstanceData": {},
+    "CurrentEventState": "PreMatch",
+    "CurrentModule": "Join",
+    "CardPool": null,
+    "CourseDeck": null,
+    "PreviousOpponents": []
+  },
+  {
+    "Id": "00000000-0000-0000-0000-000000000000",
+    "InternalEventName": "Constructed_BestOf3",
+    "PlayerId": null,
+    "ModuleInstanceData": {},
+    "CurrentEventState": "PreMatch",
+    "CurrentModule": "Join",
+    "CardPool": null,
+    "CourseDeck": null,
+    "PreviousOpponents": []
+  },
+  {
+    "Id": "00000000-0000-0000-0000-000000000000",
+    "InternalEventName": "Constructed_Event",
+    "PlayerId": null,
+    "ModuleInstanceData": {},
+    "CurrentEventState": "PreMatch",
+    "CurrentModule": "Join",
+    "CardPool": null,
+    "CourseDeck": null,
+    "PreviousOpponents": []
+  },
+  {
+    "Id": "00000000-0000-0000-0000-000000000000",
+    "InternalEventName": "Constructed_Ravnica_20190509",
+    "PlayerId": null,
+    "ModuleInstanceData": {},
+    "CurrentEventState": "PreMatch",
+    "CurrentModule": "Join",
+    "CardPool": null,
+    "CourseDeck": null,
+    "PreviousOpponents": []
+  },
+  {
+    "Id": "00000000-0000-0000-0000-000000000000",
+    "InternalEventName": "DirectGame",
+    "PlayerId": null,
+    "ModuleInstanceData": {},
+    "CurrentEventState": "PreMatch",
+    "CurrentModule": "Join",
+    "CardPool": null,
+    "CourseDeck": null,
+    "PreviousOpponents": []
+  },
+  {
+    "Id": "24b667aa-dfa5-420e-955a-7294bc40fb50",
+    "InternalEventName": "Ladder",
+    "PlayerId": null,
+    "ModuleInstanceData": {
+      "DeckSelected": true
+    },
+    "CurrentEventState": "ReadyToMatch",
+    "CurrentModule": "TransitionToMatches",
+    "CardPool": null,
+    "CourseDeck": {
+      "cardSkins": [],
+      "id": "41395e9a-ef66-4531-b653-583322aaf34d",
+      "name": "RDW",
+      "description": "",
+      "format": "Standard",
+      "deckTileId": 68576,
+      "mainDeck": [
+        66263,
+        4,
+        69235,
+        4,
+        68560,
+        3,
+        67992,
+        4,
+        68012,
+        4,
+        67358,
+        4,
+        66819,
+        4,
+        69243,
+        4,
+        67362,
+        3,
+        68576,
+        4,
+        66527,
+        5,
+        67628,
+        5,
+        68230,
+        4,
+        68228,
+        4,
+        67408,
+        4
+      ],
+      "sideboard": [],
+      "cardBack": "CardBack_EmbossedManaRed",
+      "lastUpdated": "2019-05-10T06:39:17.9068862"
+    },
+    "PreviousOpponents": []
+  },
+  {
+    "Id": "9d7f0839-224f-4b93-b32e-d95e9965a216",
+    "InternalEventName": "NPE",
+    "PlayerId": null,
+    "ModuleInstanceData": {
+      "Stage": 1,
+      "Matches": [
+        "20ffed9a-dc65-44da-b732-18972ef2c0b7"
+      ]
+    },
+    "CurrentEventState": "ReadyToMatch",
+    "CurrentModule": "NPEUpdate",
+    "CardPool": null,
+    "CourseDeck": null,
+    "PreviousOpponents": []
+  },
+  {
+    "Id": "00000000-0000-0000-0000-000000000000",
+    "InternalEventName": "Play",
+    "PlayerId": null,
+    "ModuleInstanceData": {},
+    "CurrentEventState": "PreMatch",
+    "CurrentModule": "Join",
+    "CardPool": null,
+    "CourseDeck": null,
+    "PreviousOpponents": []
+  },
+  {
+    "Id": "c36267b5-da0a-47a3-8a38-4ad6bd392115",
+    "InternalEventName": "QuickDraft_WAR_20190510",
+    "PlayerId": null,
+    "ModuleInstanceData": {
+      "HasPaidEntry": "Gold",
+      "DraftInfo": {
+        "DraftId": "ANNON:QuickDraft_WAR_20190510:Draft"
+      },
+      "DraftComplete": true,
+      "HasGranted": true,
+      "DeckSelected": true,
+      "WinLossGate": {
+        "MaxWins": 7,
+        "MaxLosses": 3,
+        "CurrentWins": 1,
+        "CurrentLosses": 1,
+        "ProcessedMatchIds": [
+          "2bbb57c4-06ed-4c2d-9113-d949b0e31138",
+          "ea7fa048-2e0a-402d-8b2e-162374f86daf"
+        ]
+      }
+    },
+    "CurrentEventState": "ReadyToMatch",
+    "CurrentModule": "WinLossGate",
+    "CardPool": [
+      69581,
+      69683,
+      69691,
+      69597,
+      69564,
+      69571,
+      69539,
+      69636,
+      69583,
+      69574,
+      69583,
+      69478,
+      69569,
+      69539,
+      69559,
+      69550,
+      69560,
+      69560,
+      69634,
+      69544,
+      69593,
+      69626,
+      69556,
+      69616,
+      69582,
+      69590,
+      69528,
+      69581,
+      69580,
+      69584,
+      69544,
+      69595,
+      69569,
+      69676,
+      69581,
+      69653,
+      69619,
+      69541,
+      69568,
+      69486,
+      69569,
+      69539
+    ],
+    "CourseDeck": {
+      "cardSkins": [],
+      "id": "5748d608-65d5-4868-a595-a6a8ccf6ef93",
+      "name": "Ultimate Boar",
+      "description": "",
+      "format": "Draft",
+      "deckTileId": 69584,
+      "mainDeck": [
+        69683,
+        0,
+        69597,
+        1,
+        69571,
+        1,
+        69636,
+        1,
+        69583,
+        2,
+        69539,
+        2,
+        69581,
+        3,
+        69564,
+        1,
+        69550,
+        1,
+        69582,
+        1,
+        69556,
+        1,
+        69593,
+        1,
+        69544,
+        2,
+        69560,
+        2,
+        69590,
+        1,
+        69584,
+        1,
+        69653,
+        1,
+        69541,
+        1,
+        69568,
+        1,
+        69619,
+        0,
+        67019,
+        8,
+        67021,
+        8
+      ],
+      "sideboard": [
+        69683,
+        1,
+        69569,
+        3,
+        69539,
+        1,
+        69691,
+        1,
+        69559,
+        1,
+        69528,
+        1,
+        69580,
+        1,
+        69595,
+        1,
+        69619,
+        1,
+        69574,
+        1,
+        69478,
+        1,
+        69616,
+        1,
+        69626,
+        1,
+        69634,
+        1,
+        69676,
+        1,
+        69486,
+        1
+      ],
+      "cardBack": "CardBack_EmbossedManaRed",
+      "lastUpdated": "2019-05-13T05:37:59.0934983"
+    },
+    "PreviousOpponents": []
+  },
+  {
+    "Id": "00000000-0000-0000-0000-000000000000",
+    "InternalEventName": "Sealed_WAR_20190422",
+    "PlayerId": null,
+    "ModuleInstanceData": {},
+    "CurrentEventState": "PreMatch",
+    "CurrentModule": "Join",
+    "CardPool": null,
+    "CourseDeck": null,
+    "PreviousOpponents": []
+  },
+  {
+    "Id": "00000000-0000-0000-0000-000000000000",
+    "InternalEventName": "Traditional_Cons_Event",
+    "PlayerId": null,
+    "ModuleInstanceData": {},
+    "CurrentEventState": "PreMatch",
+    "CurrentModule": "Join",
+    "CardPool": null,
+    "CourseDeck": null,
+    "PreviousOpponents": []
+  },
+  {
+    "Id": "00000000-0000-0000-0000-000000000000",
+    "InternalEventName": "Traditional_Ladder",
+    "PlayerId": null,
+    "ModuleInstanceData": {},
+    "CurrentEventState": "PreMatch",
+    "CurrentModule": "Join",
+    "CardPool": null,
+    "CourseDeck": null,
+    "PreviousOpponents": []
+  }
+]
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+EnableLoadingIndicator.  shouldEnable = False _loadingGameObject=121238
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:59 AM
+==> Event.GetEventAndSeasonPayouts(36):
+{
+  "jsonrpc": "2.0",
+  "method": "Event.GetEventAndSeasonPayouts",
+  "params": {},
+  "id": "36"
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[UnityCrossThreadLogger]5/13/2019 10:09:59 AM
+<== Event.GetEventAndSeasonPayouts(36)
+{
+  "eventPayouts": [],
+  "seasonPayout": null
+}
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+
+[Social Controller] Initializing.
+ 
+(Filename: C:\buildslave\unity\build\Runtime/Export/Debug.bindings.h Line: 43)
+


### PR DESCRIPTION
### Motivation
- restore our tests in `window_background/arena-log-decoder/__tests__/`
- hook our tests up to our build process
  - tests must all pass as a validation check before `npm run dist`
  - tests must all pass for TravisCI build to pass
  - all test-related code and `output_log.txt` must be excluded from build
### Approach
- restore `jest` as dev dependency
- add current `output_log.txt` and get tests working again
- update `package.json` script endpoints to call `jest` during build

### Demo

```
$ npm run lint

> MTG-Arena-Tool@2.5.2 lint C:\Users\Local Ben\code\MTG-Arena-Tool
> npx eslint . --quiet
```
```
$ npm test

> MTG-Arena-Tool@2.5.2 pretest C:\Users\Local Ben\code\MTG-Arena-Tool
> npm run lint


> MTG-Arena-Tool@2.5.2 lint C:\Users\Local Ben\code\MTG-Arena-Tool
> npx eslint . --quiet


> MTG-Arena-Tool@2.5.2 test C:\Users\Local Ben\code\MTG-Arena-Tool
> npx jest

PASS window_background/arena-log-decoder/__tests__/arena-log-decoder-spec.js
PASS window_background/arena-log-decoder/__tests__/nth-last-index-spec.js
PASS window_background/arena-log-decoder/__tests__/json-text-spec.js

Test Suites: 3 passed, 3 total
Tests:       9 passed, 9 total
Snapshots:   0 total
Time:        1.543s
Ran all test suites.
```
```
$ npm run dist

> MTG-Arena-Tool@2.5.2 predist C:\Users\Local Ben\code\MTG-Arena-Tool
> npm test


> MTG-Arena-Tool@2.5.2 pretest C:\Users\Local Ben\code\MTG-Arena-Tool
> npm run lint


> MTG-Arena-Tool@2.5.2 lint C:\Users\Local Ben\code\MTG-Arena-Tool
> npx eslint . --quiet


> MTG-Arena-Tool@2.5.2 test C:\Users\Local Ben\code\MTG-Arena-Tool
> npx jest

PASS window_background/arena-log-decoder/__tests__/arena-log-decoder-spec.js
PASS window_background/arena-log-decoder/__tests__/json-text-spec.js
PASS window_background/arena-log-decoder/__tests__/nth-last-index-spec.js

Test Suites: 3 passed, 3 total
Tests:       9 passed, 9 total
Snapshots:   0 total
Time:        1.562s
Ran all test suites.

> MTG-Arena-Tool@2.5.2 dist C:\Users\Local Ben\code\MTG-Arena-Tool
> build --x64

Configuring yargs through package.json is deprecated and will be removed in the next major release, please use the JS API instead.
Configuring yargs through package.json is deprecated and will be removed in the next major release, please use the JS API instead.
  • electron-builder version=20.40.2
  • loaded configuration file=package.json ("build" field)
  • no native production dependencies
  • packaging       platform=win32 arch=x64 electron=3.1.9 appOutDir=dist\win-unpacked
  • building        target=nsis file=dist\MTG-Arena-Tool-2.5.2.exe archs=x64 oneClick=true perMachine=false
  • building block map blockMapFile=dist\MTG-Arena-Tool-2.5.2.exe.blockmap
```

