### PR TITLE
bugfix labels do not set arena state during first pass

### DIFF
--- a/window_background/labels.js
+++ b/window_background/labels.js
@@ -697,7 +697,7 @@ function onLabelOutDraftMakePick(entry, json) {
 function onLabelInEventCompleteDraft(entry, json) {
   if (!json) return;
   clear_deck();
-  ipc_send("set_arena_state", ARENA_MODE_IDLE);
+  if (!firstPass) ipc_send("set_arena_state", ARENA_MODE_IDLE);
   //ipc_send("renderer_show", 1);
 
   currentDraft.draftId = json.Id;
@@ -759,7 +759,7 @@ function onLabelMatchGameRoomStateChangedEvent(entry, json) {
     });
 
     clear_deck();
-    ipc_send("set_arena_state", ARENA_MODE_IDLE);
+    if (!firstPass) ipc_send("set_arena_state", ARENA_MODE_IDLE);
     matchCompletedOnGameNumber = json.finalMatchResult.resultList.length - 1;
     saveMatch(json.finalMatchResult.matchId + "-" + pd.arenaId);
   }


### PR DESCRIPTION
### Before
```
MAIN:  Updating settings
OVERLAY 1:  Create process
OVERLAY 2:  Create process
OVERLAY 3:  Create process
OVERLAY 4:  Create process
OVERLAY 5:  Create process
IPC LOG:  No need to fetch remote player items.
IPC LOG:  MATCH CREATED: Tue Jun 18 2019 00:12:45 GMT-0700 (Pacific Daylight Time)
IPC LOG:  vs ProfoundWizard#40791
Uncaught exception;
TypeError: Cannot read property 'mode' of undefined
    at OverlayProcess.updateVisible (C:\Users\Local Ben\code\MTG-Arena-Tool\window_overlay\overlay-process.js:126:17)
    at C:\Users\Local Ben\code\MTG-Arena-Tool\main.js:221:45
    at Array.forEach (<anonymous>)
    at EventEmitter.<anonymous> (C:\Users\Local Ben\code\MTG-Arena-Tool\main.js:221:18)
    at EventEmitter.emit (events.js:194:13)
    at WebContents.<anonymous> (C:\Users\Local Ben\code\MTG-Arena-Tool\node_modules\electron\dist\resources\electron.asar\browser\api\web-contents.js:390:13)
    at WebContents.emit (events.js:194:13)
IPC LOG:  MATCH CREATED: Tue Jun 18 2019 00:14:25 GMT-0700 (Pacific Daylight Time)
IPC LOG:  vs Crabwalker#98155
Uncaught exception;
TypeError: Cannot read property 'mode' of undefined
    at OverlayProcess.updateVisible (C:\Users\Local Ben\code\MTG-Arena-Tool\window_overlay\overlay-process.js:126:17)
    at C:\Users\Local Ben\code\MTG-Arena-Tool\main.js:221:45
    at Array.forEach (<anonymous>)
    at EventEmitter.<anonymous> (C:\Users\Local Ben\code\MTG-Arena-Tool\main.js:221:18)
    at EventEmitter.emit (events.js:194:13)
    at WebContents.<anonymous> (C:\Users\Local Ben\code\MTG-Arena-Tool\node_modules\electron\dist\resources\electron.asar\browser\api\web-contents.js:390:13)
    at WebContents.emit (events.js:194:13)
IPC LOG:  MATCH CREATED: Tue Jun 18 2019 00:20:06 GMT-0700 (Pacific Daylight Time)
IPC LOG:  vs halt#01505
Uncaught exception;
TypeError: Cannot read property 'mode' of undefined
...
```

### After
```
MAIN:  Updating settings
OVERLAY 1:  Create process
OVERLAY 2:  Create process
OVERLAY 3:  Create process
OVERLAY 4:  Create process
OVERLAY 5:  Create process
IPC LOG:  No need to fetch remote player items.
IPC LOG:  MATCH CREATED: Tue Jun 18 2019 00:12:45 GMT-0700 (Pacific Daylight Time)
IPC LOG:  vs ProfoundWizard#40791
IPC LOG:  MATCH CREATED: Tue Jun 18 2019 00:14:25 GMT-0700 (Pacific Daylight Time)
IPC LOG:  vs Crabwalker#98155
IPC LOG:  MATCH CREATED: Tue Jun 18 2019 00:20:06 GMT-0700 (Pacific Daylight Time)
IPC LOG:  vs halt#01505
IPC LOG:  MATCH CREATED: Tue Jun 18 2019 00:34:46 GMT-0700 (Pacific Daylight Time)
IPC LOG:  vs Queegon#88158
...
```