### PR TITLE
Update Project Ignore Patterns

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,21 @@
+# See https://eslint.org/docs/user-guide/configuring#eslintignore for more about ignoring files.
+
+# dependencies
 shared/autocomplete.js
+window_background/messages_pb.js
+
+# assets
 images/*
 sounds/*
 fonts/*
-window_background/messages_pb.js
-window_background/arena-log-decoder/__tests__/*
+
+# development
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+/dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,33 @@
-node_modules
-dist
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+
+# development
 main.sublime-workspace
 main.sublime-project
 *.sublime-workspace
 *.sublime-project
 *.sublime-settings
 .vscode
-.DS_Store
 /.vs
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+/dist
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,21 @@
+# See https://prettier.io/docs/en/ignore.html for more about ignoring files.
+
+# dependencies
 shared/autocomplete.js
 window_background/messages_pb.js
+
+# assets
+images/*
+sounds/*
+fonts/*
+
+# development
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/build
+/dist

--- a/window_background/arena-log-decoder/__tests__/arena-log-decoder-spec.js
+++ b/window_background/arena-log-decoder/__tests__/arena-log-decoder-spec.js
@@ -1,3 +1,5 @@
+/* eslint-env jest */
+
 const fs = require("fs");
 const ArenaLogDecoder = require("../arena-log-decoder");
 


### PR DESCRIPTION
This PR updates our `.gitignore`, `.eslintignore`, and `.prettierignore` files to make sure that they skip over the build folders and some additional common contributor workspace tools.