### PR TITLE
Remember last open tab

### DIFF
--- a/window_background/background.js
+++ b/window_background/background.js
@@ -127,7 +127,8 @@ const defaultCfg = {
     export_format: "$Name,$Count,$Rarity,$SetName,$Collector",
     back_color: "rgba(0,0,0,0.3)",
     back_url: "",
-    right_panel_width: 200
+    right_panel_width: 200,
+    last_open_tab: -1
   },
   economy_index: [],
   economy: [],

--- a/window_main/index.html
+++ b/window_main/index.html
@@ -36,7 +36,7 @@
             <div class="top_nav hidden">
                 <div class="top_nav_icons">
                     <div class="top_nav_separator"></div>
-                    <div class="top_nav_item item_selected ith" style="width: 60px;"><div class="ith_icon"></div></div>
+                    <div class="top_nav_item ith" style="width: 60px;"><div class="ith_icon"></div></div>
                     <div class="top_nav_item it0"><span class="top_nav_item_text">MY DECKS</span><div class="top_nav_icon icon_1"></div></div>
                     <div class="top_nav_item it1"><span class="top_nav_item_text">HISTORY</span><div class="top_nav_icon icon_2"></div></div>
                     <div class="top_nav_item it2"><span class="top_nav_item_text">EVENTS</span><div class="top_nav_icon icon_3"></div></div>


### PR DESCRIPTION
This PR adds a user setting that remembers the last tab the user was on. When detected, the tool will default opening to the last tab instead of the home page.

- creates a new `settings.last_open_tab` user setting
- renderer listens to the new user setting if present
- extract the logic from the tab click handler to a new `renderer.openTab(tab)` function
- update the click handler to call the new function
- update the initialization handler to call the new function
