### PR TITLE
Vanilla picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Please read about [our Privacy Policy and How we use your data here](./PRIVACY.m
 
 [Conic Gradient Polyfill by Lea Verou](https://leaverou.github.io/conic-gradient/)
 
-[Spectrum color picker by Brian Grinstead](http://bgrins.github.io/spectrum/)
+[vanilla-picker by Andreas Borgen, Adam Brooks](https://vanilla-picker.js.org/)
 
 [Draft ranking by Magic Community Set Reviews](https://www.mtgcommunityreview.com/)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "MTG-Arena-Tool",
-  "version": "2.6.1",
+  "version": "2.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -438,6 +438,11 @@
         "@types/istanbul-reports": "^1.1.1",
         "@types/yargs": "^12.0.9"
       }
+    },
+    "@sphinxxxx/color-conversion": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@sphinxxxx/color-conversion/-/color-conversion-2.2.1.tgz",
+      "integrity": "sha512-5+ofCE09lF6C7DPSVyvQ2Nf0oaue3Cl+SosT45DYy5nhgUXsOq3TetArC1q8mVfAOjhG0WReQPPFBdc4xXVNkg=="
     },
     "@types/babel__core": {
       "version": "7.1.1",
@@ -1916,6 +1921,11 @@
       "integrity": "sha1-3vHxyl1gWdJKdm5YeULCEQbOEnU=",
       "dev": true
     },
+    "drag-tracker": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/drag-tracker/-/drag-tracker-1.0.0.tgz",
+      "integrity": "sha1-m9M9OAvDBW22m9Wzz24GL+xYvWQ="
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -2996,7 +3006,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3017,12 +3028,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3037,17 +3050,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3164,7 +3180,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3176,6 +3193,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3190,6 +3208,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3197,12 +3216,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3221,6 +3242,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3301,7 +3323,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3313,6 +3336,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3398,7 +3422,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3434,6 +3459,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3453,6 +3479,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3496,12 +3523,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -10247,7 +10276,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -10908,6 +10937,15 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "vanilla-picker": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/vanilla-picker/-/vanilla-picker-2.8.1.tgz",
+      "integrity": "sha512-mzjMw0WbeS6qi+wzXSCfHFL7Jmvp7sJfXq0FfOvUEAAnCI6cmgCUVJ+wpr2c3g+Gt9AypLpHks3oeIkX6nCM9A==",
+      "requires": {
+        "@sphinxxxx/color-conversion": "^2.2.1",
+        "drag-tracker": "^1.0.0"
       }
     },
     "verror": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10150,11 +10150,6 @@
       "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==",
       "dev": true
     },
-    "spectrum-colorpicker": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/spectrum-colorpicker/-/spectrum-colorpicker-1.8.0.tgz",
-      "integrity": "sha1-uSbPUALAp3hgtfg1HhwJPGUgAQc="
-    },
     "speedometer": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
     "queue": "^4.5.1",
     "spectrum-colorpicker": "^1.8.0",
     "striptags": "^3.1.1",
