### PR TITLE
opt-in git hooks

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,77 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at manuel.etchegaray7@gmail.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,41 @@ npm start
 You can toggle developer tools for debugging using `Shift+Alt+D`, or using `F12` if you run from source.
 
 #### Optional Git Hooks
+You can optionally install git hooks to help with code formatting and
+ensuring that your commits build successfully. Note that these can
+sometimes take a moment to run and will potentially modify files in your
+working tree. For more information, [see the git hooks documentation.](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks)
 
+##### Pre-Commit Hook
+This automatically reformats all files with staged changes to match the
+project guidelines. WARNING: this will overwrite any previous custom
+git hook.
 
+To install (or update), simply run the script in a terminal:
+```
+./git-pre-commit
+```
+This will run the hook and place a copy in your `.git/hooks/` folder.
+Future commits will always run the hook.
 
+To uninstall:
+```
+rm .git/hooks/pre-commit
+```
+
+##### Pre-Push Hook
+This automatically checks all modified files against the project
+guidelines and only allows you to push valid commits. WARNING: this will
+overwrite any previous custom git hook.
+
+To install (or update), simply run the script in a terminal:
+```
+./git-pre-push
+```
+This will run the hook and place a copy in your `.git/hooks/` folder.
+Future commits will always run the hook.
+
+To uninstall:
+```
+rm .git/hooks/pre-push
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,7 +125,7 @@ git hook.
 
 To install (or update), simply run the script in a terminal:
 ```
-./git-pre-commit
+./git-pre-commit.sh
 ```
 This will run the hook and place a copy in your `.git/hooks/` folder.
 Future commits will always run the hook.
@@ -142,10 +142,10 @@ overwrite any previous custom git hook.
 
 To install (or update), simply run the script in a terminal:
 ```
-./git-pre-push
+./git-pre-push.sh
 ```
 This will run the hook and place a copy in your `.git/hooks/` folder.
-Future commits will always run the hook.
+Future pushes will always run the hook.
 
 To uninstall:
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,118 @@
+# Contributing to MTG Arena Tool
+
+:+1: :tada: :sparkling_heart: Thanks for your interest! :sparkling_heart: :tada: :+1:
+
+The following is a set of guidelines for contributing to MTG Arena Tool, hosted
+[here on GitHub](https://github.com/Manuel-777/MTG-Arena-Tool/). These are just
+guidelines, not rules. Use your best judgment, and
+feel free to propose changes to this document in a pull request.
+
+Note that MTG Arena Tool is an evolving project, so expect things to change over
+time as the team learns, listens, and refines how we work with the community.
+
+#### Table Of Contents
+
+- [What should I know before I get started?](#what-should-i-know-before-i-get-started)
+  * [Code of Conduct](#code-of-conduct)
+
+- [How Can I Contribute?](#how-can-i-contribute)
+  * [Reporting Bugs](#reporting-bugs)
+  * [Suggesting Enhancements](#suggesting-enhancements)
+  * [Set Up Your Machine](#set-up-your-machine)
+
+## What should I know before I get started?
+
+### Code of Conduct
+
+This project adheres to the Contributor Covenant [code of conduct](../CODE_OF_CONDUCT.md).
+By participating, you are expected to uphold this code.
+Please report unacceptable behavior to [manuel.etchegaray7@gmail.com](mailto:manuel.etchegaray7@gmail.com).
+
+## How Can I Contribute?
+
+### Reporting Bugs
+
+This section guides you through submitting a bug report for MTG Arena Tool.
+Following these guidelines helps maintainers and the community understand your
+report :pencil:, reproduce the behavior :computer: :computer:, and find related
+reports :mag_right:.
+
+Before creating bug reports, please check [this list](#before-submitting-a-bug-report)
+as you might find out that you don't need to create one. When you are creating
+a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report).
+
+#### Before Submitting A Bug Report
+
+**Perform a [cursory search](https://github.com/Manuel-777/MTG-Arena-Tool/issues)**
+to see if the problem has already been reported. If it does exist, add a
+:thumbsup: to the issue to indicate this is also an issue for you, and add a
+comment to the existing issue if there is extra information you can contribute.
+
+#### How Do I Submit A (Good) Bug Report?
+
+Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/).
+
+Simply create an issue on the [MTG Arena Tool issue tracker](https://github.com/Manuel-777/MTG-Arena-Tool/issues/new).
+
+The information we are interested in includes:
+
+ - details about your environment - which build, which operating system
+ - details about reproducing the issue - what steps to take, what happens, how
+   often it happens
+ - other relevant information - log files, screenshots, etc
+
+### Suggesting Enhancements
+
+This section guides you through submitting an enhancement suggestion for
+MTG Arena Tool, including completely new features and minor improvements to
+existing functionality. Following these guidelines helps maintainers and the
+community understand your suggestion :pencil: and find related suggestions
+:mag_right:.
+
+Before creating enhancement suggestions, please check [this list](#before-submitting-an-enhancement-suggestion)
+as you might find out that you don't need to create one. When you are creating
+an enhancement suggestion, please [include as many details as possible](#how-do-i-submit-a-good-enhancement-suggestion).
+
+#### Before Submitting An Enhancement Suggestion
+
+**Perform a [cursory search](https://github.com/Manuel-777/MTG-Arena-Tool/labels/enhancement)**
+to see if the enhancement has already been suggested. If it has, add a
+:thumbsup: to indicate your interest in it, or comment if there is additional
+information you would like to add.
+
+#### How Do I Submit A (Good) Enhancement Suggestion?
+
+Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com/features/issues/).
+
+Simply create an issue on the [MTG Arena Tool issue tracker](https://github.com/Manuel-777/MTG-Arena-Tool/issues/new).
+
+Some additional advice:
+
+* **Use a clear and descriptive title** for the feature request
+* **Provide a step-by-step description of the suggested enhancement**
+  This additional context helps the maintainers understand the enhancement from
+  your perspective
+* **Explain why this enhancement would be useful** to MTG Arena Tool users
+* **Include screenshots and animated GIFs** if relevant to help you demonstrate
+  the steps or point out the part of MTG Arena Tool which the suggestion is
+  related to. You can use [this tool](http://www.cockos.com/licecap/) to record
+  GIFs on macOS and Windows
+* **List some other applications where this enhancement exists, if applicable**
+
+### Set Up Your Machine
+
+MTG Arena Tool is developed using Electron JS, To get started simply clone this repo and install:
+
+```
+git clone https://github.com/Manuel-777/MTG-Arena-Tool
+cd MTG-Arena-Tool
+npm install
+npm start
+```
+
+You can toggle developer tools for debugging using `Shift+Alt+D`, or using `F12` if you run from source.
+
+#### Optional Git Hooks
+
+
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,11 +120,12 @@ working tree. For more information, [see the git hooks documentation.](https://g
 
 ##### Pre-Commit Hook
 This automatically reformats all files with staged changes to match the
-project guidelines. WARNING: this will overwrite any previous custom
-git hook.
+project guidelines.
 
-To install (or update), simply run the script in a terminal:
+To install (or update), run the following commands in a terminal. WARNING: this will overwrite any previous custom
+git hook.
 ```
