### PR TITLE
bugfix aggregator winrate total

### DIFF
--- a/window_main/aggregator.js
+++ b/window_main/aggregator.js
@@ -411,12 +411,14 @@ class Aggregator {
     }
     // update relevant stats
     statsToUpdate.forEach(stats => {
-      stats.total++;
       // some of the data is wierd. Games which last years or have no data.
       if (match.duration && match.duration < 3600) {
         stats.duration += match.duration;
       }
       if (match.player && match.opponent) {
+        if (match.player.win || match.opponent.win) {
+          stats.total++;
+        }
         if (match.player.win > match.opponent.win) {
           stats.wins++;
         } else if (match.player.win < match.opponent.win) {


### PR DESCRIPTION
### Motivation
https://discordapp.com/channels/463844727654187020/467737642306371584/581144812258983967
![image](https://user-images.githubusercontent.com/14894693/58270070-ce5a1d00-7d3d-11e9-8a64-38c3b1240774.png)
The aggregator currently counts all items visible in matches history towards the total used in the winrate math.

### Bug
![image](https://user-images.githubusercontent.com/14894693/58270138-f0ec3600-7d3d-11e9-825d-434090a2b415.png)

### Fixed
![image](https://user-images.githubusercontent.com/14894693/58270043-bda9a700-7d3d-11e9-8ac7-b8af8c0fa709.png)
