### PR TITLE
move normalization of matches history to singleton factory

### DIFF
--- a/window_main/aggregator.js
+++ b/window_main/aggregator.js
@@ -72,6 +72,27 @@ class Aggregator {
   }
 
   static createAllMatches() {
+    // For legacy reasons, we rely on pre-processing all matches
+    // and normalizing some data irregularities (this can be slow).
+    // This should happen exactly once iff matchesHistory changes.
+    matchesHistory.matches.forEach(mid => {
+      const match = matchesHistory[mid];
+      if (!match || match.type === "draft" || match.type === "Event") return;
+      try {
+        if (match.playerDeck && match.playerDeck.mainDeck) {
+          match.playerDeck.colors = get_deck_colors(match.playerDeck);
+        } else {
+          match.playerDeck = JSON.parse(
+            '{"deckTileId":67003,"description":null,"format":"Standard","colors":[],"id":"00000000-0000-0000-0000-000000000000","isValid":false,"lastUpdated":"2018-05-31T00:06:29.7456958","lockedForEdit":false,"lockedForUse":false,"mainDeck":[],"name":"Undefined","resourceId":"00000000-0000-0000-0000-000000000000","sideboard":[]}'
+          );
+        }
+        if (match.oppDeck && match.oppDeck.mainDeck) {
+          match.oppDeck.colors = get_deck_colors(match.oppDeck);
+        }
+      } catch (e) {
+        console.log(e, match);
+      }
+    });
     return new Aggregator({ date: DATE_ALL_TIME });
   }
 

--- a/window_main/history.js
+++ b/window_main/history.js
@@ -753,29 +753,6 @@ function draftShareLink() {
 
 function sort_history() {
   matchesHistory.matches.sort(compare_matches);
-
-  matchesHistory.matches.forEach(function(mid) {
-    var match = matchesHistory[mid];
-
-    if (mid != null && match != undefined) {
-      if (match.type != "draft" && match.type != "Event") {
-        try {
-          if (match.playerDeck.mainDeck == undefined) {
-            match.playerDeck = JSON.parse(
-              '{"deckTileId":67003,"description":null,"format":"Standard","colors":[],"id":"00000000-0000-0000-0000-000000000000","isValid":false,"lastUpdated":"2018-05-31T00:06:29.7456958","lockedForEdit":false,"lockedForUse":false,"mainDeck":[],"name":"Undefined","resourceId":"00000000-0000-0000-0000-000000000000","sideboard":[]}'
-            );
-          } else {
-            match.playerDeck.colors = get_deck_colors(match.playerDeck);
-          }
-          match.playerDeck.mainDeck.sort(compare_cards);
-          match.oppDeck.colors = get_deck_colors(match.oppDeck);
-          match.oppDeck.mainDeck.sort(compare_cards);
-        } catch (e) {
-          console.log(e, match);
-        }
-      }
-    }
-  });
 }
 
 function compare_matches(a, b) {


### PR DESCRIPTION
### Motivation
This is a subtle performance optimization and bugfix that handles some minor edge cases related to `matchesHistory`.

### The Dirty Details
Opening the History page currently always requires a "deep" processing loop through `matchesHistory` that takes care of some data normalization and sorting. This can be slow, and none of the sorting appears to be used downstream. The data normalization is probably necessary for historic reasons, especially handling old match formats or weird historical data irregularities. Current issues:
- Opening the history page can be slow due to all of this unnecessary work
- Navigating to the Decks/Deck Details/Events page before visiting the History page can cause you to see only "valid" historical matches. Visiting the History page once and then going back to the other pages will correctly show all normalized historical matches.

### Approach
- Move the data normalization into the `createAllMatches` singleton factory method. Do it exactly once there, only when needed.
- Discard the unused sorting logic.

