### PR TITLE
bugfix settings input handlers

### DIFF
--- a/window_main/settings.js
+++ b/window_main/settings.js
@@ -144,7 +144,7 @@ function openSettingsTab(openSection = lastSettingsSection) {
   icd.appendTo(label);
 
   section.append(`<div class="settings_note">
-      <i>Possible constiables: $Name, $Count, $SetName, $SetCode, $Collector, $Rarity, $Type, $Cmc</i>
+      <i>Possible variables: $Name, $Count, $SetName, $SetCode, $Collector, $Rarity, $Type, $Cmc</i>
       </div>`);
 
   // OVERLAY
@@ -531,7 +531,17 @@ function openSettingsTab(openSection = lastSettingsSection) {
     }
   });
 
-  export_input.on("keyup", function() {
+  url_input.on("focusout", function() {
+    updateUserSettings();
+  });
+
+  export_input.on("keyup", function(e) {
+    if (e.keyCode === 13) {
+      updateUserSettings();
+    }
+  });
+
+  export_input.on("focusout", function() {
     updateUserSettings();
   });
 


### PR DESCRIPTION
### Motivation
The current text inputs on the Settings page behave inconsistently with when they choose to save data. Particularly problematic is the "Export Format:" input, which spams IPC with settings updates UPON EVERY KEY PRESS. 🙀 

### Approach
- standardize both inputs so that they only send updates in 2 cases:
  - user hits "Enter" key
  - the input loses focus