### PR TITLE
No Globals in Main Window Process

### DIFF
--- a/shared/database.js
+++ b/shared/database.js
@@ -6,8 +6,10 @@ class Database {
   constructor() {
     if (Database.instance) return Database.instance;
 
+    this.handleSetActiveEvents = this.handleSetActiveEvents.bind(this);
     this.handleSetDb = this.handleSetDb.bind(this);
     this.handleSetSeason = this.handleSetSeason.bind(this);
+    if (ipc) ipc.on("set_active_events", this.handleSetActiveEvents);
     if (ipc) ipc.on("set_db", this.handleSetDb);
     if (ipc) ipc.on("set_season", this.handleSetSeason);
     const dbUri = `${__dirname}/../resources/database.json`;
@@ -15,6 +17,16 @@ class Database {
     this.handleSetDb(null, defaultDb);
 
     Database.instance = this;
+  }
+
+  handleSetActiveEvents(_event, arg) {
+    if (!arg) return;
+    try {
+      this.activeEvents = JSON.parse(arg);
+    } catch (e) {
+      console.log("Error parsing JSON:", arg);
+      return false;
+    }
   }
 
   handleSetDb(_event, arg) {

--- a/shared/database.js
+++ b/shared/database.js
@@ -8,9 +8,11 @@ class Database {
 
     this.handleSetActiveEvents = this.handleSetActiveEvents.bind(this);
     this.handleSetDb = this.handleSetDb.bind(this);
+    this.handleSetRewardResets = this.handleSetRewardResets.bind(this);
     this.handleSetSeason = this.handleSetSeason.bind(this);
     if (ipc) ipc.on("set_active_events", this.handleSetActiveEvents);
     if (ipc) ipc.on("set_db", this.handleSetDb);
+    if (ipc) ipc.on("set_reward_resets", this.handleSetRewardResets);
     if (ipc) ipc.on("set_season", this.handleSetSeason);
     const dbUri = `${__dirname}/../resources/database.json`;
     const defaultDb = fs.readFileSync(dbUri, "utf8");
@@ -35,6 +37,11 @@ class Database {
     } catch (e) {
       console.log("Error parsing metadata", e);
     }
+  }
+
+  handleSetRewardResets(_event, arg) {
+    this.rewards_daily_ends = new Date(arg.daily);
+    this.rewards_weekly_ends = new Date(arg.weekly);
   }
 
   handleSetSeason(_event, arg) {

--- a/shared/player-data.js
+++ b/shared/player-data.js
@@ -17,6 +17,7 @@ const playerDataDefault = {
   userName: "",
   arenaId: "",
   arenaVersion: "",
+  offline: false,
   patreon: false,
   patreon_tier: 0,
   rank: {

--- a/window_background/background.js
+++ b/window_background/background.js
@@ -26,12 +26,12 @@ const sha1 = require("js-sha1");
 const httpApi = require("./http-api");
 const manifestParser = require("./manifest-parser");
 const greToClientInterpreter = require("./gre-to-client-interpreter");
-const Deck = require("../shared/deck.js");
+const Deck = require("../shared/deck");
 const db = require("../shared/database");
-const pd = require("../shared/player-data.js");
+const pd = require("../shared/player-data");
 const { hypergeometricRange } = require("../shared/stats-fns");
 const { get_rank_index, objectClone } = require("../shared/util");
-const { HIDDEN_PW, IPC_OVERLAY } = require("../shared/constants.js");
+const { HIDDEN_PW, IPC_OVERLAY } = require("../shared/constants");
 const { ipc_send, pd_set, unleakString } = require("./background-util");
 const {
   onLabelOutLogInfo,
@@ -243,9 +243,8 @@ ipc.on("set_renderer_state", function(event, arg) {
 });
 
 function offlineLogin() {
-  pd_set({ userName: "" });
+  pd_set({ userName: "", offline: true });
   ipc_send("auth", { ok: true, user: -1 });
-  ipc_send("set_offline", true);
   loadPlayerConfig(pd.arenaId);
 }
 

--- a/window_background/http-api.js
+++ b/window_background/http-api.js
@@ -89,7 +89,7 @@ function httpBasic() {
         _headers.method != "get_status" &&
         debugLog == false
       ) {
-        ipc_send("set_offline", true);
+        pd_set({ offline: true });
         callback({
           message: "Settings dont allow sending data! > " + _headers.method
         });

--- a/window_main/collection.js
+++ b/window_main/collection.js
@@ -18,8 +18,8 @@ const {
 
 const {
   hideLoadingBars,
-  changeBackground: change_background,
-  ipcSend: ipc_send
+  changeBackground,
+  ipcSend
 } = require("./renderer-util");
 
 let collectionPage = 0;
@@ -593,7 +593,7 @@ function resetFilters() {
 //
 function exportCollection() {
   let list = get_collection_export(pd.settings.export_format);
-  ipc_send("export_csvtxt", { str: list, name: "collection" });
+  ipcSend("export_csvtxt", { str: list, name: "collection" });
 }
 
 //
@@ -609,7 +609,7 @@ function printStats() {
   top.appendChild(createDivision(["deck_name"], "Collection Statistics"));
   top.appendChild(createDivision(["deck_top_colors"]));
 
-  //change_background("", 67574);
+  //changeBackground("", 67574);
 
   const flex = createDivision(["flex_item"]);
   const mainstats = createDivision(["main_stats"]);
@@ -657,7 +657,7 @@ function printStats() {
 
   //
   $$(".back")[0].addEventListener("click", () => {
-    change_background("default");
+    changeBackground("default");
     $(".moving_ux").animate({ left: "0px" }, 250, "easeInOutCubic");
   });
 }

--- a/window_main/collection.js
+++ b/window_main/collection.js
@@ -1,14 +1,8 @@
-/*
-global
-  change_background
-  hideLoadingBars
-  ipc_send
-  remote
-  Menu
-  MenuItem
-*/
+const { remote, shell } = require("electron");
+const Menu = remote.Menu;
+const MenuItem = remote.MenuItem;
 
-const { shell } = require("electron");
+const { COLORS_BRIEF, CARD_RARITIES } = require("../shared/constants");
 const db = require("../shared/database");
 const pd = require("../shared/player-data");
 const { queryElements: $$, createDivision } = require("../shared/dom-fns");
@@ -22,7 +16,11 @@ const {
   replaceAll
 } = require("../shared/util");
 
-const { COLORS_BRIEF, CARD_RARITIES } = require("../shared/constants.js");
+const {
+  hideLoadingBars,
+  changeBackground: change_background,
+  ipcSend: ipc_send
+} = require("./renderer-util");
 
 let collectionPage = 0;
 let sortingAlgorithm = "Sort by Set";

--- a/window_main/data-scroller.js
+++ b/window_main/data-scroller.js
@@ -1,13 +1,10 @@
-/*
-global
-  $
-  hideLoadingBars
-  showLoadingBars
-  lastDataIndex
-  lastScrollTop
-*/
-
 const { createDivision } = require("../shared/dom-fns");
+
+const {
+  setLocalState,
+  showLoadingBars,
+  hideLoadingBars
+} = require("./renderer-util");
 
 class DataScroller {
   constructor(container, renderData, loadAmount, maxDataIndex) {
@@ -33,12 +30,14 @@ class DataScroller {
     }
     jCont.off();
     jCont.on("scroll", () => {
+      const newLs = {};
       const desiredHeight = Math.round(jCont.scrollTop() + jCont.innerHeight());
       if (desiredHeight >= jCont[0].scrollHeight) {
         this.renderRows(this.loadAmount);
-        lastDataIndex = this.dataIndex;
+        newLs.lastDataIndex = this.dataIndex;
       }
-      lastScrollTop = jCont.scrollTop();
+      newLs.lastScrollTop = jCont.scrollTop();
+      setLocalState(newLs);
     });
   }
 

--- a/window_main/deck-details.js
+++ b/window_main/deck-details.js
@@ -24,10 +24,10 @@ const {
 const Aggregator = require("./aggregator");
 const StatsPanel = require("./stats-panel");
 const {
-  changeBackground: change_background,
+  changeBackground,
   drawDeck,
   drawDeckVisual,
-  ipcSend: ipc_send,
+  ipcSend,
   makeResizable,
   pop
 } = require("./renderer-util");
@@ -371,7 +371,7 @@ function openDeck(deck = currentOpenDeck, filters = currentFilters) {
 
   const tileGrpId = deck.deckTileId;
   if (db.card(tileGrpId)) {
-    change_background("", tileGrpId);
+    changeBackground("", tileGrpId);
   }
 
   const deckListSection = createDivision(["decklist"]);
@@ -399,16 +399,16 @@ function openDeck(deck = currentOpenDeck, filters = currentFilters) {
   $(".exportDeck").click(() => {
     const list = get_deck_export(deck);
     pop("Copied to clipboard", 1000);
-    ipc_send("set_clipboard", list);
+    ipcSend("set_clipboard", list);
   });
 
   $(".exportDeckStandard").click(() => {
     const list = get_deck_export_txt(deck);
-    ipc_send("export_txt", { str: list, name: deck.name });
+    ipcSend("export_txt", { str: list, name: deck.name });
   });
 
   $(".back").click(() => {
-    change_background("default");
+    changeBackground("default");
     $(".moving_ux").animate({ left: "0px" }, 250, "easeInOutCubic");
   });
 }

--- a/window_main/decks.js
+++ b/window_main/decks.js
@@ -1,23 +1,7 @@
-/*
-global
-  Aggregator
-  allMatches
-  FilterPanel
-  formatPercent
-  hideLoadingBars
-  getWinrateClass
-  ipc_send
-  makeResizable
-  ListItem
-  openDeck
-  pd
-  sidebarActive
-  getTagColor
-  StatsPanel
-  lastScrollTop
-*/
-
 const _ = require("lodash");
+
+const { MANA, CARD_RARITIES } = require("../shared/constants");
+const pd = require("../shared/player-data");
 const { createDivision } = require("../shared/dom-fns");
 const {
   get_deck_missing,
@@ -25,7 +9,21 @@ const {
   getReadableFormat
 } = require("../shared/util");
 
-const { MANA, CARD_RARITIES } = require("../shared/constants.js");
+const Aggregator = require("./aggregator");
+const FilterPanel = require("./filter-panel");
+const ListItem = require("./list-item");
+const StatsPanel = require("./stats-panel");
+const { openDeck } = require("./deck-details");
+const {
+  formatPercent,
+  getLocalState,
+  getTagColor,
+  getWinrateClass,
+  hideLoadingBars,
+  ipcSend: ipc_send,
+  makeResizable,
+  setLocalState
+} = require("./renderer-util");
 
 let filters = Aggregator.getDefaultFilters();
 filters.onlyCurrentDecks = true;
@@ -49,9 +47,8 @@ function setFilters(selected = {}) {
 
 //
 function openDecksTab(_filters = {}, scrollTop = 0) {
-  if (sidebarActive !== 0) return;
-
   hideLoadingBars();
+  const ls = getLocalState();
   const mainDiv = document.getElementById("ux_0");
   mainDiv.classList.add("flex_item");
   mainDiv.innerHTML = "";
@@ -98,7 +95,7 @@ function openDecksTab(_filters = {}, scrollTop = 0) {
     "decks_top",
     selected => openDecksTab(selected),
     filters,
-    allMatches.events,
+    ls.totalAgg.events,
     tags,
     [],
     true,
@@ -248,10 +245,10 @@ function openDecksTab(_filters = {}, scrollTop = 0) {
 
   const jCont = $(wrap_l);
   if (scrollTop) {
-    jCont.scrollTop(lastScrollTop);
+    jCont.scrollTop(ls.lastScrollTop);
   }
   jCont.on("scroll", () => {
-    lastScrollTop = jCont.scrollTop();
+    setLocalState({ lastScrollTop: jCont.scrollTop() });
   });
 }
 

--- a/window_main/decks.js
+++ b/window_main/decks.js
@@ -20,7 +20,7 @@ const {
   getTagColor,
   getWinrateClass,
   hideLoadingBars,
-  ipcSend: ipc_send,
+  ipcSend,
   makeResizable,
   setLocalState
 } = require("./renderer-util");
@@ -122,7 +122,7 @@ function openDecksTab(_filters = {}, scrollTop = 0) {
     let listItem;
     if (deck.custom) {
       const archiveCallback = id => {
-        ipc_send("toggle_deck_archived", id);
+        ipcSend("toggle_deck_archived", id);
       };
 
       listItem = new ListItem(
@@ -287,7 +287,7 @@ function createTag(tag, div, showClose = true) {
       colorPick.on("change.spectrum", (e, color) => {
         const tag = $(this).text();
         const col = color.toRgbString();
-        ipc_send("edit_tag", { tag, color: col });
+        ipcSend("edit_tag", { tag, color: col });
       });
 
       colorPick.on("hide.spectrum", () => {
@@ -364,11 +364,11 @@ function createTag(tag, div, showClose = true) {
 }
 
 function addTag(deckid, tag) {
-  ipc_send("add_tag", { deckid, tag });
+  ipcSend("add_tag", { deckid, tag });
 }
 
 function deleteTag(deckid, tag) {
-  ipc_send("delete_tag", { deckid, tag });
+  ipcSend("delete_tag", { deckid, tag });
 }
 
 module.exports = { openDecksTab: openDecksTab };

--- a/window_main/economy.js
+++ b/window_main/economy.js
@@ -1,14 +1,7 @@
-/*
-global
-  $
-  DataScroller
-  formatNumber
-  formatPercent
-  toggleArchived
-  ipc_send
-*/
-
 const { shell } = require("electron");
+
+const { differenceInCalendarDays } = require("date-fns");
+
 const db = require("../shared/database");
 const pd = require("../shared/player-data");
 const { createDivision } = require("../shared/dom-fns");
@@ -21,13 +14,18 @@ const {
   getReadableEvent
 } = require("../shared/util");
 
+const DataScroller = require("./data-scroller");
+const {
+  formatNumber,
+  formatPercent,
+  toggleArchived
+} = require("./renderer-util");
+
 var filterEconomy = "All";
 let showArchived = false;
 var daysago = 0;
 var dayList = [];
 let sortedChanges = [];
-
-const differenceInCalendarDays = require("date-fns").differenceInCalendarDays;
 
 class economyDay {
   constructor(

--- a/window_main/events.js
+++ b/window_main/events.js
@@ -18,7 +18,7 @@ const StatsPanel = require("./stats-panel");
 const {
   getEventWinLossClass,
   getLocalState,
-  openMatch: open_match,
+  openMatch,
   toggleArchived
 } = require("./renderer-util");
 
@@ -240,7 +240,7 @@ function createMatchRow(match) {
 
   var tileGrpid = match.playerDeck.deckTileId;
 
-  let matchRow = new ListItem(tileGrpid, match.id, openMatch);
+  let matchRow = new ListItem(tileGrpid, match.id, handleOpenMatch);
   matchRow.divideLeft();
   matchRow.divideRight();
 
@@ -292,8 +292,8 @@ function createMatchRow(match) {
   return matchRow.container;
 }
 
-function openMatch(id) {
-  open_match(id);
+function handleOpenMatch(id) {
+  openMatch(id);
   $(".moving_ux").animate({ left: "-100%" }, 250, "easeInOutCubic");
 }
 

--- a/window_main/events.js
+++ b/window_main/events.js
@@ -1,17 +1,5 @@
-/*
-global
-  Aggregator
-  allMatches
-  DataScroller
-  FilterPanel
-  getEventWinLossClass
-  ListItem
-  open_match
-  pd
-  StatsPanel
-  toggleArchived
-*/
-
+const { MANA } = require("../shared/constants");
+const pd = require("../shared/player-data");
 const { createDivision, queryElementsByClass } = require("../shared/dom-fns");
 const {
   compare_cards,
@@ -22,7 +10,17 @@ const {
   toMMSS
 } = require("../shared/util");
 
-const { MANA } = require("../shared/constants.js");
+const Aggregator = require("./aggregator");
+const DataScroller = require("./data-scroller");
+const FilterPanel = require("./filter-panel");
+const ListItem = require("./list-item");
+const StatsPanel = require("./stats-panel");
+const {
+  getEventWinLossClass,
+  getLocalState,
+  openMatch: open_match,
+  toggleArchived
+} = require("./renderer-util");
 
 let filters = Aggregator.getDefaultFilters();
 filters.eventId = Aggregator.ALL_EVENT_TRACKS;
@@ -51,7 +49,7 @@ function openEventsTab(_filters, dataIndex = 25, scrollTop = 0) {
     "events_top",
     selected => openEventsTab(selected),
     filters,
-    allMatches.trackEvents,
+    getLocalState().totalAgg.trackEvents,
     [],
     [],
     false,

--- a/window_main/explore.js
+++ b/window_main/explore.js
@@ -1,13 +1,6 @@
-/*
-global
-  add_checkbox
-  getWinrateClass
-  hideLoadingBars
-  ipc_send
-  showLoadingBars
-*/
-
 const _ = require("lodash");
+
+const { MANA, COLORS_BRIEF, DEFAULT_TILE } = require("../shared/constants");
 const db = require("../shared/database");
 const pd = require("../shared/player-data");
 const { queryElements: $$, createDivision } = require("../shared/dom-fns");
@@ -21,7 +14,13 @@ const {
   getBoosterCountEstimate
 } = require("../shared/util");
 
-const { MANA, COLORS_BRIEF, DEFAULT_TILE } = require("../shared/constants.js");
+const {
+  addCheckbox: add_checkbox,
+  getWinrateClass,
+  hideLoadingBars,
+  ipcSend: ipc_send,
+  showLoadingBars
+} = require("./renderer-util");
 
 let filterWCC = 0;
 let filterWCU = 0;

--- a/window_main/explore.js
+++ b/window_main/explore.js
@@ -15,10 +15,10 @@ const {
 } = require("../shared/util");
 
 const {
-  addCheckbox: add_checkbox,
+  addCheckbox,
   getWinrateClass,
   hideLoadingBars,
-  ipcSend: ipc_send,
+  ipcSend,
   showLoadingBars
 } = require("./renderer-util");
 
@@ -254,7 +254,7 @@ function drawFilters() {
   /**
    *  Only owned filter
    **/
-  let lab = add_checkbox(
+  let lab = addCheckbox(
     $(buttonsMiddle),
     "Only owned",
     "settings_owned",
@@ -427,7 +427,7 @@ function queryExplore(skip) {
   };
 
   showLoadingBars();
-  ipc_send("request_explore", query);
+  ipcSend("request_explore", query);
 }
 
 function setExploreDecks(data) {
@@ -705,7 +705,7 @@ function eventLoad(event, index) {
 
 function open_course_request(courseId) {
   showLoadingBars();
-  ipc_send("request_course", courseId);
+  ipcSend("request_course", courseId);
 }
 
 module.exports = {

--- a/window_main/explore.js
+++ b/window_main/explore.js
@@ -1,6 +1,5 @@
 /*
 global
-  activeEvents
   add_checkbox
   getWinrateClass
   hideLoadingBars
@@ -178,7 +177,7 @@ function drawFilters() {
   let eventFilters = [];
   if (filterType == "Events") {
     eventFilters = db.eventIds
-      .concat(activeEvents)
+      .concat(db.activeEvents)
       .map(ev => getEventPrettyName(ev))
       .filter(
         item =>
@@ -206,7 +205,7 @@ function drawFilters() {
     return 0;
   });
 
-  let mappedActive = activeEvents.map(ev => getEventPrettyName(ev));
+  let mappedActive = db.activeEvents.map(ev => getEventPrettyName(ev));
   eventFilters.forEach(item => {
     if (mappedActive.includes(item)) {
       eventFilters.splice(eventFilters.indexOf(item), 1);

--- a/window_main/filter-panel.js
+++ b/window_main/filter-panel.js
@@ -1,8 +1,3 @@
-/*
-global
-  getTagColor
-*/
-
 const { COLORS_ALL, COLORS_BRIEF } = require("../shared/constants");
 const pd = require("../shared/player-data");
 const { createDivision } = require("../shared/dom-fns");
@@ -13,15 +8,16 @@ const {
   getRecentDeckName
 } = require("../shared/util");
 
-const Aggregator = require("./aggregator");
+const { getTagColor } = require("./renderer-util");
 const {
   DEFAULT_ARCH,
   DEFAULT_DECK,
   DEFAULT_TAG,
   DATE_LAST_30,
   DATE_ALL_TIME,
-  DATE_SEASON
-} = Aggregator;
+  DATE_SEASON,
+  getDefaultFilters
+} = require("./aggregator");
 
 class FilterPanel {
   constructor(
@@ -40,7 +36,7 @@ class FilterPanel {
     this.prefixId = prefixId;
     this.onFilterChange = onFilterChange;
     this.filters = {
-      ...Aggregator.getDefaultFilters(),
+      ...getDefaultFilters(),
       ...filters
     };
     this.events = events || [];

--- a/window_main/history.js
+++ b/window_main/history.js
@@ -22,10 +22,10 @@ const {
   formatPercent,
   getLocalState,
   getTagColor,
-  ipcSend: ipc_send,
+  ipcSend,
   makeResizable,
-  openDraft: open_draft,
-  openMatch: open_match,
+  openDraft,
+  openMatch,
   showLoadingBars,
   toggleArchived
 } = require("./renderer-util");
@@ -198,10 +198,10 @@ function renderData(container, index) {
   let tileGrpid, clickCallback;
   if (match.type == "match") {
     tileGrpid = match.playerDeck.deckTileId;
-    clickCallback = openMatch;
+    clickCallback = handleOpenMatch;
   } else {
     tileGrpid = db.sets[match.set].tile;
-    clickCallback = openDraft;
+    clickCallback = handleOpenDraft;
   }
   const deleteCallback = id => {
     toggleArchived(id);
@@ -233,13 +233,13 @@ function renderData(container, index) {
   return 1;
 }
 
-function openMatch(id) {
-  open_match(id);
+function handleOpenMatch(id) {
+  openMatch(id);
   $(".moving_ux").animate({ left: "-100%" }, 250, "easeInOutCubic");
 }
 
-function openDraft(id) {
-  open_draft(id);
+function handleOpenDraft(id) {
+  openDraft(id);
   $(".moving_ux").animate({ left: "-100%" }, 250, "easeInOutCubic");
 }
 
@@ -436,7 +436,7 @@ function createTag(tag, div, showClose = true) {
       colorPick.on("change.spectrum", (e, color) => {
         const tag = $(this).text();
         const col = color.toRgbString();
-        ipc_send("edit_tag", { tag, color: col });
+        ipcSend("edit_tag", { tag, color: col });
       });
 
       colorPick.on("hide.spectrum", () => {
@@ -549,14 +549,14 @@ function addTag(matchid, tag, div) {
   if (!match) return;
   if (match.tags && match.tags.includes(tag)) return;
 
-  ipc_send("add_history_tag", { matchid, tag });
+  ipcSend("add_history_tag", { matchid, tag });
 }
 
 function deleteTag(matchid, tag) {
   const match = pd.match(matchid);
   if (!match || !match.tags || !match.tags.includes(tag)) return;
 
-  ipc_send("delete_history_tag", { matchid, tag });
+  ipcSend("delete_history_tag", { matchid, tag });
 }
 
 function getStepsUntilNextRank(mode, winrate) {
@@ -668,7 +668,7 @@ function addShare(_match) {
     selectAdd(select, () => draftShareLink(_match.id));
 
     but.click(function() {
-      ipc_send("set_clipboard", document.getElementById("share_input").value);
+      ipcSend("set_clipboard", document.getElementById("share_input").value);
     });
   });
 }
@@ -694,7 +694,7 @@ function draftShareLink(id) {
       break;
   }
   showLoadingBars();
-  ipc_send("request_draft_link", { expire, id });
+  ipcSend("request_draft_link", { expire, id });
 }
 
 function compare_matches(a, b) {

--- a/window_main/home.js
+++ b/window_main/home.js
@@ -1,37 +1,38 @@
-/*
-global
-  authToken
-  discordTag
-  filteredWildcardsSet
-  ipc_send
-  pd,
-  rewards_daily_ends
-  rewards_weekly_ends
-  showLoadingBars
-  tournamentCreate
-*/
-
 const { shell } = require("electron");
 const db = require("../shared/database");
+const pd = require("../shared/player-data");
 const { queryElements: $$, createDivision } = require("../shared/dom-fns");
 const { addCardHover } = require("../shared/card-hover");
 const { toHHMMSS, toDDHHMMSS, timestamp } = require("../shared/util");
+const { tournamentCreate } = require("./tournaments");
+const {
+  getLocalState,
+  ipcSend: ipc_send,
+  showLoadingBars
+} = require("./renderer-util");
 
 let usersActive;
 let tournaments_list;
 let listInterval = [];
 let topWildcards = null;
-
 let homeInterval = null;
+let filteredWildcardsSet = "";
 
+//
 function clearHomeInverals() {
   listInterval.forEach(_id => {
     clearInterval(_id);
   });
 }
 
+//
+function requestHome() {
+  ipc_send("request_home", filteredWildcardsSet);
+}
+
 // Should separate these two into smaller functions
 function openHomeTab(arg, opentab = true) {
+  const ls = getLocalState();
   let mainDiv = document.getElementById("ux_0");
   mainDiv.classList.remove("flex_item");
   mainDiv.innerHTML = "";
@@ -71,11 +72,11 @@ function openHomeTab(arg, opentab = true) {
     if (homeInterval !== null) clearInterval(homeInterval);
 
     homeInterval = window.setInterval(() => {
-      let dd = new Date(rewards_daily_ends);
+      let dd = db.rewards_daily_ends;
       let timeleft = dd.getTime() / 1000 - timestamp();
       daily.innerHTML = "Daily rewards end: " + toDDHHMMSS(timeleft);
 
-      dd = new Date(rewards_weekly_ends);
+      dd = db.rewards_weekly_ends;
       timeleft = dd.getTime() / 1000 - timestamp();
       weekly.innerHTML = "Weekly rewards end: " + toDDHHMMSS(timeleft);
     }, 250);
@@ -91,18 +92,18 @@ function openHomeTab(arg, opentab = true) {
   mainDiv.appendChild(title);
   let cont = createDivision(["tournament_list_cont"]);
 
-  if (discordTag == null) {
+  if (ls.discordTag === null) {
     let but = createDivision(["discord_but"]);
     but.addEventListener("click", () => {
       let url =
         "https://discordapp.com/api/oauth2/authorize?client_id=531626302004789280&redirect_uri=http%3A%2F%2Fmtgatool.com%2Fdiscord%2F&response_type=code&scope=identify%20email&state=" +
-        authToken;
+        ls.authToken;
       shell.openExternal(url);
     });
 
     cont.appendChild(but);
   } else {
-    let dname = discordTag.split("#")[0];
+    let dname = ls.discordTag.split("#")[0];
     let fl = createDivision(
       ["flex_item"],
       `<div class="discord_icon"></div><div class="top_username discord_username">${dname}</div><div class="discord_message">Your discord tag will be visible to your opponents.</div>`
@@ -281,7 +282,7 @@ function openHomeTab(arg, opentab = true) {
           filteredWildcardsSet = set;
         }
         showLoadingBars();
-        ipc_send("request_home", filteredWildcardsSet);
+        requestHome();
       });
     });
 
@@ -361,5 +362,6 @@ function openHomeTab(arg, opentab = true) {
 }
 
 module.exports = {
-  openHomeTab: openHomeTab
+  openHomeTab,
+  requestHome
 };

--- a/window_main/home.js
+++ b/window_main/home.js
@@ -5,11 +5,7 @@ const { queryElements: $$, createDivision } = require("../shared/dom-fns");
 const { addCardHover } = require("../shared/card-hover");
 const { toHHMMSS, toDDHHMMSS, timestamp } = require("../shared/util");
 const { tournamentCreate } = require("./tournaments");
-const {
-  getLocalState,
-  ipcSend: ipc_send,
-  showLoadingBars
-} = require("./renderer-util");
+const { getLocalState, ipcSend, showLoadingBars } = require("./renderer-util");
 
 let usersActive;
 let tournaments_list;
@@ -27,7 +23,7 @@ function clearHomeInverals() {
 
 //
 function requestHome() {
-  ipc_send("request_home", filteredWildcardsSet);
+  ipcSend("request_home", filteredWildcardsSet);
 }
 
 // Should separate these two into smaller functions
@@ -238,7 +234,7 @@ function openHomeTab(arg, opentab = true) {
         tournamentCreate();
       } else {
         document.body.style.cursor = "progress";
-        ipc_send("tou_get", cont.id);
+        ipcSend("tou_get", cont.id);
       }
     });
   });

--- a/window_main/list-item.js
+++ b/window_main/list-item.js
@@ -1,5 +1,5 @@
-const { DEFAULT_TILE } = require("../shared/constants.js");
-const db = require("../shared/database.js");
+const { DEFAULT_TILE } = require("../shared/constants");
+const db = require("../shared/database");
 const { createDivision } = require("../shared/dom-fns");
 
 class ListItem {

--- a/window_main/renderer-util.js
+++ b/window_main/renderer-util.js
@@ -1,0 +1,1203 @@
+const fs = require("fs");
+const path = require("path");
+const { app, ipcRenderer: ipc, remote } = require("electron");
+const _ = require("lodash");
+const striptags = require("striptags");
+
+const {
+  DRAFT_RANKS,
+  MANA,
+  IPC_MAIN,
+  IPC_BACKGROUND
+} = require("../shared/constants");
+const db = require("../shared/database");
+const pd = require("../shared/player-data");
+const { queryElements: $$ } = require("../shared/dom-fns");
+const deckDrawer = require("../shared/deck-drawer");
+const cardTypes = require("../shared/card-types");
+const { addCardHover } = require("../shared/card-hover");
+const {
+  compare_cards,
+  get_card_image,
+  get_deck_export,
+  get_deck_export_txt,
+  get_deck_types_ammount,
+  get_rank_index,
+  makeId
+} = require("../shared/util");
+const {
+  hypergeometricSignificance,
+  hypergeometricRange
+} = require("../shared/stats-fns");
+
+let draftPosition = 1;
+let popTimeout = null;
+// quick and dirty shared state object for main renderer process
+// (for state shared across processes, use database or player-data)
+const localState = {
+  authToken: "",
+  discordTag: null,
+  lastDataIndex: 0,
+  lastScrollTop: 0
+};
+const actionLogDir = path.join(
+  (app || remote.app).getPath("userData"),
+  "actionlogs"
+);
+
+//
+exports.ipcSend = ipc_send;
+function ipc_send(method, arg, to = IPC_BACKGROUND) {
+  ipc.send("ipc_switch", method, IPC_MAIN, arg, to);
+}
+
+//
+exports.pop = pop;
+function pop(str, timeout) {
+  $(".popup").css("opacity", 1);
+  $(".popup").html(str);
+  if (popTimeout != null) {
+    clearTimeout(popTimeout);
+  }
+  if (timeout < 1) {
+    popTimeout = null;
+  } else {
+    popTimeout = setTimeout(function() {
+      $(".popup").css("opacity", 0);
+      popTimeout = null;
+    }, timeout);
+  }
+}
+
+//
+exports.showLoadingBars = showLoadingBars;
+function showLoadingBars() {
+  $$(".main_loading")[0].style.display = "block";
+  document.body.style.cursor = "progress";
+}
+
+//
+exports.hideLoadingBars = hideLoadingBars;
+function hideLoadingBars() {
+  $$(".main_loading")[0].style.display = "none";
+  document.body.style.cursor = "auto";
+}
+
+//
+exports.setLocalState = setLocalState;
+function setLocalState(state = {}) {
+  Object.assign(localState, state);
+}
+
+//
+exports.getLocalState = getLocalState;
+function getLocalState() {
+  return localState;
+}
+
+// convenience handler for player data singleton
+exports.toggleArchived = toggleArchived;
+function toggleArchived(id) {
+  ipc_send("toggle_archived", id);
+}
+
+//
+exports.getTagColor = getTagColor;
+function getTagColor(tag) {
+  return pd.tags_colors[tag] || "#FAE5D2";
+}
+
+//
+exports.makeResizable = makeResizable;
+function makeResizable(div, resizeCallback, finalCallback) {
+  var m_pos;
+  let finalWidth;
+
+  let resize = function(e) {
+    var parent = div.parentNode;
+    var dx = m_pos - e.x;
+    m_pos = e.x;
+    let newWidth = Math.max(10, parseInt(parent.style.width) + dx);
+    parent.style.width = `${newWidth}px`;
+    parent.style.flex = `0 0 ${newWidth}px`;
+    if (resizeCallback instanceof Function) resizeCallback(newWidth);
+    finalWidth = newWidth;
+  };
+
+  let saveWidth = function(width) {
+    ipc_send("save_user_settings", { right_panel_width: width });
+  };
+
+  div.addEventListener(
+    "mousedown",
+    event => {
+      m_pos = event.x;
+      document.addEventListener("mousemove", resize, false);
+    },
+    false
+  );
+
+  document.addEventListener(
+    "mouseup",
+    event => {
+      document.removeEventListener("mousemove", resize, false);
+      if (finalWidth) {
+        saveWidth(finalWidth);
+        if (finalCallback instanceof Function) finalCallback(finalWidth);
+        finalWidth = null;
+      }
+    },
+    false
+  );
+}
+
+//
+exports.drawDeck = drawDeck;
+function drawDeck(div, deck, showWildcards = false) {
+  div.html("");
+  const unique = makeId(4);
+
+  // draw maindeck grouped by cardType
+  const cardsByGroup = _(deck.mainDeck)
+    .map(card => ({ data: db.card(card.id), ...card }))
+    .groupBy(card => {
+      const cardType = cardTypes.cardType(card.data);
+      switch (cardType) {
+        case "Creature":
+          return "Creatures";
+        case "Planeswalker":
+          return "Planeswalkers";
+        case "Instant":
+        case "Sorcery":
+          return "Spells";
+        case "Enchantment":
+          return "Enchantments";
+        case "Artifact":
+          return "Artifacts";
+        case "Land":
+          return "Lands";
+        default:
+          throw new Error(`Unexpected card type: ${cardType}`);
+      }
+    })
+    .value();
+
+  _([
+    "Creatures",
+    "Planeswalkers",
+    "Spells",
+    "Enchantments",
+    "Artifacts",
+    "Lands"
+  ])
+    .filter(group => !_.isEmpty(cardsByGroup[group]))
+    .forEach(group => {
+      // draw a separator for the group
+      const cards = cardsByGroup[group];
+      const count = _.sumBy(cards, "quantity");
+      const separator = deckDrawer.cardSeparator(`${group} (${count})`);
+      div.append(separator);
+
+      // draw the cards
+      _(cards)
+        .filter(card => card.quantity > 0)
+        .orderBy(["data.cmc", "data.name"])
+        .forEach(card => {
+          const tile = deckDrawer.cardTile(
+            pd.settings.card_tile_style,
+            card.id,
+            unique + "a",
+            card.quantity,
+            showWildcards,
+            deck,
+            false
+          );
+          div.append(tile);
+        });
+    });
+
+  const sideboardSize = _.sumBy(deck.sideboard, "quantity");
+  if (sideboardSize) {
+    // draw a separator for the sideboard
+    let separator = deckDrawer.cardSeparator(`Sideboard (${sideboardSize})`);
+    div.append(separator);
+
+    // draw the cards
+    _(deck.sideboard)
+      .filter(card => card.quantity > 0)
+      .map(card => ({ data: db.card(card.id), ...card }))
+      .orderBy(["data.cmc", "data.name"])
+      .forEach(card => {
+        const tile = deckDrawer.cardTile(
+          pd.settings.card_tile_style,
+          card.id,
+          unique + "b",
+          card.quantity,
+          showWildcards,
+          deck,
+          true
+        );
+        div.append(tile);
+      });
+  }
+}
+
+//
+exports.drawCardList = drawCardList;
+function drawCardList(div, cards) {
+  let unique = makeId(4);
+  let counts = {};
+  cards.forEach(cardId => (counts[cardId] = (counts[cardId] || 0) + 1));
+  Object.keys(counts).forEach(cardId => {
+    let tile = deckDrawer.cardTile(
+      pd.settings.card_tile_style,
+      cardId,
+      unique,
+      counts[cardId]
+    );
+    div.append(tile);
+  });
+}
+
+//
+exports.drawDeckVisual = drawDeckVisual;
+function drawDeckVisual(_div, deck, _stats, openCallback) {
+  // PLACEHOLDER
+  if (!(_div instanceof jQuery)) {
+    _div = $(_div);
+  }
+  // attempt at sorting visually..
+  var newMainDeck = [];
+
+  for (var cmc = 0; cmc < 21; cmc++) {
+    for (var qq = 4; qq > -1; qq--) {
+      deck.mainDeck.forEach(function(c) {
+        var grpId = c.id;
+        var card = db.card(grpId);
+        var quantity;
+        if (card.type.indexOf("Land") == -1 && grpId != 67306) {
+          if (card.cmc == cmc) {
+            quantity = c.quantity;
+
+            if (quantity == qq) {
+              newMainDeck.push(c);
+            }
+          }
+        } else if (cmc == 20) {
+          quantity = c.quantity;
+          if (qq == 0 && quantity > 4) {
+            newMainDeck.push(c);
+          }
+          if (quantity == qq) {
+            newMainDeck.push(c);
+          }
+        }
+      });
+    }
+  }
+
+  var types = get_deck_types_ammount(deck);
+  var typesdiv = $('<div class="types_container"></div>');
+  $(
+    '<div class="type_icon_cont"><div title="Creatures" class="type_icon type_cre"></div><span>' +
+      types.cre +
+      "</span></div>"
+  ).appendTo(typesdiv);
+  $(
+    '<div class="type_icon_cont"><div title="Lands" class="type_icon type_lan"></div><span>' +
+      types.lan +
+      "</span></div>"
+  ).appendTo(typesdiv);
+  $(
+    '<div class="type_icon_cont"><div title="Instants" class="type_icon type_ins"></div><span>' +
+      types.ins +
+      "</span></div>"
+  ).appendTo(typesdiv);
+  $(
+    '<div class="type_icon_cont"><div title="Sorceries" class="type_icon type_sor"></div><span>' +
+      types.sor +
+      "</span></div>"
+  ).appendTo(typesdiv);
+  $(
+    '<div class="type_icon_cont"><div title="Enchantments" class="type_icon type_enc"></div><span>' +
+      types.enc +
+      "</span></div>"
+  ).appendTo(typesdiv);
+  $(
+    '<div class="type_icon_cont"><div title="Artifacts" class="type_icon type_art"></div><span>' +
+      types.art +
+      "</span></div>"
+  ).appendTo(typesdiv);
+  $(
+    '<div class="type_icon_cont"><div title="Planeswalkers" class="type_icon type_pla"></div><span>' +
+      types.pla +
+      "</span></div>"
+  ).appendTo(typesdiv);
+  typesdiv.prependTo(_div.parent());
+
+  if (_stats) {
+    _stats.hide();
+  }
+  _div.css("display", "flex");
+  _div.css("width", "auto");
+  _div.css("margin", "0 auto");
+  _div.html("");
+
+  _div.parent().css("flex-direction", "column");
+
+  if (_stats) {
+    $('<div class="button_simple openDeck">Normal view</div>').appendTo(
+      _div.parent()
+    );
+
+    $(".openDeck").click(function() {
+      openCallback();
+    });
+  }
+
+  var sz = pd.cardsSize;
+  let div = $('<div class="visual_mainboard"></div>');
+  div.css("display", "flex");
+  div.css("flex-wrap", "wrap");
+  div.css("align-content", "start");
+  div.css("max-width", (sz + 6) * 5 + "px");
+  div.appendTo(_div);
+
+  //var unique = makeId(4);
+  //var prevIndex = 0;
+
+  var tileNow;
+  var _n = 0;
+  newMainDeck.forEach(function(c) {
+    var grpId = c.id;
+    var card = db.card(grpId);
+
+    if (c.quantity > 0) {
+      let dfc = "";
+      if (card.dfc == "DFC_Back") dfc = "a";
+      if (card.dfc == "DFC_Front") dfc = "b";
+      if (card.dfc == "SplitHalf") dfc = "a";
+      if (dfc != "b") {
+        for (let i = 0; i < c.quantity; i++) {
+          if (_n % 4 == 0) {
+            tileNow = $('<div class="deck_visual_tile"></div>');
+            tileNow.appendTo(div);
+          }
+
+          let d = $(
+            '<div style="width: ' +
+              sz +
+              'px !important;" class="deck_visual_card"></div>'
+          );
+          let img = $(
+            '<img style="width: ' +
+              sz +
+              'px !important;" class="deck_visual_card_img"></img>'
+          );
+
+          img.attr("src", get_card_image(card));
+          img.appendTo(d);
+          d.appendTo(tileNow);
+
+          addCardHover(img, card);
+          _n++;
+        }
+      }
+    }
+  });
+
+  div = $('<div class="visual_sideboard"></div>');
+  div.css("display", "flex");
+  div.css("flex-wrap", "wrap");
+  div.css("margin-left", "32px");
+  div.css("align-content", "start");
+  div.css("max-width", (sz + 6) * 1.5 + "px");
+  div.appendTo(_div);
+
+  if (deck.sideboard != undefined) {
+    tileNow = $('<div class="deck_visual_tile_side"></div>');
+    tileNow.css("width", (sz + 6) * 5 + "px");
+    tileNow.appendTo(div);
+
+    if (deck.sideboard.length == 0) {
+      tileNow.css("display", "none");
+    }
+
+    _n = 0;
+    deck.sideboard.forEach(function(c) {
+      var grpId = c.id;
+      var card = db.card(grpId);
+      if (c.quantity > 0) {
+        let dfc = "";
+        if (card.dfc == "DFC_Back") dfc = "a";
+        if (card.dfc == "DFC_Front") dfc = "b";
+        if (card.dfc == "SplitHalf") dfc = "a";
+        if (dfc != "b") {
+          for (let i = 0; i < c.quantity; i++) {
+            var d;
+            if (_n % 2 == 1) {
+              d = $(
+                '<div style="width: ' +
+                  sz +
+                  'px !important;" class="deck_visual_card_side"></div>'
+              );
+            } else {
+              d = $(
+                '<div style="margin-left: 60px; width: ' +
+                  sz +
+                  'px !important;" class="deck_visual_card_side"></div>'
+              );
+            }
+            let img = $(
+              '<img style="width: ' +
+                sz +
+                'px !important;" class="deck_visual_card_img"></img>'
+            );
+            img.attr("src", get_card_image(card));
+            img.appendTo(d);
+            d.appendTo(tileNow);
+
+            addCardHover(img, card);
+            _n++;
+          }
+        }
+      }
+    });
+  }
+}
+
+//
+exports.openDraft = open_draft;
+function open_draft(id) {
+  console.log("OPEN DRAFT", id, draftPosition);
+  $("#ux_1").html("");
+  $("#ux_1").removeClass("flex_item");
+  const draft = pd.draft(id);
+  let tileGrpid = db.sets[draft.set].tile;
+
+  if (draftPosition < 1) draftPosition = 1;
+  if (draftPosition > packSize * 6) draftPosition = packSize * 6;
+
+  var packSize = 14;
+  if (draft.set == "Guilds of Ravnica" || draft.set == "Ravnica Allegiance") {
+    packSize = 15;
+  }
+
+  var pa = Math.floor((draftPosition - 1) / 2 / packSize);
+  var pi = Math.floor(((draftPosition - 1) / 2) % packSize);
+  var key = "pack_" + pa + "pick_" + pi;
+
+  var pack = (draft[key] && draft[key].pack) || [];
+  var pick = (draft[key] && draft[key].pick) || "";
+
+  var top = $(
+    '<div class="decklist_top"><div class="button back"></div><div class="deck_name">' +
+      draft.set +
+      " Draft</div></div>"
+  );
+  let flr = $('<div class="deck_top_colors"></div>');
+  top.append(flr);
+
+  if (db.card(tileGrpid)) {
+    change_background("", tileGrpid);
+  }
+
+  var cont = $('<div class="flex_item" style="flex-direction: column;"></div>');
+  cont.append(
+    '<div class="draft_nav_container"><div class="draft_nav_prev"></div><div class="draft_nav_next"></div></div>'
+  );
+
+  $(
+    '<div class="draft_title">Pack ' +
+      (pa + 1) +
+      ", Pick " +
+      (pi + 1) +
+      "</div>"
+  ).appendTo(cont);
+
+  var slider = $('<div class="slidecontainer"></div>');
+  slider.appendTo(cont);
+  var sliderInput = $(
+    '<input type="range" min="1" max="' +
+      packSize * 6 +
+      '" value="' +
+      draftPosition +
+      '" class="slider" id="draftPosRange">'
+  );
+  sliderInput.appendTo(slider);
+
+  const pdiv = $('<div class="draft_pack_container"></div>');
+  pdiv.appendTo(cont);
+
+  pack.forEach(function(grpId) {
+    var d = $(
+      '<div style="width: ' +
+        pdiv.cardsSize +
+        'px !important;" class="draft_card"></div>'
+    );
+    var img = $(
+      '<img style="width: ' +
+        pdiv.cardsSize +
+        'px !important;" class="draft_card_img"></img>'
+    );
+    if (grpId == pick && draftPosition % 2 == 0) {
+      img.addClass("draft_card_picked");
+    }
+    var card = db.card(grpId);
+    img.attr("src", get_card_image(card));
+
+    img.appendTo(d);
+    var r = $(
+      '<div style="" class="draft_card_rating">' +
+        DRAFT_RANKS[card.rank] +
+        "</div>"
+    );
+    r.appendTo(d);
+    addCardHover(img, card);
+    d.appendTo(pdiv);
+  });
+
+  $("#ux_1").append(top);
+  $("#ux_1").append(cont);
+
+  var posRange = $("#draftPosRange")[0];
+
+  $(".draft_nav_prev").off();
+  $(".draft_nav_next").off();
+  $("#draftPosRange").off();
+
+  $("#draftPosRange").on("click mousemove", function() {
+    var pa = Math.floor((posRange.value - 1) / 2 / packSize);
+    var pi = Math.floor(((posRange.value - 1) / 2) % packSize);
+    $(".draft_title").html("Pack " + (pa + 1) + ", Pick " + (pi + 1));
+  });
+
+  $("#draftPosRange").on("click mouseup", function() {
+    draftPosition = parseInt(posRange.value);
+    open_draft(id, tileGrpid, draft.set);
+  });
+
+  $(".draft_nav_prev").on("click mouseup", function() {
+    draftPosition -= 1;
+    open_draft(id, tileGrpid, draft.set);
+  });
+
+  $(".draft_nav_next").on("click mouseup", function() {
+    draftPosition += 1;
+    open_draft(id, tileGrpid, draft.set);
+  });
+  //
+  $(".back").click(function() {
+    change_background("default");
+    $(".moving_ux").animate({ left: "0px" }, 250, "easeInOutCubic");
+  });
+}
+
+//
+exports.openMatch = open_match;
+function open_match(id) {
+  $("#ux_1").html("");
+  $("#ux_1").removeClass("flex_item");
+  const match = pd.match(id);
+
+  let top = $(
+    '<div class="decklist_top"><div class="button back"></div><div class="deck_name">' +
+      match.playerDeck.name +
+      "</div></div>"
+  );
+  let flr = $('<div class="deck_top_colors"></div>');
+
+  if (match.playerDeck.colors != undefined) {
+    match.playerDeck.colors.forEach(function(color) {
+      var m = $('<div class="mana_s20 mana_' + MANA[color] + '"></div>');
+      flr.append(m);
+    });
+  }
+  top.append(flr);
+
+  var flc = $(
+    '<div class="flex_item" style="justify-content: space-evenly;"></div>'
+  );
+  if (fs.existsSync(path.join(actionLogDir, id + ".txt"))) {
+    $('<div class="button_simple openLog">Action log</div>').appendTo(flc);
+  }
+
+  var tileGrpid = match.playerDeck.deckTileId;
+  if (db.card(tileGrpid)) {
+    change_background("", tileGrpid);
+  }
+  var fld = $('<div class="flex_item"></div>');
+
+  // this is a mess
+  var flt = $('<div class="flex_item"></div>');
+  var fltl = $('<div class="flex_item"></div>');
+  var r = $('<div class="rank"></div>');
+  r.appendTo(fltl);
+
+  var fltr = $('<div class="flex_item"></div>');
+  fltr.css("flex-direction", "column");
+  var fltrt = $('<div class="flex_top"></div>');
+  var fltrb = $('<div class="flex_bottom"></div>');
+  fltrt.appendTo(fltr);
+  fltrb.appendTo(fltr);
+
+  fltl.appendTo(flt);
+  fltr.appendTo(flt);
+
+  var rank = match.player.rank;
+  var tier = match.player.tier;
+  r.css(
+    "background-position",
+    get_rank_index(rank, tier) * -48 + "px 0px"
+  ).attr("title", rank + " " + tier);
+
+  var name = $(
+    '<div class="list_match_player_left">' +
+      match.player.name.slice(0, -6) +
+      " (" +
+      match.player.win +
+      ")</div>"
+  );
+  name.appendTo(fltrt);
+
+  if (match.player.win > match.opponent.win) {
+    var w = $('<div class="list_match_player_left green">Winner</div>');
+    w.appendTo(fltrb);
+  }
+
+  var dl = $('<div class="decklist"></div>');
+  flt.appendTo(dl);
+
+  drawDeck(dl, match.playerDeck);
+
+  $(
+    '<div class="button_simple centered exportDeckPlayer">Export to Arena</div>'
+  ).appendTo(dl);
+  $(
+    '<div class="button_simple centered exportDeckStandardPlayer">Export to .txt</div>'
+  ).appendTo(dl);
+
+  flt = $('<div class="flex_item" style="flex-direction: row-reverse;"></div>');
+  fltl = $('<div class="flex_item"></div>');
+  r = $('<div class="rank"></div>');
+  r.appendTo(fltl);
+
+  fltr = $('<div class="flex_item"></div>');
+  fltr.css("flex-direction", "column");
+  fltr.css("align-items", "flex-end");
+  fltrt = $('<div class="flex_top"></div>');
+  fltrb = $('<div class="flex_bottom"></div>');
+  fltrt.appendTo(fltr);
+  fltrb.appendTo(fltr);
+
+  fltl.appendTo(flt);
+  fltr.appendTo(flt);
+
+  rank = match.opponent.rank;
+  tier = match.opponent.tier;
+  r.css(
+    "background-position",
+    get_rank_index(rank, tier) * -48 + "px 0px"
+  ).attr("title", rank + " " + tier);
+
+  name = $(
+    '<div class="list_match_player_right">' +
+      match.opponent.name.slice(0, -6) +
+      " (" +
+      match.opponent.win +
+      ")</div>"
+  );
+  name.appendTo(fltrt);
+
+  if (match.player.win < match.opponent.win) {
+    w = $('<div class="list_match_player_right green">Winner</div>');
+    w.appendTo(fltrb);
+  }
+
+  var odl = $('<div class="decklist"></div>');
+  flt.appendTo(odl);
+
+  match.oppDeck.mainDeck.sort(compare_cards);
+  match.oppDeck.sideboard.sort(compare_cards);
+  /*
+  match.oppDeck.mainDeck.forEach(function(c) {
+    c.quantity = 9999;
+  });
+  match.oppDeck.sideboard.forEach(function(c) {
+    c.quantity = 9999;
+  });
+  */
+  drawDeck(odl, match.oppDeck);
+
+  $(
+    '<div class="button_simple centered exportDeck">Export to Arena</div>'
+  ).appendTo(odl);
+  $(
+    '<div class="button_simple centered exportDeckStandard">Export to .txt</div>'
+  ).appendTo(odl);
+
+  dl.appendTo(fld);
+  odl.appendTo(fld);
+
+  $("#ux_1").append(top);
+  $("#ux_1").append(flc);
+  $("#ux_1").append(fld);
+
+  if (match.gameStats) {
+    match.gameStats.forEach((game, gameIndex) => {
+      if (game && game.sideboardChanges) {
+        let separator1 = deckDrawer.cardSeparator(
+          `Game ${gameIndex + 1} Sideboard Changes`
+        );
+        $("#ux_1").append(separator1);
+        let sideboardDiv = $('<div class="card_lists_list"></div>');
+        let additionsDiv = $('<div class="cardlist"></div>');
+        if (
+          game.sideboardChanges.added.length == 0 &&
+          game.sideboardChanges.removed.length == 0
+        ) {
+          let separator2 = deckDrawer.cardSeparator("No changes");
+          additionsDiv.append(separator2);
+          additionsDiv.appendTo(sideboardDiv);
+        } else {
+          let separator3 = deckDrawer.cardSeparator("Sideboarded In");
+          additionsDiv.append(separator3);
+          drawCardList(additionsDiv, game.sideboardChanges.added);
+          additionsDiv.appendTo(sideboardDiv);
+          let removalsDiv = $('<div class="cardlist"></div>');
+          let separator4 = deckDrawer.cardSeparator("Sideboarded Out");
+          removalsDiv.append(separator4);
+          drawCardList(removalsDiv, game.sideboardChanges.removed);
+          removalsDiv.appendTo(sideboardDiv);
+        }
+
+        $("#ux_1").append(sideboardDiv);
+      }
+
+      let separator5 = deckDrawer.cardSeparator(
+        `Game ${gameIndex + 1} Hands Drawn`
+      );
+      $("#ux_1").append(separator5);
+
+      let handsDiv = $('<div class="card_lists_list"></div>');
+      if (game && game.handsDrawn.length > 3) {
+        // The default value of "center" apparently causes padding to be omitted in the calculation of how far
+        // the scrolling should go. So, if there are enough hands to actually need scrolling, override it.
+        handsDiv.css("justify-content", "start");
+      }
+
+      if (game) {
+        game.handsDrawn.forEach((hand, i) => {
+          let handDiv = $('<div class="cardlist"></div>');
+          drawCardList(handDiv, hand);
+          handDiv.appendTo(handsDiv);
+          if (game.bestOf == 1 && i == 0) {
+            let landDiv = $(
+              '<div style="margin: auto; text-align: center;" tooltip-top tooltip-content=' +
+                '"This hand was drawn with weighted odds that Wizards of the Coast has not disclosed because it is the first hand in a best-of-one match. ' +
+                'It should be more likely to have a close to average number of lands, but only they could calculate the exact odds.">Land Percentile: Unknown</div>'
+            );
+            landDiv.appendTo(handDiv);
+          } else {
+            let likelihood = hypergeometricSignificance(
+              game.handLands[i],
+              game.deckSize,
+              hand.length,
+              game.landsInDeck
+            );
+            let landDiv = $(
+              '<div style="margin: auto; text-align: center;" tooltip-top tooltip-content=' +
+                '"The probability of a random hand of the same size having a number of lands at least as far from average as this one, ' +
+                'calculated as if the distribution were continuous. Over a large number of games, this should average about 50%.">Land Likelihood: ' +
+                (likelihood * 100).toFixed(2) +
+                "%</div>"
+            );
+            landDiv.appendTo(handDiv);
+          }
+        });
+
+        $("#ux_1").append(handsDiv);
+
+        let separator6 = deckDrawer.cardSeparator(
+          `Game ${gameIndex + 1} Shuffled Order`
+        );
+        $("#ux_1").append(separator6);
+        let libraryDiv = $('<div class="library_list"></div>');
+        let unique = makeId(4);
+        let handSize = 8 - game.handsDrawn.length;
+
+        game.shuffledOrder.forEach((cardId, libraryIndex) => {
+          let rowShade =
+            libraryIndex === handSize - 1
+              ? "line_dark line_bottom_border"
+              : libraryIndex < handSize - 1
+              ? "line_dark"
+              : (libraryIndex - handSize) % 2 === 0
+              ? "line_light"
+              : "line_dark";
+          let cardDiv = $(`<div class="library_card ${rowShade}"></div>`);
+          let tile = deckDrawer.cardTile(
+            pd.settings.card_tile_style,
+            cardId,
+            unique + libraryIndex,
+            "#" + (libraryIndex + 1)
+          );
+          cardDiv.append(tile);
+          cardDiv.appendTo(libraryDiv);
+        });
+        let unknownCards = game.deckSize - game.shuffledOrder.length;
+        if (unknownCards > 0) {
+          let cardDiv = $('<div class="library_card"></div>');
+          let tile = deckDrawer.cardTile(
+            pd.settings.card_tile_style,
+            null,
+            unique + game.deckSize,
+            unknownCards + "x"
+          );
+          cardDiv.append(tile);
+          cardDiv.appendTo(libraryDiv);
+        }
+
+        let handExplanation = $(
+          '<div class="library_hand">The opening hand is excluded from the below statistics to prevent mulligan choices from influencing them.</div>'
+        );
+        handExplanation.css("grid-row-end", "span " + (handSize - 1));
+        handExplanation.appendTo(libraryDiv);
+
+        let headerDiv = $(
+          '<div class="library_header" tooltip-bottom tooltip-content="The number of lands in the library at or before this point.">Lands</div>'
+        );
+        headerDiv.css("grid-area", handSize + " / 2");
+        headerDiv.appendTo(libraryDiv);
+        headerDiv = $(
+          '<div class="library_header" tooltip-bottom tooltip-content="The average number of lands expected in the library at or before this point.">Expected</div>'
+        );
+        headerDiv.css("grid-area", handSize + " / 3");
+        headerDiv.appendTo(libraryDiv);
+        headerDiv = $(
+          '<div class="library_header" tooltip-bottom tooltip-content="The probability of the number of lands being at least this far from average, calculated as if the distribution were continuous. For details see footnote. Over a large number of games, this should average about 50%.">Likelihood</div>'
+        );
+        headerDiv.css("grid-area", handSize + " / 4");
+        headerDiv.appendTo(libraryDiv);
+        headerDiv = $(
+          '<div class="library_header" tooltip-bottomright tooltip-content="The expected percentage of games where the actual number of lands is equal or less than this one. This is easier to calculate and more widely recognized but harder to assess the meaning of.">Percentile</div>'
+        );
+        headerDiv.css("grid-area", handSize + " / 5");
+        headerDiv.appendTo(libraryDiv);
+
+        game.libraryLands.forEach((count, index) => {
+          let rowShade = index % 2 === 0 ? "line_light" : "line_dark";
+          let landsDiv = $(
+            `<div class="library_stat ${rowShade}">${count}</div>`
+          );
+          landsDiv.css("grid-area", handSize + index + 1 + " / 2");
+          landsDiv.appendTo(libraryDiv);
+          let expected = (
+            ((index + 1) * game.landsInLibrary) /
+            game.librarySize
+          ).toFixed(2);
+          let expectedDiv = $(
+            `<div class="library_stat ${rowShade}">${expected}</div>`
+          );
+          expectedDiv.css("grid-area", handSize + index + 1 + " / 3");
+          expectedDiv.appendTo(libraryDiv);
+          let likelihood = hypergeometricSignificance(
+            count,
+            game.librarySize,
+            index + 1,
+            game.landsInLibrary
+          );
+          let likelihoodDiv = $(
+            `<div class="library_stat ${rowShade}">${(likelihood * 100).toFixed(
+              2
+            )}</div>`
+          );
+          likelihoodDiv.css("grid-area", handSize + index + 1 + " / 4");
+          likelihoodDiv.appendTo(libraryDiv);
+          let percentile = hypergeometricRange(
+            0,
+            count,
+            game.librarySize,
+            index + 1,
+            game.landsInLibrary
+          );
+          let percentileDiv = $(
+            `<div class="library_stat ${rowShade}">${(percentile * 100).toFixed(
+              2
+            )}</div>`
+          );
+          percentileDiv.css("grid-area", handSize + index + 1 + " / 5");
+          percentileDiv.appendTo(libraryDiv);
+        });
+
+        let footnoteLabel = $(
+          '<div id="library_footnote_label' +
+            gameIndex +
+            '" class="library_footnote" tooltip-bottom ' +
+            'tooltip-content="Click to show footnote" onclick="toggleVisibility(\'library_footnote_label' +
+            gameIndex +
+            "', 'library_footnote" +
+            gameIndex +
+            "')\">Footnote on Likelihood</div>"
+        );
+        footnoteLabel.css("grid-row", game.shuffledOrder.length + 1);
+        footnoteLabel.appendTo(libraryDiv);
+        let footnote = $(
+          '<div id="library_footnote' +
+            gameIndex +
+            '" class="library_footnote hidden" ' +
+            "onclick=\"toggleVisibility('library_footnote_label" +
+            gameIndex +
+            "', 'library_footnote" +
+            gameIndex +
+            "')\">" +
+            "<p>The Likelihood column calculations are designed to enable assessment of fairness at a glance, in a way " +
+            "that is related to percentile but differs in important ways. In short, it treats the count of lands as if " +
+            "it were actually a bucket covering a continuous range, and calculates the cumulative probability of the " +
+            "continuous value being at least as far from the median as a randomly selected value within the range covered " +
+            "by the actual count. Importantly, this guarantees that the theoretical average will always be exactly 50%.</p>" +
+            "<p>For values that are not the median, the result is halfway between the value's own percentile and the " +
+            "next one up or down. For the median itself, the covered range is split and weighted for how much of it is " +
+            "on each side of the 50th percentile. In both cases, the result's meaning is the same for each direction " +
+            "from the 50th percentile, and scaled up by a factor of 2 to keep the possible range at 0% to 100%. " +
+            "For precise details, see the source code on github.</p></div>"
+        );
+        footnote.css("grid-row", game.shuffledOrder.length + 1);
+        footnote.appendTo(libraryDiv);
+
+        $("#ux_1").append(libraryDiv);
+      }
+    });
+  }
+
+  $(".openLog").click(function() {
+    openActionLog(id, $("#ux_1"));
+  });
+
+  $(".exportDeckPlayer").click(function() {
+    var list = get_deck_export(match.playerDeck);
+    ipc_send("set_clipboard", list);
+  });
+  $(".exportDeckStandardPlayer").click(function() {
+    var list = get_deck_export_txt(match.playerDeck);
+    ipc_send("export_txt", { str: list, name: match.playerDeck.name });
+  });
+
+  $(".exportDeck").click(function() {
+    var list = get_deck_export(match.oppDeck);
+    ipc_send("set_clipboard", list);
+  });
+  $(".exportDeckStandard").click(function() {
+    var list = get_deck_export_txt(match.oppDeck);
+    ipc_send("export_txt", {
+      str: list,
+      name: match.opponent.name.slice(0, -6) + "'s deck"
+    });
+  });
+
+  $(".back").click(function() {
+    change_background("default");
+    $(".moving_ux").animate({ left: "0px" }, 250, "easeInOutCubic");
+  });
+}
+
+//
+exports.openActionLog = openActionLog;
+function openActionLog(actionLogId) {
+  $("#ux_2").html("");
+  let top = $(
+    `<div class="decklist_top"><div class="button back actionlog_back"></div><div class="deck_name">Action Log</div><div class="deck_name"></div></div>`
+  );
+
+  let actionLogContainer = $(`<div class="action_log_container"></div>`);
+
+  let actionLogFile = path.join(actionLogDir, actionLogId + ".txt");
+  let str = fs.readFileSync(actionLogFile).toString();
+
+  let actionLog = str.split("\n");
+  for (let line = 1; line < actionLog.length - 1; line += 3) {
+    let seat = actionLog[line];
+    let time = actionLog[line + 1];
+    let str = actionLog[line + 2];
+    str = striptags(str, ["log-card", "log-ability"]);
+
+    var boxDiv = $('<div class="actionlog log_p' + seat + '"></div>');
+    var timeDiv = $('<div class="actionlog_time">' + time + "</div>");
+    var strDiv = $('<div class="actionlog_text">' + str + "</div>");
+
+    boxDiv.append(timeDiv);
+    boxDiv.append(strDiv);
+    actionLogContainer.append(boxDiv);
+  }
+
+  $("#ux_2").append(top);
+  $("#ux_2").append(actionLogContainer);
+
+  $$("log-card").forEach(obj => {
+    let grpId = obj.getAttribute("id");
+    addCardHover(obj, db.card(grpId));
+  });
+
+  $$("log-ability").forEach(obj => {
+    let grpId = obj.getAttribute("id");
+    let abilityText = db.abilities[grpId] || "";
+    obj.title = abilityText;
+  });
+
+  $(".moving_ux").animate({ left: "-200%" }, 250, "easeInOutCubic");
+
+  $(".actionlog_back").click(() => {
+    $(".moving_ux").animate({ left: "-100%" }, 250, "easeInOutCubic");
+  });
+}
+
+//
+exports.toggleVisibility = toggleVisibility;
+function toggleVisibility(...ids) {
+  ids.forEach(id => {
+    let el = document.getElementById(id);
+    if (el.classList.contains("hidden")) {
+      el.classList.remove("hidden");
+    } else {
+      el.classList.add("hidden");
+    }
+  });
+}
+
+//
+exports.addCheckbox = add_checkbox;
+function add_checkbox(div, label, iid, def, func) {
+  label = $('<label class="check_container hover_label">' + label + "</label>");
+  label.appendTo(div);
+  var check_new = $('<input type="checkbox" id="' + iid + '" />');
+  check_new.on("click", func);
+  check_new.appendTo(label);
+  check_new.prop("checked", def);
+
+  var span = $('<span class="checkmark"></span>');
+  span.appendTo(label);
+  return label;
+}
+
+//
+exports.changeBackground = change_background;
+function change_background(arg = "default", grpId = 0) {
+  let artistLine = "";
+  const _card = db.card(grpId);
+
+  //console.log(arg, grpId, _card);
+  if (arg === "default") {
+    $(".top_artist").html("Ghitu Lavarunner by Jesper Ejsing");
+    if (pd.settings.back_url === "") {
+      $(".main_wrapper").css(
+        "background-image",
+        "url(../images/Ghitu-Lavarunner-Dominaria-MtG-Art.jpg)"
+      );
+    } else {
+      $(".top_artist").html("");
+      $(".main_wrapper").css(
+        "background-image",
+        "url(" + pd.settings.back_url + ")"
+      );
+    }
+  } else if (_card) {
+    // console.log(_card.images["art_crop"]);
+    $(".main_wrapper").css(
+      "background-image",
+      "url(https://img.scryfall.com/cards" + _card.images["art_crop"] + ")"
+    );
+    try {
+      artistLine = _card.name + " by " + _card.artist;
+      $(".top_artist").html(artistLine);
+    } catch (e) {
+      console.log(e);
+    }
+  } else if (fs.existsSync(arg)) {
+    $(".top_artist").html("");
+    $(".main_wrapper").css("background-image", "url(" + arg + ")");
+  } else {
+    $(".top_artist").html("");
+    $.ajax({
+      url: arg,
+      type: "HEAD",
+      error: function() {
+        $(".main_wrapper").css("background-image", "");
+      },
+      success: function() {
+        $(".main_wrapper").css("background-image", "url(" + arg + ")");
+      }
+    });
+  }
+}
+
+//
+exports.formatPercent = formatPercent;
+function formatPercent(value, config = {}) {
+  return value.toLocaleString([], {
+    style: "percent",
+    maximumSignificantDigits: 2,
+    ...config
+  });
+}
+
+//
+exports.formatNumber = formatNumber;
+function formatNumber(value, config = {}) {
+  return value.toLocaleString([], {
+    style: "decimal",
+    ...config
+  });
+}
+
+//
+exports.getWinrateClass = getWinrateClass;
+function getWinrateClass(wr) {
+  if (wr > 0.65) return "blue";
+  if (wr > 0.55) return "green";
+  if (wr < 0.45) return "orange";
+  if (wr < 0.35) return "red";
+  return "white";
+}
+
+//
+exports.getEventWinLossClass = getEventWinLossClass;
+function getEventWinLossClass(wlGate) {
+  if (wlGate === undefined) return "white";
+  if (wlGate.MaxWins === wlGate.CurrentWins) return "blue";
+  if (wlGate.CurrentWins > wlGate.CurrentLosses) return "green";
+  if (wlGate.CurrentWins * 2 > wlGate.CurrentLosses) return "orange";
+  return "red";
+}
+
+//
+exports.compareWinrates = compare_winrates;
+function compare_winrates(a, b) {
+  let _a = a.wins / a.losses;
+  let _b = b.wins / b.losses;
+
+  if (_a < _b) return 1;
+  if (_a > _b) return -1;
+
+  return compare_color_winrates(a, b);
+}
+
+//
+exports.compareColorWinrates = compare_color_winrates;
+function compare_color_winrates(a, b) {
+  a = a.colors;
+  b = b.colors;
+
+  if (a.length < b.length) return -1;
+  if (a.length > b.length) return 1;
+
+  let sa = a.reduce(function(_a, _b) {
+    return _a + _b;
+  }, 0);
+  let sb = b.reduce(function(_a, _b) {
+    return _a + _b;
+  }, 0);
+  if (sa < sb) return -1;
+  if (sa > sb) return 1;
+
+  return 0;
+}

--- a/window_main/renderer-util.js
+++ b/window_main/renderer-util.js
@@ -46,8 +46,8 @@ const actionLogDir = path.join(
 );
 
 //
-exports.ipcSend = ipc_send;
-function ipc_send(method, arg, to = IPC_BACKGROUND) {
+exports.ipcSend = ipcSend;
+function ipcSend(method, arg, to = IPC_BACKGROUND) {
   ipc.send("ipc_switch", method, IPC_MAIN, arg, to);
 }
 
@@ -98,7 +98,7 @@ function getLocalState() {
 // convenience handler for player data singleton
 exports.toggleArchived = toggleArchived;
 function toggleArchived(id) {
-  ipc_send("toggle_archived", id);
+  ipcSend("toggle_archived", id);
 }
 
 //
@@ -125,7 +125,7 @@ function makeResizable(div, resizeCallback, finalCallback) {
   };
 
   let saveWidth = function(width) {
-    ipc_send("save_user_settings", { right_panel_width: width });
+    ipcSend("save_user_settings", { right_panel_width: width });
   };
 
   div.addEventListener(
@@ -139,7 +139,7 @@ function makeResizable(div, resizeCallback, finalCallback) {
 
   document.addEventListener(
     "mouseup",
-    event => {
+    () => {
       document.removeEventListener("mousemove", resize, false);
       if (finalWidth) {
         saveWidth(finalWidth);
@@ -467,8 +467,8 @@ function drawDeckVisual(_div, deck, _stats, openCallback) {
 }
 
 //
-exports.openDraft = open_draft;
-function open_draft(id) {
+exports.openDraft = openDraft;
+function openDraft(id) {
   console.log("OPEN DRAFT", id, draftPosition);
   $("#ux_1").html("");
   $("#ux_1").removeClass("flex_item");
@@ -499,7 +499,7 @@ function open_draft(id) {
   top.append(flr);
 
   if (db.card(tileGrpid)) {
-    change_background("", tileGrpid);
+    changeBackground("", tileGrpid);
   }
 
   var cont = $('<div class="flex_item" style="flex-direction: column;"></div>');
@@ -574,28 +574,28 @@ function open_draft(id) {
 
   $("#draftPosRange").on("click mouseup", function() {
     draftPosition = parseInt(posRange.value);
-    open_draft(id, tileGrpid, draft.set);
+    openDraft(id, tileGrpid, draft.set);
   });
 
   $(".draft_nav_prev").on("click mouseup", function() {
     draftPosition -= 1;
-    open_draft(id, tileGrpid, draft.set);
+    openDraft(id, tileGrpid, draft.set);
   });
 
   $(".draft_nav_next").on("click mouseup", function() {
     draftPosition += 1;
-    open_draft(id, tileGrpid, draft.set);
+    openDraft(id, tileGrpid, draft.set);
   });
   //
   $(".back").click(function() {
-    change_background("default");
+    changeBackground("default");
     $(".moving_ux").animate({ left: "0px" }, 250, "easeInOutCubic");
   });
 }
 
 //
-exports.openMatch = open_match;
-function open_match(id) {
+exports.openMatch = openMatch;
+function openMatch(id) {
   $("#ux_1").html("");
   $("#ux_1").removeClass("flex_item");
   const match = pd.match(id);
@@ -624,7 +624,7 @@ function open_match(id) {
 
   var tileGrpid = match.playerDeck.deckTileId;
   if (db.card(tileGrpid)) {
-    change_background("", tileGrpid);
+    changeBackground("", tileGrpid);
   }
   var fld = $('<div class="flex_item"></div>');
 
@@ -976,27 +976,27 @@ function open_match(id) {
 
   $(".exportDeckPlayer").click(function() {
     var list = get_deck_export(match.playerDeck);
-    ipc_send("set_clipboard", list);
+    ipcSend("set_clipboard", list);
   });
   $(".exportDeckStandardPlayer").click(function() {
     var list = get_deck_export_txt(match.playerDeck);
-    ipc_send("export_txt", { str: list, name: match.playerDeck.name });
+    ipcSend("export_txt", { str: list, name: match.playerDeck.name });
   });
 
   $(".exportDeck").click(function() {
     var list = get_deck_export(match.oppDeck);
-    ipc_send("set_clipboard", list);
+    ipcSend("set_clipboard", list);
   });
   $(".exportDeckStandard").click(function() {
     var list = get_deck_export_txt(match.oppDeck);
-    ipc_send("export_txt", {
+    ipcSend("export_txt", {
       str: list,
       name: match.opponent.name.slice(0, -6) + "'s deck"
     });
   });
 
   $(".back").click(function() {
-    change_background("default");
+    changeBackground("default");
     $(".moving_ux").animate({ left: "0px" }, 250, "easeInOutCubic");
   });
 }
@@ -1065,8 +1065,8 @@ function toggleVisibility(...ids) {
 }
 
 //
-exports.addCheckbox = add_checkbox;
-function add_checkbox(div, label, iid, def, func) {
+exports.addCheckbox = addCheckbox;
+function addCheckbox(div, label, iid, def, func) {
   label = $('<label class="check_container hover_label">' + label + "</label>");
   label.appendTo(div);
   var check_new = $('<input type="checkbox" id="' + iid + '" />');
@@ -1080,8 +1080,8 @@ function add_checkbox(div, label, iid, def, func) {
 }
 
 //
-exports.changeBackground = change_background;
-function change_background(arg = "default", grpId = 0) {
+exports.changeBackground = changeBackground;
+function changeBackground(arg = "default", grpId = 0) {
   let artistLine = "";
   const _card = db.card(grpId);
 
@@ -1170,20 +1170,20 @@ function getEventWinLossClass(wlGate) {
 }
 
 //
-exports.compareWinrates = compare_winrates;
-function compare_winrates(a, b) {
+exports.compareWinrates = compareWinrates;
+function compareWinrates(a, b) {
   let _a = a.wins / a.losses;
   let _b = b.wins / b.losses;
 
   if (_a < _b) return 1;
   if (_a > _b) return -1;
 
-  return compare_color_winrates(a, b);
+  return compareColorWinrates(a, b);
 }
 
 //
-exports.compareColorWinrates = compare_color_winrates;
-function compare_color_winrates(a, b) {
+exports.compareColorWinrates = compareColorWinrates;
+function compareColorWinrates(a, b) {
   a = a.colors;
   b = b.colors;
 

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -31,10 +31,10 @@ const {
 } = require("../shared/util");
 
 const {
-  changeBackground: change_background,
+  changeBackground,
   getLocalState,
   hideLoadingBars,
-  ipcSend: ipc_send,
+  ipcSend,
   pop,
   setLocalState,
   showLoadingBars
@@ -76,7 +76,7 @@ ipc.on("auth", function(event, arg) {
     loggedIn = true;
   } else {
     canLogin = true;
-    ipc_send("renderer_show");
+    ipcSend("renderer_show");
     pop(arg.error, -1);
   }
 });
@@ -260,7 +260,7 @@ ipc.on("open_course_deck", function(event, arg) {
 //
 ipc.on("settings_updated", function() {
   if (lastSettings.back_url !== pd.settings.back_url) {
-    change_background();
+    changeBackground();
   }
   $(".main_wrapper").css("background-color", pd.settings.back_color);
   if (sidebarActive === 6) {
@@ -322,7 +322,7 @@ function rememberMe() {
   const rSettings = {
     remember_me: document.getElementById("rememberme").checked
   };
-  ipc_send("save_app_settings", rSettings);
+  ipcSend("save_app_settings", rSettings);
 }
 
 //
@@ -378,7 +378,7 @@ function openTab(tab, filters = {}, dataIndex = 0, scrollTop = 0) {
       break;
   }
   $("." + tabClass).addClass("item_selected");
-  ipc_send("save_user_settings", { last_open_tab: tab });
+  ipcSend("save_user_settings", { last_open_tab: tab });
 }
 
 //
@@ -463,7 +463,7 @@ ipc.on("no_log", function(event, arg) {
     but.appendTo(dialog);
 
     but.click(function() {
-      ipc_send("set_log", document.getElementById("log_input").value);
+      ipcSend("set_log", document.getElementById("log_input").value);
       console.log(".dialog_wrapper on click");
       //e.stopPropagation();
       $(".dialog_wrapper").css("opacity", 0);
@@ -586,7 +586,7 @@ $(document).ready(function() {
   });
 
   $(".offline_link").click(function() {
-    ipc_send("login", { username: "", password: "" });
+    ipcSend("login", { username: "", password: "" });
     $(".unlink").show();
   });
 
@@ -601,7 +601,7 @@ $(document).ready(function() {
       if (pass != HIDDEN_PW) {
         pass = sha1(pass);
       }
-      ipc_send("login", { username: user, password: pass });
+      ipcSend("login", { username: user, password: pass });
       canLogin = false;
     }
   }
@@ -615,12 +615,12 @@ $(document).ready(function() {
 
   //
   $(".close").click(function() {
-    ipc_send("renderer_window_close", 1);
+    ipcSend("renderer_window_close", 1);
   });
 
   //
   $(".minimize").click(function() {
-    ipc_send("renderer_window_minimize", 1);
+    ipcSend("renderer_window_minimize", 1);
   });
 
   //
@@ -633,7 +633,7 @@ $(document).ready(function() {
     $("#ux_0").off();
     $("#ux_0")[0].removeEventListener("scroll", () => {}, false);
     $("#history_column").off();
-    change_background("default");
+    changeBackground("default");
     document.body.style.cursor = "auto";
     if (!$(this).hasClass("item_selected")) {
       $(".moving_ux").animate({ left: "0px" }, 250, "easeInOutCubic");

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -1,10 +1,5 @@
-/*
-global
-  set_tou_state
-*/
-
-const { app, ipcRenderer: ipc, remote, shell } = require("electron");
-
+const { ipcRenderer: ipc, remote, shell } = require("electron");
+const sha1 = require("js-sha1");
 if (!remote.app.isPackaged) {
   const { openNewGitHubIssue, debugInfo } = require("electron-util");
   const unhandled = require("electron-unhandled");
@@ -20,117 +15,52 @@ if (!remote.app.isPackaged) {
   });
   require("devtron").install();
 }
-
-const _ = require("lodash");
 window.$ = window.jQuery = require("jquery");
 require("jquery.easing");
 require("spectrum-colorpicker");
 require("time-elements");
-const striptags = require("striptags");
 
-const pd = require("../shared/player-data.js");
-const Aggregator = require("./aggregator.js");
-const ListItem = require("./list-item.js");
-const FilterPanel = require("./filter-panel.js");
-const StatsPanel = require("./stats-panel.js");
-const DataScroller = require("./data-scroller.js");
-const openHomeTab = require("./home").openHomeTab;
-const tournamentOpen = require("./tournaments").tournamentOpen;
-const tournamentCreate = require("./tournaments").tournamentCreate;
-const tournamentSetState = require("./tournaments").tournamentSetState;
-const openDeck = require("./deck-details").openDeck;
-const openDecksTab = require("./decks").openDecksTab;
-const { openHistoryTab } = require("./history");
-const openExploreTab = require("./explore").openExploreTab;
-const setExploreDecks = require("./explore").setExploreDecks;
-const openCollectionTab = require("./collection").openCollectionTab;
-const openEventsTab = require("./events").openEventsTab;
-const expandEvent = require("./events").expandEvent;
-const openSettingsTab = require("./settings").openSettingsTab;
-const deckDrawer = require("../shared/deck-drawer");
-const cardTypes = require("../shared/card-types");
-const openEconomyTab = require("./economy").openEconomyTab;
-const db = require("../shared/database");
+const { HIDDEN_PW } = require("../shared/constants");
+const pd = require("../shared/player-data");
 const { queryElements: $$ } = require("../shared/dom-fns");
-const { addCardHover } = require("../shared/card-hover");
 const {
-  compare_archetypes,
   compare_cards,
-  get_card_image,
   get_deck_colors,
-  get_deck_export,
-  get_deck_export_txt,
-  get_deck_types_ammount,
   get_rank_index,
-  makeId,
-  removeDuplicates,
-  timeSince
+  removeDuplicates
 } = require("../shared/util");
+
 const {
-  DRAFT_RANKS,
-  HIDDEN_PW,
-  MANA,
-  IPC_MAIN,
-  IPC_BACKGROUND,
-  CARD_TILE_FLAT
-} = require("../shared/constants.js");
+  changeBackground: change_background,
+  getLocalState,
+  hideLoadingBars,
+  ipcSend: ipc_send,
+  pop,
+  setLocalState,
+  showLoadingBars
+} = require("./renderer-util");
 const {
-  hypergeometricSignificance,
-  hypergeometricRange
-} = require("../shared/stats-fns");
-
-const Menu = remote.Menu;
-const MenuItem = remote.MenuItem;
-
-const { RANKED_CONST, RANKED_DRAFT, DATE_SEASON } = Aggregator;
-
-let deck = null;
-let changes = null;
-let allMatches = null;
-
-let explore = null;
-let ladder = null;
+  createAllMatches,
+  getDefaultFilters,
+  RANKED_CONST,
+  RANKED_DRAFT,
+  DATE_SEASON
+} = require("./aggregator");
+const { openHomeTab, requestHome } = require("./home");
+const { tournamentOpen } = require("./tournaments");
+const { openDecksTab } = require("./decks");
+const { openDeck } = require("./deck-details");
+const { openHistoryTab } = require("./history");
+const { openEventsTab } = require("./events");
+const { openEconomyTab } = require("./economy");
+const { openExploreTab, setExploreDecks } = require("./explore");
+const { openCollectionTab } = require("./collection");
+const { openSettingsTab } = require("./settings");
 
 let sidebarActive = -2;
-let lastDataIndex = 0;
-let lastScrollTop = 0;
-
-let draftPosition = 1;
-let loadEvents = 0;
 let loggedIn = false;
 let canLogin = false;
-let offlineMode = false;
 let lastSettings = {};
-
-let rewards_daily_ends = new Date();
-let rewards_weekly_ends = new Date();
-let activeEvents = [];
-
-let filteredWildcardsSet = "";
-
-let authToken = null;
-let discordTag = null;
-
-const sha1 = require("js-sha1");
-const fs = require("fs");
-const path = require("path");
-
-const actionLogDir = path.join(
-  (app || remote.app).getPath("userData"),
-  "actionlogs"
-);
-
-function ipc_send(method, arg, to = IPC_BACKGROUND) {
-  // 0: Main window
-  // 1: background
-  // 2: overlay
-  ipc.send("ipc_switch", method, IPC_MAIN, arg, to);
-}
-
-// convenience handler for player data singleton
-function toggleArchived(id) {
-  ipc_send("toggle_archived", id);
-}
 
 //
 ipc.on("clear_pwd", function() {
@@ -139,7 +69,7 @@ ipc.on("clear_pwd", function() {
 
 //
 ipc.on("auth", function(event, arg) {
-  authToken = arg.token;
+  setLocalState({ authToken: arg.token });
   if (arg.ok) {
     $(".message_center").css("display", "flex");
     $(".authenticate").hide();
@@ -151,15 +81,12 @@ ipc.on("auth", function(event, arg) {
   }
 });
 
+//
 ipc.on("set_discord_tag", (event, arg) => {
-  discordTag = arg;
+  setLocalState({ discordTag: arg });
   if (sidebarActive == -1) {
     openHomeTab(null, true);
   }
-});
-
-ipc.on("set_tou_state", (event, arg) => {
-  set_tou_state(arg);
 });
 
 //
@@ -181,15 +108,12 @@ ipc.on("too_slow", function() {
 });
 
 //
-function getTagColor(tag) {
-  return pd.tags_colors[tag] || "#FAE5D2";
-}
-
 ipc.on("show_login", () => {
   canLogin = true;
   showLogin();
 });
 
+//
 function showLogin() {
   $(".authenticate").show();
   $(".message_center").css("display", "none");
@@ -235,35 +159,6 @@ ipc.on("player_data_updated", () => {
       patreonIcon.style.display = "block";
     } else {
       patreonIcon.style.display = "none";
-    }
-  }
-});
-
-//
-ipc.on("set_reward_resets", function(event, arg) {
-  rewards_daily_ends = new Date(arg.daily);
-  rewards_weekly_ends = new Date(arg.weekly);
-});
-
-//
-// Whats this?
-ipc.on("set_deck_updated", function(event, str) {
-  try {
-    deck = JSON.parse(str);
-  } catch (e) {
-    console.log("Error parsing JSON:", str);
-    return false;
-  }
-});
-
-//
-ipc.on("set_active_events", (event, arg) => {
-  if (arg != null) {
-    try {
-      activeEvents = JSON.parse(arg);
-    } catch (e) {
-      console.log("Error parsing JSON:", arg);
-      return false;
     }
   }
 });
@@ -347,37 +242,6 @@ ipc.on("set_explore_decks", function(event, arg) {
   }
 });
 
-/*//
-ipc.on("set_explore", function(event, arg) {
-  if (sidebarActive == 3) {
-    open_explore_tab(arg, 0);
-  }
-});
-
-//
-ipc.on("set_ladder_decks", function(event, arg) {
-  set_ladder_decks(arg);
-});
-
-//
-ipc.on("set_ladder_traditional_decks", function(event, arg) {
-  set_ladder_decks(arg);
-});
-
-function set_ladder_decks(arg) {
-  if (sidebarActive == 3) {
-
-    arg.decks.forEach(function(deck) {
-      deck.colors = [];
-      deck.colors = get_deck_colors(deck);
-      deck.mainDeck.sort(compare_cards);
-    });
-
-    open_explore_tab(arg.decks, 0);
-  }
-}
-*/
-
 //
 ipc.on("open_course_deck", function(event, arg) {
   $(".moving_ux").animate({ left: "-100%" }, 250, "easeInOutCubic");
@@ -407,7 +271,8 @@ ipc.on("settings_updated", function() {
 
 //
 ipc.on("player_data_refresh", () => {
-  openTab(sidebarActive, {}, lastDataIndex, lastScrollTop);
+  const ls = getLocalState();
+  openTab(sidebarActive, {}, ls.lastDataIndex, ls.lastScrollTop);
 });
 
 //
@@ -479,7 +344,7 @@ function openTab(tab, filters = {}, dataIndex = 0, scrollTop = 0) {
       openEventsTab(filters, dataIndex, scrollTop);
       break;
     case 3:
-      if (offlineMode) {
+      if (pd.offline) {
         showOfflineSplash();
       } else {
         openExploreTab();
@@ -496,13 +361,13 @@ function openTab(tab, filters = {}, dataIndex = 0, scrollTop = 0) {
       break;
     case -1:
       tabClass = "ith";
-      if (offlineMode) {
+      if (pd.offline) {
         showOfflineSplash();
       } else {
-        if (discordTag == null) {
+        if (getLocalState().discordTag === null) {
           openHomeTab(null, true);
         } else {
-          ipc_send("request_home", filteredWildcardsSet);
+          requestHome();
         }
       }
       break;
@@ -525,7 +390,8 @@ ipc.on("initialize", function() {
   }
 
   sidebarActive = pd.settings.last_open_tab;
-  allMatches = Aggregator.createAllMatches();
+  const totalAgg = createAllMatches();
+  setLocalState({ totalAgg });
   openTab(sidebarActive);
 
   $(".top_nav").removeClass("hidden");
@@ -613,6 +479,7 @@ ipc.on("no_log", function(event, arg) {
   }
 });
 
+//
 ipc.on("log_ok", function() {
   logDialogOpen = false;
   $(".dialog_wrapper").css("opacity", 0);
@@ -626,15 +493,11 @@ ipc.on("log_ok", function() {
 });
 
 //
-ipc.on("set_offline", (_event, arg) => {
-  offlineMode = arg;
-});
-
-//
 ipc.on("offline", function() {
   showOfflineSplash();
 });
 
+//
 function showOfflineSplash() {
   hideLoadingBars();
   $("#ux_0").html(
@@ -654,6 +517,7 @@ ipc.on("log_read", function() {
   }
 });
 
+//
 $(".list_deck").on("mouseenter mouseleave", function(e) {
   $(".deck_tile").trigger(e.type);
 });
@@ -663,23 +527,7 @@ ipc.on("popup", function(event, arg, time) {
   pop(arg, time);
 });
 
-var popTimeout = null;
-function pop(str, timeout) {
-  $(".popup").css("opacity", 1);
-  $(".popup").html(str);
-  if (popTimeout != null) {
-    clearTimeout(popTimeout);
-  }
-  if (timeout < 1) {
-    popTimeout = null;
-  } else {
-    popTimeout = setTimeout(function() {
-      $(".popup").css("opacity", 0);
-      popTimeout = null;
-    }, timeout);
-  }
-}
-
+//
 function force_open_settings() {
   sidebarActive = 6;
   $(".top_nav_item").each(function() {
@@ -692,6 +540,7 @@ function force_open_settings() {
   openSettingsTab();
 }
 
+//
 function force_open_about() {
   sidebarActive = 9;
   $(".top_nav_item").each(function() {
@@ -704,6 +553,7 @@ function force_open_about() {
   openSettingsTab(5);
 }
 
+//
 let top_compact = false;
 let resizeTimer;
 window.addEventListener("resize", event => {
@@ -807,7 +657,7 @@ $(document).ready(function() {
       } else if ($(this).hasClass("it7")) {
         sidebarActive = 1;
         filters = {
-          ...Aggregator.getDefaultFilters(),
+          ...getDefaultFilters(),
           date: DATE_SEASON,
           eventId: RANKED_CONST,
           rankedMode: true
@@ -815,7 +665,7 @@ $(document).ready(function() {
       } else if ($(this).hasClass("it8")) {
         sidebarActive = 1;
         filters = {
-          ...Aggregator.getDefaultFilters(),
+          ...getDefaultFilters(),
           date: DATE_SEASON,
           eventId: RANKED_DRAFT,
           rankedMode: true
@@ -828,18 +678,8 @@ $(document).ready(function() {
   });
 });
 
-function showLoadingBars() {
-  $$(".main_loading")[0].style.display = "block";
-  document.body.style.cursor = "progress";
-}
-
 //
 //ipc.on("show_loading", () => showLoadingBars());
-
-function hideLoadingBars() {
-  $$(".main_loading")[0].style.display = "none";
-  document.body.style.cursor = "auto";
-}
 
 //
 //ipc.on("hide_loading", () => hideLoadingBars());
@@ -851,1330 +691,8 @@ ipc.on("set_draft_link", function(event, arg) {
 });
 
 //
-function addHover(_match, tileGrpid) {
-  $("." + _match.id).on("mouseenter", function() {
-    $("." + _match.id + "t").css("opacity", 1);
-    $("." + _match.id + "t").css("width", "200px");
-  });
-
-  $("." + _match.id).on("mouseleave", function() {
-    $("." + _match.id + "t").css("opacity", 0.66);
-    $("." + _match.id + "t").css("width", "128px");
-  });
-
-  $("." + _match.id).on("click", function() {
-    if (_match.type == "match") {
-      open_match(_match.id);
-      $(".moving_ux").animate({ left: "-100%" }, 250, "easeInOutCubic");
-    } else if (_match.type == "draft") {
-      draftPosition = 1;
-      open_draft(_match.id, tileGrpid, _match.set);
-      $(".moving_ux").animate({ left: "-100%" }, 250, "easeInOutCubic");
-    } else if (_match.type == "Event") {
-      expandEvent(_match, tileGrpid);
-    }
-  });
-}
-
-//
 ipc.on("tou_set", function(event, arg) {
   document.body.style.cursor = "auto";
   tournamentOpen(arg);
   $(".moving_ux").animate({ left: "-100%" }, 250, "easeInOutCubic");
 });
-
-//
-function makeResizable(div, resizeCallback, finalCallback) {
-  var m_pos;
-  let finalWidth;
-
-  let resize = function(e) {
-    var parent = div.parentNode;
-    var dx = m_pos - e.x;
-    m_pos = e.x;
-    let newWidth = Math.max(10, parseInt(parent.style.width) + dx);
-    parent.style.width = `${newWidth}px`;
-    parent.style.flex = `0 0 ${newWidth}px`;
-    if (resizeCallback instanceof Function) resizeCallback(newWidth);
-    finalWidth = newWidth;
-  };
-
-  let saveWidth = function(width) {
-    ipc_send("save_user_settings", { right_panel_width: width });
-  };
-
-  div.addEventListener(
-    "mousedown",
-    event => {
-      m_pos = event.x;
-      document.addEventListener("mousemove", resize, false);
-    },
-    false
-  );
-
-  document.addEventListener(
-    "mouseup",
-    event => {
-      document.removeEventListener("mousemove", resize, false);
-      if (finalWidth) {
-        saveWidth(finalWidth);
-        if (finalCallback instanceof Function) finalCallback(finalWidth);
-        finalWidth = null;
-      }
-    },
-    false
-  );
-}
-
-//
-function drawDeck(div, deck, showWildcards = false) {
-  div.html("");
-  const unique = makeId(4);
-
-  // draw maindeck grouped by cardType
-  const cardsByGroup = _(deck.mainDeck)
-    .map(card => ({ data: db.card(card.id), ...card }))
-    .groupBy(card => {
-      const cardType = cardTypes.cardType(card.data);
-      switch (cardType) {
-        case "Creature":
-          return "Creatures";
-        case "Planeswalker":
-          return "Planeswalkers";
-        case "Instant":
-        case "Sorcery":
-          return "Spells";
-        case "Enchantment":
-          return "Enchantments";
-        case "Artifact":
-          return "Artifacts";
-        case "Land":
-          return "Lands";
-        default:
-          throw new Error(`Unexpected card type: ${cardType}`);
-      }
-    })
-    .value();
-
-  _([
-    "Creatures",
-    "Planeswalkers",
-    "Spells",
-    "Enchantments",
-    "Artifacts",
-    "Lands"
-  ])
-    .filter(group => !_.isEmpty(cardsByGroup[group]))
-    .forEach(group => {
-      // draw a separator for the group
-      const cards = cardsByGroup[group];
-      const count = _.sumBy(cards, "quantity");
-      const separator = deckDrawer.cardSeparator(`${group} (${count})`);
-      div.append(separator);
-
-      // draw the cards
-      _(cards)
-        .filter(card => card.quantity > 0)
-        .orderBy(["data.cmc", "data.name"])
-        .forEach(card => {
-          const tile = deckDrawer.cardTile(
-            pd.settings.card_tile_style,
-            card.id,
-            unique + "a",
-            card.quantity,
-            showWildcards,
-            deck,
-            false
-          );
-          div.append(tile);
-        });
-    });
-
-  const sideboardSize = _.sumBy(deck.sideboard, "quantity");
-  if (sideboardSize) {
-    // draw a separator for the sideboard
-    let separator = deckDrawer.cardSeparator(`Sideboard (${sideboardSize})`);
-    div.append(separator);
-
-    // draw the cards
-    _(deck.sideboard)
-      .filter(card => card.quantity > 0)
-      .map(card => ({ data: db.card(card.id), ...card }))
-      .orderBy(["data.cmc", "data.name"])
-      .forEach(card => {
-        const tile = deckDrawer.cardTile(
-          pd.settings.card_tile_style,
-          card.id,
-          unique + "b",
-          card.quantity,
-          showWildcards,
-          deck,
-          true
-        );
-        div.append(tile);
-      });
-  }
-}
-
-//
-function drawCardList(div, cards) {
-  let unique = makeId(4);
-  let counts = {};
-  cards.forEach(cardId => (counts[cardId] = (counts[cardId] || 0) + 1));
-  Object.keys(counts).forEach(cardId => {
-    let tile = deckDrawer.cardTile(
-      pd.settings.card_tile_style,
-      cardId,
-      unique,
-      counts[cardId]
-    );
-    div.append(tile);
-  });
-}
-
-//
-function drawDeckVisual(_div, _stats, deck) {
-  // PLACEHOLDER
-  if (!(_div instanceof jQuery)) {
-    _div = $(_div);
-  }
-  // attempt at sorting visually..
-  var newMainDeck = [];
-
-  for (var cmc = 0; cmc < 21; cmc++) {
-    for (var qq = 4; qq > -1; qq--) {
-      deck.mainDeck.forEach(function(c) {
-        var grpId = c.id;
-        var card = db.card(grpId);
-        var quantity;
-        if (card.type.indexOf("Land") == -1 && grpId != 67306) {
-          if (card.cmc == cmc) {
-            quantity = c.quantity;
-
-            if (quantity == qq) {
-              newMainDeck.push(c);
-            }
-          }
-        } else if (cmc == 20) {
-          quantity = c.quantity;
-          if (qq == 0 && quantity > 4) {
-            newMainDeck.push(c);
-          }
-          if (quantity == qq) {
-            newMainDeck.push(c);
-          }
-        }
-      });
-    }
-  }
-
-  var types = get_deck_types_ammount(deck);
-  var typesdiv = $('<div class="types_container"></div>');
-  $(
-    '<div class="type_icon_cont"><div title="Creatures" class="type_icon type_cre"></div><span>' +
-      types.cre +
-      "</span></div>"
-  ).appendTo(typesdiv);
-  $(
-    '<div class="type_icon_cont"><div title="Lands" class="type_icon type_lan"></div><span>' +
-      types.lan +
-      "</span></div>"
-  ).appendTo(typesdiv);
-  $(
-    '<div class="type_icon_cont"><div title="Instants" class="type_icon type_ins"></div><span>' +
-      types.ins +
-      "</span></div>"
-  ).appendTo(typesdiv);
-  $(
-    '<div class="type_icon_cont"><div title="Sorceries" class="type_icon type_sor"></div><span>' +
-      types.sor +
-      "</span></div>"
-  ).appendTo(typesdiv);
-  $(
-    '<div class="type_icon_cont"><div title="Enchantments" class="type_icon type_enc"></div><span>' +
-      types.enc +
-      "</span></div>"
-  ).appendTo(typesdiv);
-  $(
-    '<div class="type_icon_cont"><div title="Artifacts" class="type_icon type_art"></div><span>' +
-      types.art +
-      "</span></div>"
-  ).appendTo(typesdiv);
-  $(
-    '<div class="type_icon_cont"><div title="Planeswalkers" class="type_icon type_pla"></div><span>' +
-      types.pla +
-      "</span></div>"
-  ).appendTo(typesdiv);
-  typesdiv.prependTo(_div.parent());
-
-  if (_stats) {
-    _stats.hide();
-  }
-  _div.css("display", "flex");
-  _div.css("width", "auto");
-  _div.css("margin", "0 auto");
-  _div.html("");
-
-  _div.parent().css("flex-direction", "column");
-
-  if (_stats) {
-    $('<div class="button_simple openDeck">Normal view</div>').appendTo(
-      _div.parent()
-    );
-
-    $(".openDeck").click(function() {
-      openDeck();
-    });
-  }
-
-  var sz = pd.cardsSize;
-  let div = $('<div class="visual_mainboard"></div>');
-  div.css("display", "flex");
-  div.css("flex-wrap", "wrap");
-  div.css("align-content", "start");
-  div.css("max-width", (sz + 6) * 5 + "px");
-  div.appendTo(_div);
-
-  //var unique = makeId(4);
-  //var prevIndex = 0;
-
-  var tileNow;
-  var _n = 0;
-  newMainDeck.forEach(function(c) {
-    var grpId = c.id;
-    var card = db.card(grpId);
-
-    if (c.quantity > 0) {
-      let dfc = "";
-      if (card.dfc == "DFC_Back") dfc = "a";
-      if (card.dfc == "DFC_Front") dfc = "b";
-      if (card.dfc == "SplitHalf") dfc = "a";
-      if (dfc != "b") {
-        for (let i = 0; i < c.quantity; i++) {
-          if (_n % 4 == 0) {
-            tileNow = $('<div class="deck_visual_tile"></div>');
-            tileNow.appendTo(div);
-          }
-
-          let d = $(
-            '<div style="width: ' +
-              sz +
-              'px !important;" class="deck_visual_card"></div>'
-          );
-          let img = $(
-            '<img style="width: ' +
-              sz +
-              'px !important;" class="deck_visual_card_img"></img>'
-          );
-
-          img.attr("src", get_card_image(card));
-          img.appendTo(d);
-          d.appendTo(tileNow);
-
-          addCardHover(img, card);
-          _n++;
-        }
-      }
-    }
-  });
-
-  div = $('<div class="visual_sideboard"></div>');
-  div.css("display", "flex");
-  div.css("flex-wrap", "wrap");
-  div.css("margin-left", "32px");
-  div.css("align-content", "start");
-  div.css("max-width", (sz + 6) * 1.5 + "px");
-  div.appendTo(_div);
-
-  if (deck.sideboard != undefined) {
-    tileNow = $('<div class="deck_visual_tile_side"></div>');
-    tileNow.css("width", (sz + 6) * 5 + "px");
-    tileNow.appendTo(div);
-
-    if (deck.sideboard.length == 0) {
-      tileNow.css("display", "none");
-    }
-
-    _n = 0;
-    deck.sideboard.forEach(function(c) {
-      var grpId = c.id;
-      var card = db.card(grpId);
-      if (c.quantity > 0) {
-        let dfc = "";
-        if (card.dfc == "DFC_Back") dfc = "a";
-        if (card.dfc == "DFC_Front") dfc = "b";
-        if (card.dfc == "SplitHalf") dfc = "a";
-        if (dfc != "b") {
-          for (let i = 0; i < c.quantity; i++) {
-            var d;
-            if (_n % 2 == 1) {
-              d = $(
-                '<div style="width: ' +
-                  sz +
-                  'px !important;" class="deck_visual_card_side"></div>'
-              );
-            } else {
-              d = $(
-                '<div style="margin-left: 60px; width: ' +
-                  sz +
-                  'px !important;" class="deck_visual_card_side"></div>'
-              );
-            }
-            let img = $(
-              '<img style="width: ' +
-                sz +
-                'px !important;" class="deck_visual_card_img"></img>'
-            );
-            img.attr("src", get_card_image(card));
-            img.appendTo(d);
-            d.appendTo(tileNow);
-
-            addCardHover(img, card);
-            _n++;
-          }
-        }
-      }
-    });
-  }
-}
-
-//
-function setChangesTimeline(deckId) {
-  const changes = [...pd.deckChanges(deckId)];
-  changes.sort(compare_changes);
-
-  var cont = $(".stats");
-  cont.html("");
-
-  var time = $('<div class="changes_timeline"></div>');
-
-  // CURRENT DECK
-  let div = $('<div class="change"></div>');
-  let butbox = $(
-    '<div class="change_button_cont" style="transform: scaleY(-1);"></div>'
-  );
-  let button = $('<div class="change_button"></div>');
-  button.appendTo(butbox);
-  let datbox = $('<div class="change_data"></div>');
-
-  // title
-  let title = $('<div class="change_data_box"></div>');
-  title.html("Current Deck");
-
-  butbox.appendTo(div);
-  datbox.appendTo(div);
-  title.appendTo(datbox);
-  div.appendTo(time);
-
-  butbox.on("mouseenter", function() {
-    button.css("width", "32px");
-    button.css("height", "32px");
-    button.css("top", "calc(50% - 16px)");
-  });
-
-  butbox.on("mouseleave", function() {
-    button.css("width", "24px");
-    button.css("height", "24px");
-    button.css("top", "calc(50% - 12px)");
-  });
-
-  butbox.on("click", function() {
-    var hasc = button.hasClass("change_button_active");
-
-    $(".change_data_box_inside").each(function() {
-      $(this).css("height", "0px");
-    });
-
-    $(".change_button").each(function() {
-      $(this).removeClass("change_button_active");
-    });
-
-    if (!hasc) {
-      button.addClass("change_button_active");
-    }
-  });
-  //
-
-  var cn = 0;
-  changes.forEach(function(change) {
-    change.changesMain.sort(compare_changes_inner);
-    change.changesSide.sort(compare_changes_inner);
-
-    let div = $('<div class="change"></div>');
-    let butbox;
-    if (cn < changes.length - 1) {
-      butbox = $(
-        '<div style="background-size: 100% 100% !important;" class="change_button_cont"></div>'
-      );
-    } else {
-      butbox = $('<div class="change_button_cont"></div>');
-    }
-    var button = $('<div class="change_button"></div>');
-    button.appendTo(butbox);
-    let datbox = $('<div class="change_data"></div>');
-
-    // title
-    let title = $('<div class="change_data_box"></div>');
-    // inside
-    let data = $('<div class="change_data_box_inside"></div>');
-    var innherH = 54;
-    let nc = 0;
-    if (change.changesMain.length > 0) {
-      let dd = $('<div class="change_item_box"></div>');
-      let separator = deckDrawer.cardSeparator("Mainboard");
-      dd.append(separator);
-      dd.appendTo(data);
-    }
-
-    change.changesMain.forEach(function(c) {
-      innherH += 30;
-      if (c.quantity > 0) nc += c.quantity;
-      let dd = $('<div class="change_item_box"></div>');
-      if (c.quantity > 0) {
-        let ic = $('<div class="change_add"></div>');
-        ic.appendTo(dd);
-      } else {
-        let ic = $('<div class="change_remove"></div>');
-        ic.appendTo(dd);
-      }
-
-      let tile = deckDrawer.cardTile(
-        pd.settings.card_tile_style,
-        c.id,
-        "chm" + cn,
-        Math.abs(c.quantity)
-      );
-      dd.append(tile);
-      dd.appendTo(data);
-    });
-
-    if (change.changesSide.length > 0) {
-      let dd = $('<div class="change_item_box"></div>');
-      let separator = deckDrawer.cardSeparator("Sideboard");
-      dd.append(separator);
-      innherH += 30;
-      dd.appendTo(data);
-    }
-
-    change.changesSide.forEach(function(c) {
-      innherH += 30;
-      if (c.quantity > 0) nc += c.quantity;
-      let dd = $('<div class="change_item_box"></div>');
-      if (c.quantity > 0) {
-        let ic = $('<div class="change_add"></div>');
-        ic.appendTo(dd);
-      } else {
-        let ic = $('<div class="change_remove"></div>');
-        ic.appendTo(dd);
-      }
-
-      let tile = deckDrawer.cardTile(
-        pd.settings.card_tile_style,
-        c.id,
-        "chs" + cn,
-        Math.abs(c.quantity)
-      );
-      dd.append(tile);
-      dd.appendTo(data);
-    });
-
-    title.html(
-      nc + " changes, " + timeSince(Date.parse(change.date)) + " ago."
-    );
-
-    butbox.appendTo(div);
-    datbox.appendTo(div);
-    title.appendTo(datbox);
-    data.appendTo(datbox);
-    div.appendTo(time);
-
-    butbox.on("mouseenter", function() {
-      button.css("width", "32px");
-      button.css("height", "32px");
-      button.css("top", "calc(50% - 16px)");
-    });
-
-    butbox.on("mouseleave", function() {
-      button.css("width", "24px");
-      button.css("height", "24px");
-      button.css("top", "calc(50% - 12px)");
-    });
-
-    butbox.on("click", function() {
-      // This requires some UX indicators
-      //drawDeck($('.decklist'), {mainDeck: change.previousMain, sideboard: change.previousSide});
-      var hasc = button.hasClass("change_button_active");
-
-      $(".change_data_box_inside").each(function() {
-        $(this).css("height", "0px");
-      });
-
-      $(".change_button").each(function() {
-        $(this).removeClass("change_button_active");
-      });
-
-      if (!hasc) {
-        button.addClass("change_button_active");
-        data.css("height", innherH + "px");
-      }
-    });
-
-    cn++;
-  });
-
-  $('<div class="button_simple openDeck">View stats</div>').appendTo(cont);
-
-  $(".openDeck").click(function() {
-    openDeck();
-  });
-  time.appendTo(cont);
-}
-
-//
-function open_draft(id) {
-  console.log("OPEN DRAFT", id, draftPosition);
-  $("#ux_1").html("");
-  $("#ux_1").removeClass("flex_item");
-  const draft = pd.draft(id);
-  let tileGrpid = db.sets[draft.set].tile;
-
-  if (draftPosition < 1) draftPosition = 1;
-  if (draftPosition > packSize * 6) draftPosition = packSize * 6;
-
-  var packSize = 14;
-  if (draft.set == "Guilds of Ravnica" || draft.set == "Ravnica Allegiance") {
-    packSize = 15;
-  }
-
-  var pa = Math.floor((draftPosition - 1) / 2 / packSize);
-  var pi = Math.floor(((draftPosition - 1) / 2) % packSize);
-  var key = "pack_" + pa + "pick_" + pi;
-
-  var pack = (draft[key] && draft[key].pack) || [];
-  var pick = (draft[key] && draft[key].pick) || "";
-
-  var top = $(
-    '<div class="decklist_top"><div class="button back"></div><div class="deck_name">' +
-      draft.set +
-      " Draft</div></div>"
-  );
-  let flr = $('<div class="deck_top_colors"></div>');
-  top.append(flr);
-
-  if (db.card(tileGrpid)) {
-    change_background("", tileGrpid);
-  }
-
-  var cont = $('<div class="flex_item" style="flex-direction: column;"></div>');
-  cont.append(
-    '<div class="draft_nav_container"><div class="draft_nav_prev"></div><div class="draft_nav_next"></div></div>'
-  );
-
-  $(
-    '<div class="draft_title">Pack ' +
-      (pa + 1) +
-      ", Pick " +
-      (pi + 1) +
-      "</div>"
-  ).appendTo(cont);
-
-  var slider = $('<div class="slidecontainer"></div>');
-  slider.appendTo(cont);
-  var sliderInput = $(
-    '<input type="range" min="1" max="' +
-      packSize * 6 +
-      '" value="' +
-      draftPosition +
-      '" class="slider" id="draftPosRange">'
-  );
-  sliderInput.appendTo(slider);
-
-  const pdiv = $('<div class="draft_pack_container"></div>');
-  pdiv.appendTo(cont);
-
-  pack.forEach(function(grpId) {
-    var d = $(
-      '<div style="width: ' +
-        pdiv.cardsSize +
-        'px !important;" class="draft_card"></div>'
-    );
-    var img = $(
-      '<img style="width: ' +
-        pdiv.cardsSize +
-        'px !important;" class="draft_card_img"></img>'
-    );
-    if (grpId == pick && draftPosition % 2 == 0) {
-      img.addClass("draft_card_picked");
-    }
-    var card = db.card(grpId);
-    img.attr("src", get_card_image(card));
-
-    img.appendTo(d);
-    var r = $(
-      '<div style="" class="draft_card_rating">' +
-        DRAFT_RANKS[card.rank] +
-        "</div>"
-    );
-    r.appendTo(d);
-    addCardHover(img, card);
-    d.appendTo(pdiv);
-  });
-
-  $("#ux_1").append(top);
-  $("#ux_1").append(cont);
-
-  var posRange = $("#draftPosRange")[0];
-
-  $(".draft_nav_prev").off();
-  $(".draft_nav_next").off();
-  $("#draftPosRange").off();
-
-  $("#draftPosRange").on("click mousemove", function() {
-    var pa = Math.floor((posRange.value - 1) / 2 / packSize);
-    var pi = Math.floor(((posRange.value - 1) / 2) % packSize);
-    $(".draft_title").html("Pack " + (pa + 1) + ", Pick " + (pi + 1));
-  });
-
-  $("#draftPosRange").on("click mouseup", function() {
-    draftPosition = parseInt(posRange.value);
-    open_draft(id, tileGrpid, draft.set);
-  });
-
-  $(".draft_nav_prev").on("click mouseup", function() {
-    draftPosition -= 1;
-    open_draft(id, tileGrpid, draft.set);
-  });
-
-  $(".draft_nav_next").on("click mouseup", function() {
-    draftPosition += 1;
-    open_draft(id, tileGrpid, draft.set);
-  });
-  //
-  $(".back").click(function() {
-    change_background("default");
-    $(".moving_ux").animate({ left: "0px" }, 250, "easeInOutCubic");
-  });
-}
-
-function open_match(id) {
-  $("#ux_1").html("");
-  $("#ux_1").removeClass("flex_item");
-  const match = pd.match(id);
-
-  let top = $(
-    '<div class="decklist_top"><div class="button back"></div><div class="deck_name">' +
-      match.playerDeck.name +
-      "</div></div>"
-  );
-  let flr = $('<div class="deck_top_colors"></div>');
-
-  if (match.playerDeck.colors != undefined) {
-    match.playerDeck.colors.forEach(function(color) {
-      var m = $('<div class="mana_s20 mana_' + MANA[color] + '"></div>');
-      flr.append(m);
-    });
-  }
-  top.append(flr);
-
-  var flc = $(
-    '<div class="flex_item" style="justify-content: space-evenly;"></div>'
-  );
-  if (fs.existsSync(path.join(actionLogDir, id + ".txt"))) {
-    $('<div class="button_simple openLog">Action log</div>').appendTo(flc);
-  }
-
-  var tileGrpid = match.playerDeck.deckTileId;
-  if (db.card(tileGrpid)) {
-    change_background("", tileGrpid);
-  }
-  var fld = $('<div class="flex_item"></div>');
-
-  // this is a mess
-  var flt = $('<div class="flex_item"></div>');
-  var fltl = $('<div class="flex_item"></div>');
-  var r = $('<div class="rank"></div>');
-  r.appendTo(fltl);
-
-  var fltr = $('<div class="flex_item"></div>');
-  fltr.css("flex-direction", "column");
-  var fltrt = $('<div class="flex_top"></div>');
-  var fltrb = $('<div class="flex_bottom"></div>');
-  fltrt.appendTo(fltr);
-  fltrb.appendTo(fltr);
-
-  fltl.appendTo(flt);
-  fltr.appendTo(flt);
-
-  var rank = match.player.rank;
-  var tier = match.player.tier;
-  r.css(
-    "background-position",
-    get_rank_index(rank, tier) * -48 + "px 0px"
-  ).attr("title", rank + " " + tier);
-
-  var name = $(
-    '<div class="list_match_player_left">' +
-      match.player.name.slice(0, -6) +
-      " (" +
-      match.player.win +
-      ")</div>"
-  );
-  name.appendTo(fltrt);
-
-  if (match.player.win > match.opponent.win) {
-    var w = $('<div class="list_match_player_left green">Winner</div>');
-    w.appendTo(fltrb);
-  }
-
-  var dl = $('<div class="decklist"></div>');
-  flt.appendTo(dl);
-
-  drawDeck(dl, match.playerDeck);
-
-  $(
-    '<div class="button_simple centered exportDeckPlayer">Export to Arena</div>'
-  ).appendTo(dl);
-  $(
-    '<div class="button_simple centered exportDeckStandardPlayer">Export to .txt</div>'
-  ).appendTo(dl);
-
-  flt = $('<div class="flex_item" style="flex-direction: row-reverse;"></div>');
-  fltl = $('<div class="flex_item"></div>');
-  r = $('<div class="rank"></div>');
-  r.appendTo(fltl);
-
-  fltr = $('<div class="flex_item"></div>');
-  fltr.css("flex-direction", "column");
-  fltr.css("align-items", "flex-end");
-  fltrt = $('<div class="flex_top"></div>');
-  fltrb = $('<div class="flex_bottom"></div>');
-  fltrt.appendTo(fltr);
-  fltrb.appendTo(fltr);
-
-  fltl.appendTo(flt);
-  fltr.appendTo(flt);
-
-  rank = match.opponent.rank;
-  tier = match.opponent.tier;
-  r.css(
-    "background-position",
-    get_rank_index(rank, tier) * -48 + "px 0px"
-  ).attr("title", rank + " " + tier);
-
-  name = $(
-    '<div class="list_match_player_right">' +
-      match.opponent.name.slice(0, -6) +
-      " (" +
-      match.opponent.win +
-      ")</div>"
-  );
-  name.appendTo(fltrt);
-
-  if (match.player.win < match.opponent.win) {
-    w = $('<div class="list_match_player_right green">Winner</div>');
-    w.appendTo(fltrb);
-  }
-
-  var odl = $('<div class="decklist"></div>');
-  flt.appendTo(odl);
-
-  match.oppDeck.mainDeck.sort(compare_cards);
-  match.oppDeck.sideboard.sort(compare_cards);
-  /*
-  match.oppDeck.mainDeck.forEach(function(c) {
-    c.quantity = 9999;
-  });
-  match.oppDeck.sideboard.forEach(function(c) {
-    c.quantity = 9999;
-  });
-  */
-  drawDeck(odl, match.oppDeck);
-
-  $(
-    '<div class="button_simple centered exportDeck">Export to Arena</div>'
-  ).appendTo(odl);
-  $(
-    '<div class="button_simple centered exportDeckStandard">Export to .txt</div>'
-  ).appendTo(odl);
-
-  dl.appendTo(fld);
-  odl.appendTo(fld);
-
-  $("#ux_1").append(top);
-  $("#ux_1").append(flc);
-  $("#ux_1").append(fld);
-
-  if (match.gameStats) {
-    match.gameStats.forEach((game, gameIndex) => {
-      if (game && game.sideboardChanges) {
-        let separator1 = deckDrawer.cardSeparator(
-          `Game ${gameIndex + 1} Sideboard Changes`
-        );
-        $("#ux_1").append(separator1);
-        let sideboardDiv = $('<div class="card_lists_list"></div>');
-        let additionsDiv = $('<div class="cardlist"></div>');
-        if (
-          game.sideboardChanges.added.length == 0 &&
-          game.sideboardChanges.removed.length == 0
-        ) {
-          let separator2 = deckDrawer.cardSeparator("No changes");
-          additionsDiv.append(separator2);
-          additionsDiv.appendTo(sideboardDiv);
-        } else {
-          let separator3 = deckDrawer.cardSeparator("Sideboarded In");
-          additionsDiv.append(separator3);
-          drawCardList(additionsDiv, game.sideboardChanges.added);
-          additionsDiv.appendTo(sideboardDiv);
-          let removalsDiv = $('<div class="cardlist"></div>');
-          let separator4 = deckDrawer.cardSeparator("Sideboarded Out");
-          removalsDiv.append(separator4);
-          drawCardList(removalsDiv, game.sideboardChanges.removed);
-          removalsDiv.appendTo(sideboardDiv);
-        }
-
-        $("#ux_1").append(sideboardDiv);
-      }
-
-      let separator5 = deckDrawer.cardSeparator(
-        `Game ${gameIndex + 1} Hands Drawn`
-      );
-      $("#ux_1").append(separator5);
-
-      let handsDiv = $('<div class="card_lists_list"></div>');
-      if (game && game.handsDrawn.length > 3) {
-        // The default value of "center" apparently causes padding to be omitted in the calculation of how far
-        // the scrolling should go. So, if there are enough hands to actually need scrolling, override it.
-        handsDiv.css("justify-content", "start");
-      }
-
-      if (game) {
-        game.handsDrawn.forEach((hand, i) => {
-          let handDiv = $('<div class="cardlist"></div>');
-          drawCardList(handDiv, hand);
-          handDiv.appendTo(handsDiv);
-          if (game.bestOf == 1 && i == 0) {
-            let landDiv = $(
-              '<div style="margin: auto; text-align: center;" tooltip-top tooltip-content=' +
-                '"This hand was drawn with weighted odds that Wizards of the Coast has not disclosed because it is the first hand in a best-of-one match. ' +
-                'It should be more likely to have a close to average number of lands, but only they could calculate the exact odds.">Land Percentile: Unknown</div>'
-            );
-            landDiv.appendTo(handDiv);
-          } else {
-            let likelihood = hypergeometricSignificance(
-              game.handLands[i],
-              game.deckSize,
-              hand.length,
-              game.landsInDeck
-            );
-            let landDiv = $(
-              '<div style="margin: auto; text-align: center;" tooltip-top tooltip-content=' +
-                '"The probability of a random hand of the same size having a number of lands at least as far from average as this one, ' +
-                'calculated as if the distribution were continuous. Over a large number of games, this should average about 50%.">Land Likelihood: ' +
-                (likelihood * 100).toFixed(2) +
-                "%</div>"
-            );
-            landDiv.appendTo(handDiv);
-          }
-        });
-
-        $("#ux_1").append(handsDiv);
-
-        let separator6 = deckDrawer.cardSeparator(
-          `Game ${gameIndex + 1} Shuffled Order`
-        );
-        $("#ux_1").append(separator6);
-        let libraryDiv = $('<div class="library_list"></div>');
-        let unique = makeId(4);
-        let handSize = 8 - game.handsDrawn.length;
-
-        game.shuffledOrder.forEach((cardId, libraryIndex) => {
-          let rowShade =
-            libraryIndex === handSize - 1
-              ? "line_dark line_bottom_border"
-              : libraryIndex < handSize - 1
-              ? "line_dark"
-              : (libraryIndex - handSize) % 2 === 0
-              ? "line_light"
-              : "line_dark";
-          let cardDiv = $(`<div class="library_card ${rowShade}"></div>`);
-          let tile = deckDrawer.cardTile(
-            pd.settings.card_tile_style,
-            cardId,
-            unique + libraryIndex,
-            "#" + (libraryIndex + 1)
-          );
-          cardDiv.append(tile);
-          cardDiv.appendTo(libraryDiv);
-        });
-        let unknownCards = game.deckSize - game.shuffledOrder.length;
-        if (unknownCards > 0) {
-          let cardDiv = $('<div class="library_card"></div>');
-          let tile = deckDrawer.cardTile(
-            pd.settings.card_tile_style,
-            null,
-            unique + game.deckSize,
-            unknownCards + "x"
-          );
-          cardDiv.append(tile);
-          cardDiv.appendTo(libraryDiv);
-        }
-
-        let handExplanation = $(
-          '<div class="library_hand">The opening hand is excluded from the below statistics to prevent mulligan choices from influencing them.</div>'
-        );
-        handExplanation.css("grid-row-end", "span " + (handSize - 1));
-        handExplanation.appendTo(libraryDiv);
-
-        let headerDiv = $(
-          '<div class="library_header" tooltip-bottom tooltip-content="The number of lands in the library at or before this point.">Lands</div>'
-        );
-        headerDiv.css("grid-area", handSize + " / 2");
-        headerDiv.appendTo(libraryDiv);
-        headerDiv = $(
-          '<div class="library_header" tooltip-bottom tooltip-content="The average number of lands expected in the library at or before this point.">Expected</div>'
-        );
-        headerDiv.css("grid-area", handSize + " / 3");
-        headerDiv.appendTo(libraryDiv);
-        headerDiv = $(
-          '<div class="library_header" tooltip-bottom tooltip-content="The probability of the number of lands being at least this far from average, calculated as if the distribution were continuous. For details see footnote. Over a large number of games, this should average about 50%.">Likelihood</div>'
-        );
-        headerDiv.css("grid-area", handSize + " / 4");
-        headerDiv.appendTo(libraryDiv);
-        headerDiv = $(
-          '<div class="library_header" tooltip-bottomright tooltip-content="The expected percentage of games where the actual number of lands is equal or less than this one. This is easier to calculate and more widely recognized but harder to assess the meaning of.">Percentile</div>'
-        );
-        headerDiv.css("grid-area", handSize + " / 5");
-        headerDiv.appendTo(libraryDiv);
-
-        game.libraryLands.forEach((count, index) => {
-          let rowShade = index % 2 === 0 ? "line_light" : "line_dark";
-          let landsDiv = $(
-            `<div class="library_stat ${rowShade}">${count}</div>`
-          );
-          landsDiv.css("grid-area", handSize + index + 1 + " / 2");
-          landsDiv.appendTo(libraryDiv);
-          let expected = (
-            ((index + 1) * game.landsInLibrary) /
-            game.librarySize
-          ).toFixed(2);
-          let expectedDiv = $(
-            `<div class="library_stat ${rowShade}">${expected}</div>`
-          );
-          expectedDiv.css("grid-area", handSize + index + 1 + " / 3");
-          expectedDiv.appendTo(libraryDiv);
-          let likelihood = hypergeometricSignificance(
-            count,
-            game.librarySize,
-            index + 1,
-            game.landsInLibrary
-          );
-          let likelihoodDiv = $(
-            `<div class="library_stat ${rowShade}">${(likelihood * 100).toFixed(
-              2
-            )}</div>`
-          );
-          likelihoodDiv.css("grid-area", handSize + index + 1 + " / 4");
-          likelihoodDiv.appendTo(libraryDiv);
-          let percentile = hypergeometricRange(
-            0,
-            count,
-            game.librarySize,
-            index + 1,
-            game.landsInLibrary
-          );
-          let percentileDiv = $(
-            `<div class="library_stat ${rowShade}">${(percentile * 100).toFixed(
-              2
-            )}</div>`
-          );
-          percentileDiv.css("grid-area", handSize + index + 1 + " / 5");
-          percentileDiv.appendTo(libraryDiv);
-        });
-
-        let footnoteLabel = $(
-          '<div id="library_footnote_label' +
-            gameIndex +
-            '" class="library_footnote" tooltip-bottom ' +
-            'tooltip-content="Click to show footnote" onclick="toggleVisibility(\'library_footnote_label' +
-            gameIndex +
-            "', 'library_footnote" +
-            gameIndex +
-            "')\">Footnote on Likelihood</div>"
-        );
-        footnoteLabel.css("grid-row", game.shuffledOrder.length + 1);
-        footnoteLabel.appendTo(libraryDiv);
-        let footnote = $(
-          '<div id="library_footnote' +
-            gameIndex +
-            '" class="library_footnote hidden" ' +
-            "onclick=\"toggleVisibility('library_footnote_label" +
-            gameIndex +
-            "', 'library_footnote" +
-            gameIndex +
-            "')\">" +
-            "<p>The Likelihood column calculations are designed to enable assessment of fairness at a glance, in a way " +
-            "that is related to percentile but differs in important ways. In short, it treats the count of lands as if " +
-            "it were actually a bucket covering a continuous range, and calculates the cumulative probability of the " +
-            "continuous value being at least as far from the median as a randomly selected value within the range covered " +
-            "by the actual count. Importantly, this guarantees that the theoretical average will always be exactly 50%.</p>" +
-            "<p>For values that are not the median, the result is halfway between the value's own percentile and the " +
-            "next one up or down. For the median itself, the covered range is split and weighted for how much of it is " +
-            "on each side of the 50th percentile. In both cases, the result's meaning is the same for each direction " +
-            "from the 50th percentile, and scaled up by a factor of 2 to keep the possible range at 0% to 100%. " +
-            "For precise details, see the source code on github.</p></div>"
-        );
-        footnote.css("grid-row", game.shuffledOrder.length + 1);
-        footnote.appendTo(libraryDiv);
-
-        $("#ux_1").append(libraryDiv);
-      }
-    });
-  }
-
-  $(".openLog").click(function() {
-    openActionLog(id, $("#ux_1"));
-  });
-
-  $(".exportDeckPlayer").click(function() {
-    var list = get_deck_export(match.playerDeck);
-    ipc_send("set_clipboard", list);
-  });
-  $(".exportDeckStandardPlayer").click(function() {
-    var list = get_deck_export_txt(match.playerDeck);
-    ipc_send("export_txt", { str: list, name: match.playerDeck.name });
-  });
-
-  $(".exportDeck").click(function() {
-    var list = get_deck_export(match.oppDeck);
-    ipc_send("set_clipboard", list);
-  });
-  $(".exportDeckStandard").click(function() {
-    var list = get_deck_export_txt(match.oppDeck);
-    ipc_send("export_txt", {
-      str: list,
-      name: match.opponent.name.slice(0, -6) + "'s deck"
-    });
-  });
-
-  $(".back").click(function() {
-    change_background("default");
-    $(".moving_ux").animate({ left: "0px" }, 250, "easeInOutCubic");
-  });
-}
-
-function openActionLog(actionLogId) {
-  $("#ux_2").html("");
-  let top = $(
-    `<div class="decklist_top"><div class="button back actionlog_back"></div><div class="deck_name">Action Log</div><div class="deck_name"></div></div>`
-  );
-
-  let actionLogContainer = $(`<div class="action_log_container"></div>`);
-
-  let actionLogFile = path.join(actionLogDir, actionLogId + ".txt");
-  let str = fs.readFileSync(actionLogFile).toString();
-
-  let actionLog = str.split("\n");
-  for (let line = 1; line < actionLog.length - 1; line += 3) {
-    let seat = actionLog[line];
-    let time = actionLog[line + 1];
-    let str = actionLog[line + 2];
-    str = striptags(str, ["log-card", "log-ability"]);
-
-    var boxDiv = $('<div class="actionlog log_p' + seat + '"></div>');
-    var timeDiv = $('<div class="actionlog_time">' + time + "</div>");
-    var strDiv = $('<div class="actionlog_text">' + str + "</div>");
-
-    boxDiv.append(timeDiv);
-    boxDiv.append(strDiv);
-    actionLogContainer.append(boxDiv);
-  }
-
-  $("#ux_2").append(top);
-  $("#ux_2").append(actionLogContainer);
-
-  $$("log-card").forEach(obj => {
-    let grpId = obj.getAttribute("id");
-    addCardHover(obj, db.card(grpId));
-  });
-
-  $$("log-ability").forEach(obj => {
-    let grpId = obj.getAttribute("id");
-    let abilityText = db.abilities[grpId] || "";
-    obj.title = abilityText;
-  });
-
-  $(".moving_ux").animate({ left: "-200%" }, 250, "easeInOutCubic");
-
-  $(".actionlog_back").click(() => {
-    $(".moving_ux").animate({ left: "-100%" }, 250, "easeInOutCubic");
-  });
-}
-
-//
-function toggleVisibility(...ids) {
-  ids.forEach(id => {
-    let el = document.getElementById(id);
-    if (el.classList.contains("hidden")) {
-      el.classList.remove("hidden");
-    } else {
-      el.classList.add("hidden");
-    }
-  });
-}
-
-//
-function add_checkbox(div, label, iid, def, func) {
-  label = $('<label class="check_container hover_label">' + label + "</label>");
-  label.appendTo(div);
-  var check_new = $('<input type="checkbox" id="' + iid + '" />');
-  check_new.on("click", func);
-  check_new.appendTo(label);
-  check_new.prop("checked", def);
-
-  var span = $('<span class="checkmark"></span>');
-  span.appendTo(label);
-  return label;
-}
-
-//
-function change_background(arg = "default", grpId = 0) {
-  let artistLine = "";
-  const _card = db.card(grpId);
-
-  //console.log(arg, grpId, _card);
-  if (arg === "default") {
-    $(".top_artist").html("Ghitu Lavarunner by Jesper Ejsing");
-    if (pd.settings.back_url === "") {
-      $(".main_wrapper").css(
-        "background-image",
-        "url(../images/Ghitu-Lavarunner-Dominaria-MtG-Art.jpg)"
-      );
-    } else {
-      $(".top_artist").html("");
-      $(".main_wrapper").css(
-        "background-image",
-        "url(" + pd.settings.back_url + ")"
-      );
-    }
-  } else if (_card) {
-    // console.log(_card.images["art_crop"]);
-    $(".main_wrapper").css(
-      "background-image",
-      "url(https://img.scryfall.com/cards" + _card.images["art_crop"] + ")"
-    );
-    try {
-      artistLine = _card.name + " by " + _card.artist;
-      $(".top_artist").html(artistLine);
-    } catch (e) {
-      console.log(e);
-    }
-  } else if (fs.existsSync(arg)) {
-    $(".top_artist").html("");
-    $(".main_wrapper").css("background-image", "url(" + arg + ")");
-  } else {
-    $(".top_artist").html("");
-    $.ajax({
-      url: arg,
-      type: "HEAD",
-      error: function() {
-        $(".main_wrapper").css("background-image", "");
-      },
-      success: function() {
-        $(".main_wrapper").css("background-image", "url(" + arg + ")");
-      }
-    });
-  }
-}
-
-//
-function formatPercent(value, config = {}) {
-  return value.toLocaleString([], {
-    style: "percent",
-    maximumSignificantDigits: 2,
-    ...config
-  });
-}
-
-//
-function formatNumber(value, config = {}) {
-  return value.toLocaleString([], {
-    style: "decimal",
-    ...config
-  });
-}
-
-//
-function getWinrateClass(wr) {
-  if (wr > 0.65) return "blue";
-  if (wr > 0.55) return "green";
-  if (wr < 0.45) return "orange";
-  if (wr < 0.35) return "red";
-  return "white";
-}
-
-function getEventWinLossClass(wlGate) {
-  if (wlGate === undefined) return "white";
-  if (wlGate.MaxWins === wlGate.CurrentWins) return "blue";
-  if (wlGate.CurrentWins > wlGate.CurrentLosses) return "green";
-  if (wlGate.CurrentWins * 2 > wlGate.CurrentLosses) return "orange";
-  return "red";
-}
-
-function compare_winrates(a, b) {
-  let _a = a.wins / a.losses;
-  let _b = b.wins / b.losses;
-
-  if (_a < _b) return 1;
-  if (_a > _b) return -1;
-
-  return compare_color_winrates(a, b);
-}
-
-function compare_color_winrates(a, b) {
-  a = a.colors;
-  b = b.colors;
-
-  if (a.length < b.length) return -1;
-  if (a.length > b.length) return 1;
-
-  let sa = a.reduce(function(_a, _b) {
-    return _a + _b;
-  }, 0);
-  let sb = b.reduce(function(_a, _b) {
-    return _a + _b;
-  }, 0);
-  if (sa < sb) return -1;
-  if (sa > sb) return 1;
-
-  return 0;
-}
-
-//
-function compare_changes(a, b) {
-  a = Date.parse(a.date);
-  b = Date.parse(b.date);
-  if (a < b) return 1;
-  if (a > b) return -1;
-  return 0;
-}
-
-//
-function compare_changes_inner(a, b) {
-  a = a.quantity;
-  b = b.quantity;
-  if (a > 0 && b > 0) {
-    if (a < b) return -1;
-    if (a > b) return 1;
-  }
-  if (a < 0 && b < 0) {
-    if (a < b) return 1;
-    if (a > b) return -1;
-  }
-  if (a < 0 && b > 0) {
-    return -1;
-  }
-  if (a > 0 && b < 0) {
-    return 1;
-  }
-  return 0;
-}

--- a/window_main/settings.js
+++ b/window_main/settings.js
@@ -1,21 +1,18 @@
-/*
-global
-  add_checkbox
-  change_background
-  hideLoadingBars
-  ipc_send
-  offlineMode
-  pd
-*/
-
 const { ipcRenderer: ipc, remote, shell } = require("electron");
 
+const { CARD_TILE_ARENA, CARD_TILE_FLAT } = require("../shared/constants");
 const db = require("../shared/database");
+const pd = require("../shared/player-data");
 const deckDrawer = require("../shared/deck-drawer");
 const { createSelect } = require("../shared/select");
 const { get_card_image } = require("../shared/util");
 
-const { CARD_TILE_ARENA, CARD_TILE_FLAT } = require("../shared/constants.js");
+const {
+  add_checkbox,
+  changeBackground: change_background,
+  hideLoadingBars,
+  ipcSend: ipc_send
+} = require("./renderer-util");
 
 let lastSettingsSection = 1;
 let updateState = "";
@@ -44,7 +41,7 @@ function openSettingsTab(openSection = lastSettingsSection) {
   $('<div class="settings_nav sn4">Privacy</div>').appendTo(wrap_l);
   $('<div class="settings_nav sn5">About</div>').appendTo(wrap_l);
 
-  if (offlineMode) {
+  if (pd.offline) {
     $('<div class="settings_nav sn6">Login</div>').appendTo(wrap_l);
   } else {
     $('<div class="settings_nav sn6">Logout</div>').appendTo(wrap_l);
@@ -428,7 +425,7 @@ function openSettingsTab(openSection = lastSettingsSection) {
   section = $('<div class="settings_section ss6" style="height: 100%;"></div>');
   const login = $('<div class="about"></div>');
   section.appendTo(div);
-  if (offlineMode) {
+  if (pd.offline) {
     button = $(
       '<div class="button_simple centered login_link_about">Login</div>'
     );

--- a/window_main/settings.js
+++ b/window_main/settings.js
@@ -8,10 +8,10 @@ const { createSelect } = require("../shared/select");
 const { get_card_image } = require("../shared/util");
 
 const {
-  addCheckbox: add_checkbox,
-  changeBackground: change_background,
+  addCheckbox,
+  changeBackground,
   hideLoadingBars,
-  ipcSend: ipc_send
+  ipcSend
 } = require("./renderer-util");
 
 let lastSettingsSection = 1;
@@ -25,7 +25,7 @@ function getCardStyleName(style) {
 //
 function openSettingsTab(openSection = lastSettingsSection) {
   lastSettingsSection = openSection;
-  change_background("default");
+  changeBackground("default");
   hideLoadingBars();
   $("#ux_0").off();
   $("#history_column").off();
@@ -56,35 +56,35 @@ function openSettingsTab(openSection = lastSettingsSection) {
   section.appendTo(div);
   section.append('<div class="settings_title">Behaviour</div>');
 
-  add_checkbox(
+  addCheckbox(
     section,
     "Beta updates channel",
     "settings_betachannel",
     pd.settings.beta_channel,
     updateAppSettings
   );
-  add_checkbox(
+  addCheckbox(
     section,
     "Login automatically",
     "settings_autologin",
     pd.settings.auto_login,
     updateAppSettings
   );
-  add_checkbox(
+  addCheckbox(
     section,
     "Launch to tray",
     "settings_launchtotray",
     pd.settings.launch_to_tray,
     updateAppSettings
   );
-  add_checkbox(
+  addCheckbox(
     section,
     "Launch on startup",
     "settings_startup",
     pd.settings.startup,
     updateUserSettings
   );
-  add_checkbox(
+  addCheckbox(
     section,
     "Read log on login",
     "settings_readlogonlogin",
@@ -95,21 +95,21 @@ function openSettingsTab(openSection = lastSettingsSection) {
       <div class="settings_note">
       <i>Reading the log on startup can take a while, disabling this will make mtgatool load instantly, but you may have have to play with Arena to load some data, like Rank, wildcards and decklists. <b>This feature makes mtgatool read games when it was closed.</b></i>
       </div>`);
-  add_checkbox(
+  addCheckbox(
     section,
     "Close main window on match found",
     "settings_closeonmatch",
     pd.settings.close_on_match,
     updateUserSettings
   );
-  add_checkbox(
+  addCheckbox(
     section,
     "Close to tray",
     "settings_closetotray",
     pd.settings.close_to_tray,
     updateUserSettings
   );
-  add_checkbox(
+  addCheckbox(
     section,
     "Sound when priority changes",
     "settings_soundpriority",
@@ -152,21 +152,21 @@ function openSettingsTab(openSection = lastSettingsSection) {
   section.appendTo(div);
   section.append('<div class="settings_title">Overlay</div>');
 
-  add_checkbox(
+  addCheckbox(
     section,
     "Always on top",
     "settings_overlay_ontop",
     pd.settings.overlay_ontop,
     updateUserSettings
   );
-  add_checkbox(
+  addCheckbox(
     section,
     "Show overlay",
     "settings_showoverlay",
     pd.settings.show_overlay,
     updateUserSettings
   );
-  add_checkbox(
+  addCheckbox(
     section,
     "Persistent overlay&nbsp;<i>(useful for OBS setup)</i>",
     "settings_showoverlayalways",
@@ -174,42 +174,42 @@ function openSettingsTab(openSection = lastSettingsSection) {
     updateUserSettings
   );
 
-  add_checkbox(
+  addCheckbox(
     section,
     "Show top bar",
     "settings_overlay_top",
     pd.settings.overlay_top,
     updateUserSettings
   );
-  add_checkbox(
+  addCheckbox(
     section,
     "Show title",
     "settings_overlay_title",
     pd.settings.overlay_title,
     updateUserSettings
   );
-  add_checkbox(
+  addCheckbox(
     section,
     "Show deck/lists",
     "settings_overlay_deck",
     pd.settings.overlay_deck,
     updateUserSettings
   );
-  add_checkbox(
+  addCheckbox(
     section,
     "Show clock",
     "settings_overlay_clock",
     pd.settings.overlay_clock,
     updateUserSettings
   );
-  add_checkbox(
+  addCheckbox(
     section,
     "Show sideboard",
     "settings_overlay_sideboard",
     pd.settings.overlay_sideboard,
     updateUserSettings
   );
-  add_checkbox(
+  addCheckbox(
     section,
     "Compact lands",
     "settings_overlay_lands",
@@ -368,14 +368,14 @@ function openSettingsTab(openSection = lastSettingsSection) {
   section = $('<div class="settings_section ss4"></div>');
   section.appendTo(div);
   section.append('<div class="settings_title">Privacy</div>');
-  add_checkbox(
+  addCheckbox(
     section,
     "Anonymous sharing&nbsp;<i>(makes your username anonymous on Explore)</i>",
     "settings_anon_explore",
     pd.settings.anon_explore,
     updateUserSettings
   );
-  add_checkbox(
+  addCheckbox(
     section,
     "Online sharing&nbsp;<i>(when disabled, blocks any connections with our servers)</i>",
     "settings_senddata",
@@ -445,7 +445,7 @@ function openSettingsTab(openSection = lastSettingsSection) {
   $(".sn" + openSection).addClass("nav_selected");
 
   $(".resetOverlayPos").click(function() {
-    ipc_send("reset_overlay_pos", true);
+    ipcSend("reset_overlay_pos", true);
   });
 
   $(".top_logo_about").click(function() {
@@ -478,13 +478,13 @@ function openSettingsTab(openSection = lastSettingsSection) {
       auto_login: false,
       launch_to_tray: false
     };
-    ipc_send("save_app_settings", clearAppSettings);
+    ipcSend("save_app_settings", clearAppSettings);
     remote.app.relaunch();
     remote.app.exit(0);
   });
 
   $(".update_link_about").click(function() {
-    ipc_send("updates_check", true);
+    ipcSend("updates_check", true);
   });
 
   $(".settings_nav").click(function() {
@@ -629,7 +629,7 @@ function updateAppSettings() {
     launch_to_tray,
     beta_channel
   };
-  ipc_send("save_app_settings", rSettings);
+  ipcSend("save_app_settings", rSettings);
 }
 
 //
@@ -642,7 +642,7 @@ function transparencyFromAlpha(alpha) {
   return Math.round((1 - alpha) * 100);
 }
 
-// only purpose is to strip paramaters for use with add_checkbox
+// only purpose is to strip paramaters for use with addCheckbox
 function updateUserSettings() {
   updateUserSettingsBlend();
 }
@@ -663,8 +663,8 @@ function updateUserSettingsBlend(_settings = {}) {
     .spectrum("get")
     .toRgbString();
   const backUrl = document.getElementById("query_image").value;
-  if (backUrl === "") change_background("default");
-  else change_background(backUrl);
+  if (backUrl === "") changeBackground("default");
+  else changeBackground(backUrl);
 
   const overlayOnTop = document.getElementById("settings_overlay_ontop")
     .checked;
@@ -687,7 +687,7 @@ function updateUserSettingsBlend(_settings = {}) {
 
   const exportFormat = document.getElementById("settings_export_format").value;
 
-  ipc_send("save_user_settings", {
+  ipcSend("save_user_settings", {
     sound_priority: soundPriority,
     show_overlay: showOverlay,
     show_overlay_always: showOverlayAlways,
@@ -723,7 +723,7 @@ function eraseData() {
       "This will erase all of your decks and events shared online, are you sure?"
     )
   ) {
-    ipc_send("delete_data", true);
+    ipcSend("delete_data", true);
   } else {
     return;
   }

--- a/window_main/settings.js
+++ b/window_main/settings.js
@@ -8,7 +8,7 @@ const { createSelect } = require("../shared/select");
 const { get_card_image } = require("../shared/util");
 
 const {
-  add_checkbox,
+  addCheckbox: add_checkbox,
   changeBackground: change_background,
   hideLoadingBars,
   ipcSend: ipc_send

--- a/window_main/stats-panel.js
+++ b/window_main/stats-panel.js
@@ -1,15 +1,13 @@
-/*
-global
-  compare_winrates
-  formatPercent
-  getTagColor
-  getWinrateClass
-*/
-
+const { MANA, RANKS } = require("../shared/constants");
 const { createDivision } = require("../shared/dom-fns");
 const { get_rank_index, toDDHHMMSS, toMMSS } = require("../shared/util");
 
-const { MANA, RANKS } = require("../shared/constants.js");
+const {
+  compareWinrates: compare_winrates,
+  formatPercent,
+  getTagColor,
+  getWinrateClass
+} = require("./renderer-util");
 
 class StatsPanel {
   constructor(

--- a/window_main/stats-panel.js
+++ b/window_main/stats-panel.js
@@ -3,7 +3,7 @@ const { createDivision } = require("../shared/dom-fns");
 const { get_rank_index, toDDHHMMSS, toMMSS } = require("../shared/util");
 
 const {
-  compareWinrates: compare_winrates,
+  compareWinrates,
   formatPercent,
   getTagColor,
   getWinrateClass
@@ -146,7 +146,7 @@ class StatsPanel {
       ...tagsWinrates.map(cwr => Math.max(cwr.wins || 0, cwr.losses || 0)),
       0
     );
-    tagsWinrates.sort(compare_winrates);
+    tagsWinrates.sort(compareWinrates);
     // Colors
     let colorsWinrates = [...Object.values(this.data.colorStats)];
     colorsWinrates.sort(frequencySort);
@@ -155,7 +155,7 @@ class StatsPanel {
       ...colorsWinrates.map(cwr => Math.max(cwr.wins || 0, cwr.losses || 0)),
       0
     );
-    colorsWinrates.sort(compare_winrates);
+    colorsWinrates.sort(compareWinrates);
 
     if (curveMaxTags || curveMax) {
       const chartTitle = createDivision(["ranks_history_title"]);

--- a/window_main/tournaments.js
+++ b/window_main/tournaments.js
@@ -1,15 +1,3 @@
-/*
-global
-  allMatches
-  change_background
-  drawDeck
-  drawDeckVisual
-  FilterPanel
-  ipc_send
-  pd
-  pop
-*/
-
 const { queryElements: $$, createDivision } = require("../shared/dom-fns");
 const { createSelect } = require("../shared/select");
 const deckDrawer = require("../shared/deck-drawer");
@@ -24,6 +12,17 @@ const {
   toHHMMSS,
   urlDecode
 } = require("../shared/util");
+const pd = require("../shared/player-data");
+
+const FilterPanel = require("./filter-panel");
+const {
+  pop,
+  changeBackground: change_background,
+  drawDeck,
+  drawDeckVisual,
+  getLocalState,
+  ipcSend: ipc_send
+} = require("./renderer-util");
 
 let tournamentDeck = null;
 let currentDeck = null;
@@ -173,7 +172,7 @@ function showTournamentRegister(mainDiv, tou) {
 
     mainDiv.appendChild(deckContainer);
     if (tou.deck) {
-      drawDeckVisual(deckvisual, undefined, tou.deck);
+      drawDeckVisual(deckvisual, tou.deck);
     }
 
     if (tou.state !== 4) {
@@ -187,7 +186,7 @@ function showTournamentRegister(mainDiv, tou) {
     const validDecks = pd.deckList
       .filter(deck => !deck.custom)
       .filter(deck => getBoosterCountEstimate(get_deck_missing(deck)) === 0);
-    validDecks.sort(allMatches.compareDecks);
+    validDecks.sort(getLocalState().totalAgg.compareDecks);
     // hack to make pretty deck names
     // TODO move getDeckString out of FilterPanel
     const filterPanel = new FilterPanel("unused", null, {}, [], [], validDecks);

--- a/window_main/tournaments.js
+++ b/window_main/tournaments.js
@@ -17,11 +17,11 @@ const pd = require("../shared/player-data");
 const FilterPanel = require("./filter-panel");
 const {
   pop,
-  changeBackground: change_background,
+  changeBackground,
   drawDeck,
   drawDeckVisual,
   getLocalState,
-  ipcSend: ipc_send
+  ipcSend
 } = require("./renderer-util");
 
 let tournamentDeck = null;
@@ -51,7 +51,7 @@ function tournamentCreate() {
   // Append
   mainDiv.appendChild(top);
   buttonBack.addEventListener("click", () => {
-    change_background("default");
+    changeBackground("default");
     $(".moving_ux").animate({ left: "0px" }, 250, "easeInOutCubic");
   });
 }
@@ -153,7 +153,7 @@ function tournamentOpen(t) {
   }
 
   topButtonBack.addEventListener("click", () => {
-    change_background("default");
+    changeBackground("default");
     $(".moving_ux").animate({ left: "0px" }, 250, "easeInOutCubic");
   });
 }
@@ -269,13 +269,13 @@ function showTournamentRegister(mainDiv, tou) {
 
   if (buttonDrop) {
     buttonDrop.addEventListener("click", () => {
-      ipc_send("tou_drop", tou._id);
+      ipcSend("tou_drop", tou._id);
     });
   }
 }
 
 function tournamentJoin(_id, _deck, _pass) {
-  ipc_send("tou_join", { id: _id, deck: _deck, pass: _pass });
+  ipcSend("tou_join", { id: _id, deck: _deck, pass: _pass });
 }
 
 function showTournamentStarted(mainDiv, tou) {
@@ -326,12 +326,12 @@ function showTournamentStarted(mainDiv, tou) {
 
       copyMtgaButton.addEventListener("click", () => {
         pop("Copied to clipboard", 1000);
-        ipc_send("set_clipboard", urlDecode(tou.current_opponent));
+        ipcSend("set_clipboard", urlDecode(tou.current_opponent));
       });
 
       copyDiscordButton.addEventListener("click", () => {
         pop("Copied to clipboard", 1000);
-        ipc_send("set_clipboard", urlDecode(tou.current_opponent_discord));
+        ipcSend("set_clipboard", urlDecode(tou.current_opponent_discord));
       });
     }
 
@@ -530,7 +530,7 @@ function createRoundsTab(joined) {
     let dropButton = createDivision(["button_simple", "but_drop"], "Drop");
     tab_cont_a.appendChild(dropButton);
     dropButton.addEventListener("click", () => {
-      ipc_send("tou_drop", tou._id);
+      ipcSend("tou_drop", tou._id);
     });
   }
 
@@ -700,7 +700,7 @@ function createDecklistTab() {
 
   buttonExport.addEventListener("click", () => {
     let list = get_deck_export(currentDeck);
-    ipc_send("set_clipboard", list);
+    ipcSend("set_clipboard", list);
   });
   return tab_cont_c;
 }


### PR DESCRIPTION
### Motivation
- No more globals in any of the main window process files.
- Eliminate circular dependencies in `require` chain

### Approach
- Split `renderer` into 2 files:
  - `renderer-util` for fns shared across files in main window process
  - `renderer` Classic for IPC listeners, navigation logic, and "outer" window chrome
- Circular `require` dependencies should now be linear chains, e.g. `renderer` -> `decks` -> `deck-details` -> `renderer-util`
- Split up global variables and refactor into metadata database, player data singleton, or `renderer-util.localState` depending on usage