### PR TITLE
Remove jQuery from Decks Page

### DIFF
--- a/window_main/decks.js
+++ b/window_main/decks.js
@@ -309,8 +309,6 @@ function createTag(div, deckId, tag, showClose = true) {
       });
       input.addEventListener("focusout", function() {
         const val = this.value;
-        t.innerHTML = "...";
-        t.style.width = "24px";
         if (val && val !== tagPrompt) {
           addTag(deckId, val);
         }
@@ -328,9 +326,6 @@ function createTag(div, deckId, tag, showClose = true) {
     tc.addEventListener("click", function(e) {
       e.stopPropagation();
       tc.style.visibility = "hidden";
-      t.innerHTML = "...";
-      t.style.width = "24px";
-      t.style.paddingRight = "12px";
       deleteTag(deckId, val);
     });
     t.appendChild(tc);

--- a/window_main/settings.js
+++ b/window_main/settings.js
@@ -143,7 +143,6 @@ function openSettingsTab(openSection = lastSettingsSection, scrollTop = 0) {
 
   wrap_r.appendChild(div);
   wrap_r.addEventListener("scroll", () => {
-    console.log(wrap_r.scrollTop);
     setLocalState({ lastScrollTop: wrap_r.scrollTop });
   });
   mainDiv.appendChild(wrap_r);


### PR DESCRIPTION
### Motivation
Removing `jquery` from Decks page***.
https://github.com/Manuel-777/MTG-Arena-Tool/projects/2#card-18924534

### ***TODO
- `animate` call, part of our dependency on `jquery.easing` extension
- tag `colorpicker`, which is a `jquery` extension
