### PR TITLE
Refactor so that loading http-api module does not cause side-effects

### DIFF
--- a/window_background/background.js
+++ b/window_background/background.js
@@ -1989,3 +1989,8 @@ function finishLoading() {
     ipc_send("ipc_log", `Log read in ${logReadElapsed}s`);
   }
 }
+
+// start
+httpApi.httpBasic();
+httpApi.httpGetDatabase();
+httpApi.htttpGetStatus();

--- a/window_background/http-api.js
+++ b/window_background/http-api.js
@@ -23,9 +23,6 @@ const qs = require("qs");
 let metadataState = false;
 
 var httpAsync = [];
-httpBasic();
-httpGetDatabase();
-htttpGetStatus();
 
 const serverAddress = "mtgatool.com";
 
@@ -676,6 +673,7 @@ function httpSyncRequest(data) {
 
 module.exports = {
   httpAuth,
+  httpBasic,
   httpSubmitCourse,
   httpSetPlayer,
   httpGetExplore,


### PR DESCRIPTION
I was getting a weird race condition based when I changed the way that modules are loaded. It turns out to be caused by the http-api module because it does stuff when its loaded.