### PR TITLE
Collection page wanted card counts respect deck.archived

### DIFF
--- a/shared/util.js
+++ b/shared/util.js
@@ -1549,9 +1549,11 @@ function get_collection_stats() {
         }
 
         // count cards we know we want across decks
-        const wanted = Math.max(...decks.filter(deck => deck && !deck.archived).map(deck =>
-          getCardsMissingCount(deck, grpId)
-        ));
+        const wanted = Math.max(
+          ...decks
+            .filter(deck => deck && !deck.archived)
+            .map(deck => getCardsMissingCount(deck, grpId))
+        );
         stats[card.set][card.rarity].wanted += wanted;
         stats.complete[card.rarity].wanted += wanted;
 

--- a/shared/util.js
+++ b/shared/util.js
@@ -1549,10 +1549,9 @@ function get_collection_stats() {
         }
 
         // count cards we know we want across decks
-        let deckWantedCounts = decks.map(deck =>
+        const wanted = Math.max(...decks.filter(deck => deck && !deck.archived).map(deck =>
           getCardsMissingCount(deck, grpId)
-        );
-        let wanted = Math.max(...deckWantedCounts);
+        ));
         stats[card.set][card.rarity].wanted += wanted;
         stats.complete[card.rarity].wanted += wanted;
 


### PR DESCRIPTION
This PR patches our "wanted" card math to respect the new `deck.archived` flag.
- Archiving a deck with missing cards should hide those cards from the collection "wanted" counts and "next booster" math
