### PR TITLE
Check player id for each log message that gives it.

### DIFF
--- a/window_background/background.js
+++ b/window_background/background.js
@@ -1005,6 +1005,8 @@ function onLogEntryFound(entry) {
     playerData.arenaVersion = entry.socket.ClientVersion;
     playerData.name = entry.socket.PlayerScreenName;
     ipc_send("set_player_data", playerData);
+  } else if (entry.playerId && entry.playerId !== playerData.arenaId) {
+    return;
   } else {
     //console.log("Entry:", entry.label, entry, entry.json());
     if (firstPass) {


### PR DESCRIPTION
This should prevent direct challenges with both players on the same computer from corrupting gameplay data. Not sure how often that actually happens, but it's still good to have.

Also switched to regex literals.