### PR TITLE
Overlay Process Manager

### DIFF
--- a/window_background/background.js
+++ b/window_background/background.js
@@ -225,7 +225,9 @@ ipc.on("set_renderer_state", function(event, arg) {
   // first time during bootstrapping that we load
   // app-level settings into singletons
   const appSettings = rstore.get("settings");
-  syncSettings(appSettings);
+  const settings = { ...pd.settings, ...appSettings };
+  pd_set({ settings });
+  ipc_send("initial_settings", settings);
 
   let username = "";
   let password = "";
@@ -521,7 +523,6 @@ function loadPlayerConfig(playerId, serverData = undefined) {
     time: 3000,
     progress: -1
   });
-  ipc_send("player_data_loaded", true);
 }
 
 function syncUserData(data) {
@@ -596,7 +597,6 @@ function syncSettings(dirtySettings = {}) {
   skipFirstPass = settings.skip_firstpass;
   pd_set({ settings });
   ipc_send("set_settings", settings);
-  ipc_send("settings_updated");
 }
 
 // Set a new log URI
@@ -1048,7 +1048,7 @@ function dataChop(data, startStr, endStr) {
 }
 
 function setDraftCards(json) {
-  ipc.send("set_draft_cards", currentDraft);
+  ipc_send("set_draft_cards", currentDraft);
 }
 
 function actionLogGenerateLink(grpId) {

--- a/window_background/gre-to-client-interpreter.js
+++ b/window_background/gre-to-client-interpreter.js
@@ -14,10 +14,9 @@ global
   instanceToCardIdMap
   update_deck
 */
-
 const { objectClone } = require("../shared/util");
 
-const { ipcRenderer: ipc } = require("electron");
+const { ipc_send } = require("./background-util");
 
 let actionType = [];
 actionType[0] = "ActionType_None";
@@ -701,16 +700,15 @@ function checkTurnDiff(turnInfo) {
   }
 
   if (!firstPass) {
-    ipc.send(
-      "set_turn",
-      currentMatch.player.seat,
-      turnInfo.phase,
-      turnInfo.step,
-      turnInfo.turnNumber,
-      turnInfo.activePlayer,
-      turnInfo.priorityPlayer,
-      turnInfo.decisionPlayer
-    );
+    ipc_send("set_turn", {
+      playerSeat: currentMatch.player.seat,
+      turnPhase: turnInfo.phase,
+      turnStep: turnInfo.step,
+      turnNumber: turnInfo.turnNumber,
+      turnActive: turnInfo.activePlayer,
+      turnPriority: turnInfo.priorityPlayer,
+      turnDecision: turnInfo.decisionPlayer
+    });
   }
 }
 

--- a/window_background/labels.js
+++ b/window_background/labels.js
@@ -696,7 +696,6 @@ function onLabelOutDraftMakePick(entry, json) {
 
 function onLabelInEventCompleteDraft(entry, json) {
   if (!json) return;
-  ipc_send("save_overlay_pos", 1);
   clear_deck();
   ipc_send("set_arena_state", ARENA_MODE_IDLE);
   //ipc_send("renderer_show", 1);
@@ -759,7 +758,6 @@ function onLabelMatchGameRoomStateChangedEvent(entry, json) {
       }
     });
 
-    ipc_send("save_overlay_pos", 1);
     clear_deck();
     ipc_send("set_arena_state", ARENA_MODE_IDLE);
     matchCompletedOnGameNumber = json.finalMatchResult.resultList.length - 1;

--- a/window_main/renderer-util.js
+++ b/window_main/renderer-util.js
@@ -1088,17 +1088,17 @@ function changeBackground(arg = "default", grpId = 0) {
 
   //console.log(arg, grpId, _card);
   if (arg === "default") {
-    $(".top_artist").html("Ghitu Lavarunner by Jesper Ejsing");
-    if (pd.settings.back_url === "") {
-      $(".main_wrapper").css(
-        "background-image",
-        "url(../images/Ghitu-Lavarunner-Dominaria-MtG-Art.jpg)"
-      );
-    } else {
+    if (pd.settings.back_url && pd.settings.back_url !== "default") {
       $(".top_artist").html("");
       $(".main_wrapper").css(
         "background-image",
         "url(" + pd.settings.back_url + ")"
+      );
+    } else {
+      $(".top_artist").html("Ghitu Lavarunner by Jesper Ejsing");
+      $(".main_wrapper").css(
+        "background-image",
+        "url(../images/Ghitu-Lavarunner-Dominaria-MtG-Art.jpg)"
       );
     }
   } else if (_card) {

--- a/window_main/settings.js
+++ b/window_main/settings.js
@@ -595,9 +595,11 @@ function appendVisual(section) {
   label.appendTo(section);
 
   let icd = $('<div class="input_container"></div>');
+  const display =
+    pd.settings.back_url !== "default" ? pd.settings.back_url : "";
   const url_input = $(
-    '<input type="search" id="query_image" autocomplete="off" value="' +
-      pd.settings.back_url +
+    '<input type="search" id="query_image" autocomplete="off" placeholder="https://example.com/photo.png" value="' +
+      display +
       '" />'
   );
   url_input.appendTo(icd);
@@ -826,9 +828,7 @@ function updateUserSettingsBlend(_settings = {}) {
     .spectrum("get")
     .toRgbString();
 
-  const backUrl = byId("query_image").value;
-  if (backUrl === "") changeBackground("default");
-  else changeBackground(backUrl);
+  const backUrl = byId("query_image").value || "default";
 
   pd.settings.overlays.forEach((overlaySettings, index) => {
     const showOverlay = byId(`overlay_${index}_show`).checked;


### PR DESCRIPTION
This is a minor refactor that cleans up a few code tangles around the new multiple overlays. It should have no effective change to tool behavior.

- Creates `OverlayProcess` class to simplify state and logic in `main` process
  - each instance manages its own `index`, `BrowserWindow`, and state
  - each instance takes care of updating itself
  - each instance takes care of cleaning up after itself
- Simplifies how `main` handles most overlay-related IPC signals, usually just a split
- Explicitly separates `main` initialization and settings updates
- Removes several unused IPC signals entirely
- Bugfix: clearing custom background image now correctly updates overlays