### PR TITLE
Remove jQuery from Settings Page

### DIFF
--- a/main.js
+++ b/main.js
@@ -269,7 +269,9 @@ function startApp() {
         break;
 
       case "reset_overlay_pos":
-        overlays.forEach(overlay => overlay.window.setPosition(0, 0));
+        if (arg < overlays.length) {
+          overlays[arg].window.setPosition(0, 0);
+        }
         break;
 
       case "updates_check":

--- a/shared/dom-fns.js
+++ b/shared/dom-fns.js
@@ -15,16 +15,33 @@ function queryElementsByClass(selectors, parentNode = document) {
   return [...parentNode.getElementsByClassName(selectors)];
 }
 
-exports.createDivision = createDivision;
-function createDivision(classNames, innerHTML) {
-  // Utility function. Create a <div> element with specified class names and content
-  let div = document.createElement("div");
+exports.createElement = createElement;
+function createElement(type, classNames = [], innerHTML = "", attrs = {}) {
+  // Utility function. Create a <type> element with specified class names and content
+  const el = document.createElement(type);
+  classNames.forEach(className => el.classList.add(className));
+  el.innerHTML = innerHTML;
+  Object.assign(el, attrs);
+  return el;
+}
 
-  if (classNames !== undefined) {
-    classNames.forEach(className => div.classList.add(className));
-  }
-  if (innerHTML !== undefined) {
-    div.innerHTML = innerHTML;
-  }
-  return div;
+exports.createDivision = createDivision;
+exports.createDiv = createDivision;
+function createDivision(classNames, innerHTML, attrs = {}) {
+  return createElement("div", classNames, innerHTML, attrs);
+}
+
+exports.createImg = createImg;
+function createImg(classNames, innerHTML, attrs = {}) {
+  return createElement("img", classNames, innerHTML, attrs);
+}
+
+exports.createInput = createInput;
+function createInput(classNames, innerHTML, attrs = {}) {
+  return createElement("input", classNames, innerHTML, attrs);
+}
+
+exports.createLabel = createLabel;
+function createLabel(classNames, innerHTML, attrs = {}) {
+  return createElement("label", classNames, innerHTML, attrs);
 }

--- a/window_main/renderer-util.js
+++ b/window_main/renderer-util.js
@@ -1069,7 +1069,7 @@ function toggleVisibility(...ids) {
 exports.addCheckbox = addCheckbox;
 function addCheckbox(div, label, iid, def, func) {
   label = $('<label class="check_container hover_label">' + label + "</label>");
-  label.appendTo(div);
+  label.appendTo($(div));
   var check_new = $('<input type="checkbox" id="' + iid + '" />');
   check_new.on("click", func);
   check_new.appendTo(label);


### PR DESCRIPTION
### Motivation
Since we are actively building new features into the Settings page, now is a great time to refactor out `jQuery`***.

### Bugfixes
- Clicking the reset position button affects current overlay instead of all overlays
- Removes some animation flicker that happened right after updates

### Minor Enhancements
- Adds example prompt to empty input fields (export format and background URL)
- Renames a few labels in Visual tab, groups card size/quality together, moves card example below
- Adds release notes link to current version number

### Other Misc
- Adds several new DOM utility functions to `dom-fns` module (`createInput`, `createLabel`, etc.)
- ***only remaining `jQuery` on the page is the `colorpicker`, which is a `jQuery` extension
