### PR TITLE
Upgrade to Electron 5.0.1

### DIFF
--- a/main.js
+++ b/main.js
@@ -468,7 +468,10 @@ function createUpdaterWindow() {
     width: 320,
     height: 240,
     title: "Updater",
-    icon: "icon.png"
+    icon: "icon.png",
+    webPreferences: {
+      nodeIntegration: true
+    }
   });
   win.loadURL(`file://${__dirname}/window_updater/index.html`);
 

--- a/main.js
+++ b/main.js
@@ -47,30 +47,30 @@ var firstSettingsRead = true;
 
 const singleLock = app.requestSingleInstanceLock();
 
+app.on("second-instance", () => {
+  if (updaterWindow) {
+    showWindow();
+  } else if (mainWindow.isVisible()) {
+    if (mainWindow.isMinimized()) {
+      showWindow();
+    }
+  } else {
+    showWindow();
+  }
+});
+
 if (!singleLock) {
   console.log("We dont have single instance lock! quitting the app.");
   app.quit();
-} else {
-  app.on("second-instance", () => {
-    if (updaterWindow) {
-      showWindow();
-    } else if (mainWindow.isVisible()) {
-      if (mainWindow.isMinimized()) {
-        showWindow();
-      }
-    } else {
-      showWindow();
-    }
-  });
-
-  app.on("ready", () => {
-    if (app.isPackaged) {
-      startUpdater();
-    } else {
-      startApp();
-    }
-  });
 }
+
+app.on("ready", () => {
+  if (app.isPackaged) {
+    startUpdater();
+  } else {
+    startApp();
+  }
+});
 
 function startUpdater() {
   updaterWindow = createUpdaterWindow();
@@ -484,7 +484,10 @@ function createBackgroundWindow() {
     width: 640,
     height: 480,
     title: "Background",
-    icon: "icon.png"
+    icon: "icon.png",
+    webPreferences: {
+      nodeIntegration: true
+    }
   });
   win.loadURL(`file://${__dirname}/window_background/index.html`);
   win.on("closed", onClosed);
@@ -500,7 +503,10 @@ function createMainWindow() {
     width: 800,
     height: 600,
     title: "MTG Arena Tool",
-    icon: "icon.png"
+    icon: "icon.png",
+    webPreferences: {
+      nodeIntegration: true
+    }
   });
   win.loadURL(`file://${__dirname}/window_main/index.html`);
   win.on("closed", onClosed);
@@ -547,7 +553,10 @@ function createOverlay() {
     height: 600,
     show: false,
     title: "MTG Arena Tool",
-    icon: "iconoverlay.png"
+    icon: "iconoverlay.png",
+    webPreferences: {
+      nodeIntegration: true
+    }
   });
   over.loadURL(`file://${__dirname}/window_overlay/index.html`);
   over.on("closed", onOverlayClosed);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "MTG-Arena-Tool",
-  "version": "2.5.8",
+  "version": "2.5.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -506,9 +506,9 @@
       }
     },
     "@types/node": {
-      "version": "8.10.48",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.48.tgz",
-      "integrity": "sha512-c35YEBTkL4rzXY2ucpSKy+UYHjUBIIkuJbWYbsGIrKLEWU5dgJMmLkkIb3qeC3O3Tpb1ZQCwecscvJTDjDjkRw==",
+      "version": "10.14.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.7.tgz",
+      "integrity": "sha512-on4MmIDgHXiuJDELPk1NFaKVUxxCFr37tm8E9yN6rAiF5Pzp/9bBfBHkoexqRiY+hk/Z04EJU9kKEb59YqJ82A==",
       "dev": true
     },
     "@types/stack-utils": {
@@ -1921,12 +1921,12 @@
       "dev": true
     },
     "electron": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-3.1.9.tgz",
-      "integrity": "sha512-F9AoMjY9zuQBdxmjZz644wHnJehNlYD+WQK2kBMXKoRKrzkYgD5k6QU6mqZuT5OGARpYp9zFOJ8uuJVcAB+TbQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-5.0.1.tgz",
+      "integrity": "sha512-8KksyhAPcpXVeO8ViVGxfZAuf8yEVBCtV0h/lMBD8VFbCQ9icej1K5csCFAGirbZbqOz5IdsBZX9Gpb9n4RCag==",
       "dev": true,
       "requires": {
-        "@types/node": "^8.0.24",
+        "@types/node": "^10.12.18",
         "electron-download": "^4.1.0",
         "extract-zip": "^1.0.3"
       }
@@ -2092,6 +2092,12 @@
           }
         }
       }
+    },
+    "electron-react-devtools": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/electron-react-devtools/-/electron-react-devtools-0.5.3.tgz",
+      "integrity": "sha1-x07bEkXcHP4TgLkwFs1OtYjtALc=",
+      "dev": true
     },
     "electron-store": {
       "version": "3.2.0",
@@ -2486,9 +2492,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-4.2.0.tgz",
-      "integrity": "sha512-y0uWc/FRfrHhpPZCYflWC8aE0KRJRY04rdZVfl8cL3sEZmOYyaBdhdlQPjKZBnuRMyLVK+JUZr7HaZFClQiH4w==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-4.3.0.tgz",
+      "integrity": "sha512-sZwhSTHVVz78+kYD3t5pCWSYEdVSBR0PXnwjDRsUs8ytIrK8PLXw+6FKp8r3Z7rx4ZszdetWlXYKOHoUrrwPlA==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"
@@ -2503,9 +2509,9 @@
       }
     },
     "eslint-plugin-prettier": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.0.1.tgz",
-      "integrity": "sha512-/PMttrarPAY78PLvV3xfWibMOdMDl57hmlQ2XqFeA37wd+CJ7WSxV7txqjVPHi/AAFKd2lX0ZqfsOc/i5yFCSQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.0.tgz",
+      "integrity": "sha512-XWX2yVuwVNLOUhQijAkXz+rMPPoCr7WFiAl8ig6I7Xn+pPVhDhzg4DxHpmbeb0iqjO9UronEA3Tb09ChnFVHHA==",
       "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -91,11 +91,12 @@
   },
   "devDependencies": {
     "acorn": "^6.1.1",
-    "electron": "^3.1.9",
+    "electron": "^5.0.1",
     "electron-builder": "^20.40.2",
+    "electron-react-devtools": "^0.5.3",
     "eslint": "^5.16.0",
-    "eslint-config-prettier": "^4.2.0",
-    "eslint-plugin-prettier": "^3.0.1",
+    "eslint-config-prettier": "^4.3.0",
+    "eslint-plugin-prettier": "^3.1.0",
     "jest": "^24.8.0",
     "prettier": "1.16.4"
   }


### PR DESCRIPTION
### Motivation
We are now 2 versions behind the latest stable Electron. There are too many bugfixes and features to list here, see [the ElectronJS release notes for details.](https://electronjs.org/releases/stable)

### Major Breaking Changes
- Upgraded to Chromium 73.0.3683.119
- Upgraded to Node.js 12.0.0
- Upgraded to V8 7.3.492.27
- Updated the single app instance API
- Window processes need explicit `nodeIntegration`