+rm .git/hooks/pre-commit
 ./git-pre-commit.sh
 ```
 This will run the hook and place a copy in your `.git/hooks/` folder.
@@ -137,11 +138,12 @@ rm .git/hooks/pre-commit
 
 ##### Pre-Push Hook
 This automatically checks all modified files against the project
-guidelines and only allows you to push valid commits. WARNING: this will
-overwrite any previous custom git hook.
+guidelines and only allows you to push valid commits.
 
-To install (or update), simply run the script in a terminal:
+To install (or update), run the following commands in a terminal. WARNING: this will overwrite any previous custom
+git hook.
 ```
+rm .git/hooks/pre-push
 ./git-pre-push.sh
 ```
 This will run the hook and place a copy in your `.git/hooks/` folder.

--- a/README.md
+++ b/README.md
@@ -46,32 +46,27 @@ An MTG Arena deck tracker and collection manager.
 	- See wildcards and boosters needed
 	- Sort by winrate, boosters required
 
-### Compiling / Run from source
-MTG Arena Tool is developed using Electron JS, To get started simply clone this repo and install:
-
-```
-git clone https://github.com/Manuel-777/MTG-Arena-Tool
-cd MTG-Arena-Tool
-npm install
-npm start
-```
-
-You can toggle developer tools for debugging using `Shift+Alt+D`, or using `F12` if you run from source.
-
 ### Download
 Currently, our releases are hosted [here at GitHub](https://github.com/Manuel-777/MTG-Arena-Tool/releases). You will find all stable and pre-production releases right here.
 
 Once downloaded the installer should simply install and run immediately. The app will read your user data and warn you if anything goes wrong.
 
-### Disclaimer
+If you would like to compile and run the latest source, see [the contribution guidelines on how to set up your machine.](./CONTRIBUTING.md#set-up-your-machine)
 
+### Disclaimer
 Even though no official statement has been made about third party software by MTG Arena developers, I am obliged to put a warning about the use of this software.
 
 It is not stated if it is legal or allowed by Wizards of the Coast to use Deck Trackers and other tools alike while playing MTG Arena, therefore MTG Arena Tool developers are not responsible if your account gets banned, locked or suspended for using this software. `Use at your own risk.`
 
 MtG Arena Tool is unofficial Fan Content permitted under the Fan Content Policy. Not approved/endorsed by Wizards. Portions of the materials used are property of Wizards of the Coast. ©Wizards of the Coast LLC.
 
-Please read about [our Privacy Policy and How we use your data here](https://github.com/Manuel-777/MTG-Arena-Tool/blob/master/PRIVACY.md)
+Please read about [our Privacy Policy and How we use your data here](./PRIVACY.md)
+
+### Troubleshooting
+Please see [our troubleshooting guide.](./TROUBLESHOOTING.md)
+
+### Contributing
+Please see [our contributing guide.](./CONTRIBUTING.md)
 
 ### Credits
 [Electron](https://electronjs.org/)

--- a/git-pre-commit.sh
+++ b/git-pre-commit.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+if [ ! -f .git/hooks/pre-commit ]; then
+    cp ./git-pre-commit.sh .git/hooks/pre-commit
+fi
+
+FILES=$(git diff --cached --name-only --diff-filter=ACM "*.js" "*.jsx" | sed 's| |\\ |g')
+[ -z "$FILES" ] && exit 0
+
+echo "$FILES" | xargs npx prettier --write
+echo "$FILES" | xargs npx eslint --fix --quiet
+echo "$FILES" | xargs git add
+
+exit 0


### PR DESCRIPTION
### Motivation
- Open source projects should have a low barrier to entry.
- Opinionated is good, but opt-in convenience is better

Here are some git hooks that I have been using and enjoying:
- They are opt-in, so contributors may choose to use them or ignore them as they wish.
- They auto-install upon first run
- the pre-commit hook follows approach #5 listed here: https://prettier.io/docs/en/precommit.html
- the pre-push hook ensures that the build will pass before ever pushing a commit