-    "time-elements": "^2.0.0"
+    "time-elements": "^2.0.0",
+    "vanilla-picker": "^2.8.1"
   },
   "devDependencies": {
     "acorn": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "npm": "^6.9.0",
     "qs": "^6.7.0",
     "queue": "^4.5.1",
-    "spectrum-colorpicker": "^1.8.0",
     "striptags": "^3.1.1",
     "time-elements": "^2.0.0",
     "vanilla-picker": "^2.8.1"

--- a/shared/shared.css
+++ b/shared/shared.css
@@ -1,5 +1,3 @@
-@import "../node_modules/spectrum-colorpicker/spectrum.css";
-
 :root {
   --main-font-name:  'lato', sans-serif;
   --main-font-name-it:  'lato-italic', sans-serif;

--- a/window_main/decks.js
+++ b/window_main/decks.js
@@ -22,7 +22,8 @@ const {
   hideLoadingBars,
   ipcSend,
   makeResizable,
-  setLocalState
+  setLocalState,
+  showColorpicker
 } = require("./renderer-util");
 
 const byId = id => document.getElementById(id);
@@ -259,35 +260,13 @@ function createTag(div, deckId, tag, showClose = true) {
 
   if (tag) {
     t.addEventListener("click", function(e) {
-      // TODO remove jquery colorpicker
-      const colorPick = $(t);
-      colorPick.spectrum({
-        showInitial: true,
-        showAlpha: false,
-        showButtons: false
-      });
-      colorPick.spectrum("set", tagCol);
-      colorPick.spectrum("show");
-
-      colorPick.on("move.spectrum", (e, color) => {
-        const tag = $(this).text();
-        const col = color.toRgbString();
-        $(".deck_tag").each((index, obj) => {
-          if (tag !== $(obj).text()) return;
-          $(obj).css("background-color", col);
-        });
-      });
-
-      colorPick.on("change.spectrum", (e, color) => {
-        const tag = $(this).text();
-        const col = color.toRgbString();
-        ipcSend("edit_tag", { tag, color: col });
-      });
-
-      colorPick.on("hide.spectrum", () => {
-        colorPick.spectrum("destroy");
-      });
       e.stopPropagation();
+      showColorpicker(
+        tagCol,
+        color => (t.style.backgroundColor = color.rgbString),
+        color => ipcSend("edit_tag", { tag, color: color.rgbString }),
+        () => (t.style.backgroundColor = tagCol)
+      );
     });
   } else {
     t.addEventListener("click", function(e) {

--- a/window_main/history.js
+++ b/window_main/history.js
@@ -29,6 +29,7 @@ const {
   ipcSend,
   makeResizable,
   openDraft,
+  showColorpicker,
   showLoadingBars,
   toggleArchived
 } = require("./renderer-util");
@@ -450,35 +451,13 @@ function createTag(div, matchId, tags, tag, showClose = true) {
 
   if (tag) {
     t.addEventListener("click", function(e) {
-      // TODO remove jquery colorpicker
-      const colorPick = $(t);
-      colorPick.spectrum({
-        showInitial: true,
-        showAlpha: false,
-        showButtons: false
-      });
-      colorPick.spectrum("set", tagCol);
-      colorPick.spectrum("show");
-
-      colorPick.on("move.spectrum", (e, color) => {
-        const tag = $(this).text();
-        const col = color.toRgbString();
-        $(".deck_tag").each((index, obj) => {
-          if (tag !== $(obj).text()) return;
-          $(obj).css("background-color", col);
-        });
-      });
-
-      colorPick.on("change.spectrum", (e, color) => {
-        const tag = $(this).text();
-        const col = color.toRgbString();
-        ipcSend("edit_tag", { tag, color: col });
-      });
-
-      colorPick.on("hide.spectrum", () => {
-        colorPick.spectrum("destroy");
-      });
       e.stopPropagation();
+      showColorpicker(
+        tagCol,
+        color => (t.style.backgroundColor = color.rgbString),
+        color => ipcSend("edit_tag", { tag, color: color.rgbString }),
+        () => (t.style.backgroundColor = tagCol)
+      );
     });
   } else {
     t.addEventListener("click", function(e) {

--- a/window_main/renderer-util.js
+++ b/window_main/renderer-util.js
@@ -3,6 +3,7 @@ const path = require("path");
 const { app, ipcRenderer: ipc, remote } = require("electron");
 const _ = require("lodash");
 const striptags = require("striptags");
+const Picker = require("vanilla-picker");
 
 const {
   CARD_TYPE_CODES,
@@ -776,6 +777,65 @@ function changeBackground(arg = "default", grpId = 0) {
     };
     xhr.send();
   }
+}
+
+//
+exports.showColorpicker = showColorpicker;
+function showColorpicker(
+  color,
+  onChange = () => {},
+  onDone = () => {},
+  onCancel = () => {},
+  pickerOptions = {}
+) {
+  const wrapper = $$(".dialog_wrapper")[0];
+  wrapper.style.opacity = 1;
+  wrapper.style.pointerEvents = "all";
+  wrapper.style.display = "block";
+
+  const dialog = $$(".dialog")[0];
+  dialog.innerHTML = "";
+  dialog.style.width = "260px";
+  dialog.style.height = "320px";
+  dialog.style.top = "calc(50% - 100px)";
+  dialog.addEventListener("mousedown", function(e) {
+    e.stopPropagation();
+  });
+
+  const closeDialog = () => {
+    wrapper.style.opacity = 0;
+    wrapper.style.pointerEvents = "none";
+
+    setTimeout(() => {
+      wrapper.style.display = "none";
+      dialog.style.width = "400px";
+      dialog.style.height = "160px";
+      dialog.style.top = "calc(50% - 80px)";
+    }, 250);
+  };
+
+  wrapper.addEventListener("mousedown", function() {
+    onCancel(color);
+    closeDialog();
+  });
+  // https://vanilla-picker.js.org/gen/Picker.html
+  new Picker({
+    alpha: false,
+    color,
+    parent: dialog,
+    popup: false,
+    onChange,
+    onDone: function(color) {
+      onDone(color);
+      closeDialog();
+    },
+    ...pickerOptions
+  });
+  const pickerWrapper = $$(".picker_wrapper")[0];
+  pickerWrapper.style.alignSelf = "center";
+  pickerWrapper.style.margin = "1px";
+  pickerWrapper.style.backgroundColor = "rgb(0,0,0,0)";
+  pickerWrapper.style.boxShadow = "none";
 }
 
 //

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -17,7 +17,6 @@ if (!remote.app.isPackaged) {
 }
 window.$ = window.jQuery = require("jquery");
 require("jquery.easing");
-require("spectrum-colorpicker");
 require("time-elements");
 
 const { HIDDEN_PW } = require("../shared/constants");

--- a/window_main/settings.js
+++ b/window_main/settings.js
@@ -30,7 +30,8 @@ const {
   addCheckbox,
   changeBackground,
   hideLoadingBars,
-  ipcSend
+  ipcSend,
+  showColorpicker
 } = require("./renderer-util");
 
 let lastSettingsSection = 1;
@@ -572,19 +573,23 @@ function appendVisual(section) {
     ["but_container_label"],
     "<span style='margin-right: 32px;'>Background shade:</span>"
   );
-  // TODO remove jQuery colorpicker
-  const colorPick = $('<input type="text" id="flat" class="color_picker" />');
-  colorPick.appendTo($(label));
-  colorPick.spectrum({
-    showInitial: true,
-    showAlpha: true,
-    showButtons: false
+  const colorPick = createInput(["color_picker"], "", {
+    id: "flat",
+    type: "text",
+    value: "Example Content"
   });
-  colorPick.spectrum("set", pd.settings.back_color);
-  colorPick.on("dragstop.spectrum", function(e, color) {
-    $(".main_wrapper").css("background-color", color.toRgbString());
-    updateUserSettings();
+  colorPick.style.backgroundColor = pd.settings.back_color;
+  colorPick.addEventListener("click", function(e) {
+    e.stopPropagation();
+    showColorpicker(
+      pd.settings.back_color,
+      color => (colorPick.style.backgroundColor = color.rgbaString),
+      color => updateUserSettingsBlend({ back_color: color.rgbaString }),
+      () => (colorPick.style.backgroundColor = pd.settings.back_color),
+      { alpha: true }
+    );
   });
+  label.appendChild(colorPick);
   section.appendChild(label);
 
   label = createLabel(["but_container_label"], "List style:");
@@ -817,14 +822,8 @@ function updateUserSettingsBlend(_settings = {}) {
     };
   });
 
-  // TODO remove jQuery colorpicker
-  const back_color = $(".color_picker")
-    .spectrum("get")
-    .toRgbString();
-
   ipcSend("save_user_settings", {
     anon_explore: byId("settings_anon_explore").checked,
-    back_color,
     back_url: byId("query_image").value || "default",
     close_on_match: byId("settings_closeonmatch").checked,
     close_to_tray: byId("settings_closetotray").checked,


### PR DESCRIPTION
### Motivation
Removing `jquery` from the main window process pages requires finding a replacement for our `jquery` Spectrum colorpicker.
https://github.com/Manuel-777/MTG-Arena-Tool/projects/2#card-22822431

This depends on #424, #425, #426, and #427. Most of the commits will disappear from the diff once the prerequisite PRs have been merged.

### Approach
This uses https://vanilla-picker.js.org/, which seems to have a similar set of features. It has no external dependency on `jquery`. Although it has its own default popup mode, I had the easiest time replacing the old colorpicker by embedding the new one in our dialog window.
- add dependency on `vanilla-picker`
- add `renderer-util.showColorpicker`
- replace `jquery.colorpicker` on Decks page, History page, and Settings page

### Demo
![image](https://user-images.githubusercontent.com/14894693/59714677-0d598200-91c7-11e9-9b82-a44a1155e018.png)
