### PR TITLE
Elder Dragon store.get() REBORN!

### DIFF
--- a/shared/card-hover.js
+++ b/shared/card-hover.js
@@ -79,7 +79,7 @@ function attachOwnerhipStars(card, starContainer) {
   starContainer.innerHTML = "";
   starContainer.style.opacity = 1;
 
-  const owned = pd.cards[card.id];
+  const owned = pd.cards.cards[card.id];
   const aquired = pd.cardsNew[card.id];
   starContainer.title = `${owned}/4 copies in collection`;
   if (aquired) {

--- a/shared/database.js
+++ b/shared/database.js
@@ -14,6 +14,10 @@ class Database {
     if (ipc) ipc.on("set_db", this.handleSetDb);
     if (ipc) ipc.on("set_reward_resets", this.handleSetRewardResets);
     if (ipc) ipc.on("set_season", this.handleSetSeason);
+
+    this.rewards_daily_ends = new Date();
+    this.rewards_weekly_ends = new Date();
+
     const dbUri = `${__dirname}/../resources/database.json`;
     const defaultDb = fs.readFileSync(dbUri, "utf8");
     this.handleSetDb(null, defaultDb);

--- a/shared/player-data.js
+++ b/shared/player-data.js
@@ -65,7 +65,7 @@ const overlayCfg = {
 
 const defaultCfg = {
   windowBounds: { width: 800, height: 600, x: 0, y: 0 },
-  cards: { cards_time: 0, cards_before: [], cards: [] },
+  cards: { cards_time: 0, cards_before: {}, cards: {} },
   cardsNew: {},
   settings: {
     sound_priority: false,

--- a/shared/util.js
+++ b/shared/util.js
@@ -314,7 +314,7 @@ function get_wc_missing(deck, grpid, isSideboard) {
 
   let have = 0;
   arr.forEach(id => {
-    let n = pd.cards[id];
+    let n = pd.cards.cards[id];
     if (n !== undefined) {
       have += n;
     }

--- a/window_background/background.js
+++ b/window_background/background.js
@@ -106,7 +106,7 @@ var settingsStore = new Store({
 });
 
 const debugLog = false;
-const debugNet = true;
+const debugNet = false;
 var debugLogSpeed = 0.001;
 
 const actionLogDir = path.join(
@@ -357,8 +357,7 @@ ipc.on("request_explore", function(event, arg) {
   if (pd.userName === "") {
     ipc_send("offline", 1);
   } else {
-    let cards = store.get("cards.cards");
-    httpApi.httpGetExplore(arg, cards);
+    httpApi.httpGetExplore(arg);
   }
 });
 
@@ -1636,9 +1635,7 @@ function finishLoading() {
       update_deck(false);
     }
 
-    let obj = store.get("windowBounds");
-    ipc_send("renderer_set_bounds", obj);
-
+    ipc_send("renderer_set_bounds", pd.windowBounds);
     ipc_send("initialize", 1);
 
     if (pd.name) {

--- a/window_background/http-api.js
+++ b/window_background/http-api.js
@@ -6,7 +6,6 @@ global
   db
   pd
   debugNet
-  store
   debugLog
   syncUserData
 */
@@ -431,9 +430,8 @@ function httpSetPlayer() {
   //httpAsync.push({'reqId': _id, 'method': 'set_player', 'name': name, 'rank': rank, 'tier': tier});
 }
 
-function httpGetExplore(query, collection) {
+function httpGetExplore(query) {
   var _id = makeId(6);
-  collection = JSON.stringify(collection);
   httpAsync.unshift({
     reqId: _id,
     method: "get_explore",
@@ -450,7 +448,7 @@ function httpGetExplore(query, collection) {
     filter_mana: query.filteredMana,
     filter_ranks: query.filteredranks,
     filter_skip: query.filterSkip,
-    collection: collection
+    collection: JSON.stringify(pd.cards.cards)
   });
 }
 

--- a/window_background/labels.js
+++ b/window_background/labels.js
@@ -546,37 +546,37 @@ function onLabelInPlayerInventoryGetPlayerInventory(entry, json) {
 function onLabelInPlayerInventoryGetPlayerCardsV3(entry, json) {
   if (!json) return;
 
-  var date = new Date(store.get("cards.cards_time"));
-  var now = new Date();
-  var diff = Math.abs(now.getTime() - date.getTime());
-  var days = Math.floor(diff / (1000 * 3600 * 24));
+  const date = new Date(pd.cards.cards_time);
+  const now = new Date();
+  const diff = Math.abs(now.getTime() - date.getTime());
+  const days = Math.floor(diff / (1000 * 3600 * 24));
 
-  if (store.get("cards.cards_time") == 0) {
-    store.set("cards.cards_time", now);
-    store.set("cards.cards_before", json);
-    store.set("cards.cards", json);
-  }
+  let cards_before = pd.cards.cards_before;
   // If a day has passed since last update
-  else if (days > 0) {
-    var cardsPrev = store.get("cards.cards");
-    store.set("cards.cards_time", now);
-    store.set("cards.cards_before", cardsPrev);
-    store.set("cards.cards", json);
+  if (pd.cards.cards_time !== 0 && days > 0) {
+    cards_before = pd.cards.cards;
   }
 
-  var cardsPrevious = store.get("cards.cards_before");
-  const cardsNew = {};
+  const cards = {
+    ...pd.cards,
+    cards_time: now,
+    cards_before,
+    cards: json
+  };
 
+  store.set("cards", cards);
+
+  const cardsNew = {};
   Object.keys(json).forEach(function(key) {
     // get differences
-    if (cardsPrevious[key] === undefined) {
+    if (cards_before[key] === undefined) {
       cardsNew[key] = json[key];
-    } else if (cardsPrevious[key] < json[key]) {
-      cardsNew[key] = json[key] - cardsPrevious[key];
+    } else if (cards_before[key] < json[key]) {
+      cardsNew[key] = json[key] - cards_before[key];
     }
   });
 
-  pd_set({ cards: json, cardsNew });
+  pd_set({ cards, cardsNew });
   if (!firstPass) ipc_send("player_data_refresh");
 }
 

--- a/window_main/collection.js
+++ b/window_main/collection.js
@@ -37,7 +37,7 @@ let countMode = ALL_CARDS;
 //
 function get_collection_export(exportFormat) {
   let list = "";
-  Object.keys(pd.cards).forEach(key => {
+  Object.keys(pd.cards.cards).forEach(key => {
     let add = exportFormat + "";
     const card = db.card(key);
     if (card) {
@@ -45,7 +45,10 @@ function get_collection_export(exportFormat) {
       name = replaceAll(name, "///", "//");
       add = add.replace("$Name", '"' + name + '"');
 
-      add = add.replace("$Count", pd.cards[key] === 9999 ? 1 : pd.cards[key]);
+      add = add.replace(
+        "$Count",
+        pd.cards.cards[key] === 9999 ? 1 : pd.cards.cards[key]
+      );
 
       add = add.replace("$SetName", card.set);
       add = add.replace("$SetCode", db.sets[card.set].code);
@@ -173,8 +176,8 @@ function get_collection_stats() {
     stats.complete[card.rarity].unique += 1;
 
     // add cards we own
-    if (pd.cards[card.id] !== undefined) {
-      const owned = pd.cards[card.id];
+    if (pd.cards.cards[card.id] !== undefined) {
+      const owned = pd.cards.cards[card.id];
       stats[card.set][card.rarity].owned += owned;
       stats.complete[card.rarity].owned += owned;
       stats[card.set][card.rarity].uniqueOwned += 1;
@@ -868,7 +871,7 @@ function printCards() {
   if (filterUnown) {
     list = db.cardIds;
   } else {
-    list = Object.keys(pd.cards);
+    list = Object.keys(pd.cards.cards);
   }
 
   let keysSorted = [...list];
@@ -911,7 +914,7 @@ function printCards() {
     }
 
     if (filterIncomplete) {
-      const owned = pd.cards[card.id];
+      const owned = pd.cards.cards[card.id];
       if (owned >= 4) {
         continue;
       }


### PR DESCRIPTION
### Motivation
This PR has a single, Bolas-Minded Goal:
- Reduce the number of calls to `store.get()` to exactly 1

This should have no perceivable impact to users (other than being a little faster). This finishes some of the performance-optimization work that I began as part of `multiple-overlays`. (Minimizing calls to the player store reduces end-to-end IPC time.)

### Approach
- Now that we can depend on player-data singletons, this is mostly a straightforward search/replace all `store.get("foo")` => `pd.foo`
- There was one place where the `background` process was still using a different data model structure from the rest of the processes: `cards` VS `cards.cards`
  - standardizes all player-data access on `cards.cards`, since it more directly matches the JSON

(this is a second attempt at #421, in which I did not understand or handle `cards.cards` correctly)