### PR TITLE
Bugfix overlay position persistence

### DIFF
--- a/main.js
+++ b/main.js
@@ -635,7 +635,7 @@ function saveOverlayPos(index) {
   if (!overlays[index] || overlaysResizeLock) return false;
 
   let bounds = overlays[index].getBounds();
-  overlays[index].bounds = bounds;
+  overlays_settings[index].bounds = bounds;
   background.webContents.send("overlayBounds", index, bounds);
   /*
   console.log(


### PR DESCRIPTION
### Motivation
The main process was not correctly keeping track of where the overlays were supposed to be. Although all of the player-data singletons in the renderer processes were correct, some events (e.g. end of a match) could cause the main process to move the overlays around to an old location immediately before saving the settings. This made it impossible to change overlay location mid-match.

https://discordapp.com/channels/463844727654187020/467737642306371584/588773548244598786
![image](https://user-images.githubusercontent.com/14894693/59467432-7fefe980-8de4-11e9-91c3-23032ad3a4ac.png)

