### PR TITLE
Renderer no jquery

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Please read about [our Privacy Policy and How we use your data here](./PRIVACY.m
 
 [Conic Gradient Polyfill by Lea Verou](https://leaverou.github.io/conic-gradient/)
 
-[Spectrum color picker by Brian Grinstead](http://bgrins.github.io/spectrum/)
+[vanilla-picker by Andreas Borgen, Adam Brooks](https://vanilla-picker.js.org/)
 
 [Draft ranking by Magic Community Set Reviews](https://www.mtgcommunityreview.com/)
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ Please read about [our Privacy Policy and How we use your data here](./PRIVACY.m
 
 [Electron Store by Sindre Sorhus](https://github.com/sindresorhus/electron-store)
 
-[Jquery Easing by GSGD](http://gsgd.co.uk/sandbox/jquery/easing/)
-
 [Conic Gradient Polyfill by Lea Verou](https://leaverou.github.io/conic-gradient/)
 
 [vanilla-picker by Andreas Borgen, Adam Brooks](https://vanilla-picker.js.org/)

--- a/package-lock.json
+++ b/package-lock.json
@@ -5111,11 +5111,6 @@
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
       "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
     },
-    "jquery.easing": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jquery.easing/-/jquery.easing-1.4.1.tgz",
-      "integrity": "sha1-R5gsWDa9dY/UhJSSPEoQHvbpPjs="
-    },
     "js-sha1": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/js-sha1/-/js-sha1-0.6.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -590,6 +590,11 @@
       "integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
       "dev": true
     },
+    "animejs": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/animejs/-/animejs-3.0.1.tgz",
+      "integrity": "sha512-7mMoBQScvA7s4zm3EVgnuXXrtOu6TJNAhU+Ajo7HsXYH0NwbuZIcRHMO65a9NyUlmAXz4VPxlK5cENNOQbCi8g=="
+    },
     "ansi-align": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "MTG-Arena-Tool",
-  "version": "2.6.1",
+  "version": "2.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -438,6 +438,11 @@
         "@types/istanbul-reports": "^1.1.1",
         "@types/yargs": "^12.0.9"
       }
+    },
+    "@sphinxxxx/color-conversion": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@sphinxxxx/color-conversion/-/color-conversion-2.2.1.tgz",
+      "integrity": "sha512-5+ofCE09lF6C7DPSVyvQ2Nf0oaue3Cl+SosT45DYy5nhgUXsOq3TetArC1q8mVfAOjhG0WReQPPFBdc4xXVNkg=="
     },
     "@types/babel__core": {
       "version": "7.1.1",
@@ -1916,6 +1921,11 @@
       "integrity": "sha1-3vHxyl1gWdJKdm5YeULCEQbOEnU=",
       "dev": true
     },
+    "drag-tracker": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/drag-tracker/-/drag-tracker-1.0.0.tgz",
+      "integrity": "sha1-m9M9OAvDBW22m9Wzz24GL+xYvWQ="
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -2996,7 +3006,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3017,12 +3028,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3037,17 +3050,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3164,7 +3180,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3176,6 +3193,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3190,6 +3208,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3197,12 +3216,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3221,6 +3242,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3301,7 +3323,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3313,6 +3336,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3398,7 +3422,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3434,6 +3459,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3453,6 +3479,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3496,12 +3523,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -10121,11 +10150,6 @@
       "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==",
       "dev": true
     },
-    "spectrum-colorpicker": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/spectrum-colorpicker/-/spectrum-colorpicker-1.8.0.tgz",
-      "integrity": "sha1-uSbPUALAp3hgtfg1HhwJPGUgAQc="
-    },
     "speedometer": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz",
@@ -10247,7 +10271,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -10908,6 +10932,15 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "vanilla-picker": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/vanilla-picker/-/vanilla-picker-2.8.1.tgz",
+      "integrity": "sha512-mzjMw0WbeS6qi+wzXSCfHFL7Jmvp7sJfXq0FfOvUEAAnCI6cmgCUVJ+wpr2c3g+Gt9AypLpHks3oeIkX6nCM9A==",
+      "requires": {
+        "@sphinxxxx/color-conversion": "^2.2.1",
+        "drag-tracker": "^1.0.0"
       }
     },
     "verror": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "version": "node -p \"require('./package.json').version\""
   },
   "dependencies": {
+    "animejs": "^3.0.1",
     "async": "^2.6.1",
     "chart.js": "^2.8.0",
     "conf": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "gunzip-file": "^0.1.1",
     "howler": "^2.1.2",
     "jquery": "^3.4.1",
-    "jquery.easing": "^1.4.1",
     "js-sha1": "^0.6.0",
     "lodash": "^4.17.11",
     "mathjs": "^5.9.0",

--- a/package.json
+++ b/package.json
@@ -89,9 +89,9 @@
     "npm": "^6.9.0",
     "qs": "^6.7.0",
     "queue": "^4.5.1",
-    "spectrum-colorpicker": "^1.8.0",
     "striptags": "^3.1.1",
-    "time-elements": "^2.0.0"
+    "time-elements": "^2.0.0",
+    "vanilla-picker": "^2.8.1"
   },
   "devDependencies": {
     "acorn": "^6.1.1",

--- a/shared/card-hover.js
+++ b/shared/card-hover.js
@@ -16,10 +16,6 @@ exports.addCardHover = addCardHover;
 function addCardHover(element, card) {
   if (!card || !card.images || card.type == "Special") return;
 
-  if (element instanceof jQuery) {
-    element = element[0];
-  }
-
   element.addEventListener("mouseover", () => {
     $$(".loader, .main_hover").forEach(element => (element.style.opacity = 1));
 

--- a/shared/shared.css
+++ b/shared/shared.css
@@ -1,5 +1,3 @@
-@import "../node_modules/spectrum-colorpicker/spectrum.css";
-
 :root {
   --main-font-name:  'lato', sans-serif;
   --main-font-name-it:  'lato-italic', sans-serif;

--- a/window_main/collection.js
+++ b/window_main/collection.js
@@ -1,3 +1,4 @@
+const anime = require("animejs");
 const { remote, shell } = require("electron");
 const Menu = remote.Menu;
 const MenuItem = remote.MenuItem;
@@ -600,7 +601,12 @@ function exportCollection() {
 
 //
 function printStats() {
-  $(".moving_ux").animate({ left: "-100%" }, 250, "easeInOutCubic");
+  anime({
+    targets: ".moving_ux",
+    left: "-100%",
+    easing: "easeInOutCubic",
+    duration: 350
+  });
   let mainDiv = document.getElementById("ux_1");
   mainDiv.innerHTML = "";
   mainDiv.classList.remove("flex_item");
@@ -660,7 +666,12 @@ function printStats() {
   //
   $$(".back")[0].addEventListener("click", () => {
     changeBackground("default");
-    $(".moving_ux").animate({ left: "0px" }, 250, "easeInOutCubic");
+    anime({
+      targets: ".moving_ux",
+      left: 0,
+      easing: "easeInOutCubic",
+      duration: 350
+    });
   });
 }
 

--- a/window_main/collection.js
+++ b/window_main/collection.js
@@ -19,7 +19,8 @@ const {
 const {
   hideLoadingBars,
   changeBackground,
-  ipcSend
+  ipcSend,
+  resetMainContainer
 } = require("./renderer-util");
 
 let collectionPage = 0;
@@ -227,9 +228,7 @@ function openCollectionTab() {
   mainDiv = document.getElementById("ux_1");
   mainDiv.innerHTML = "";
   mainDiv.classList.remove("flex_item");
-  mainDiv = document.getElementById("ux_0");
-  mainDiv.innerHTML = "";
-  mainDiv.classList.remove("flex_item");
+  mainDiv = resetMainContainer();
 
   let div = createDivision(["inventory"]);
 

--- a/window_main/data-scroller.js
+++ b/window_main/data-scroller.js
@@ -24,21 +24,23 @@ class DataScroller {
 
     this.renderRows(loadMore || this.loadAmount);
 
-    const jCont = $(this.container);
     if (scrollTop) {
-      jCont.scrollTop(scrollTop);
+      this.container.scrollTop = scrollTop;
     }
-    jCont.off();
-    jCont.on("scroll", () => {
+    const handler = () => {
       const newLs = {};
-      const desiredHeight = Math.round(jCont.scrollTop() + jCont.innerHeight());
-      if (desiredHeight >= jCont[0].scrollHeight) {
+      const desiredHeight = Math.round(
+        this.container.scrollTop + this.container.offsetHeight
+      );
+      if (desiredHeight >= this.container.scrollHeight) {
         this.renderRows(this.loadAmount);
         newLs.lastDataIndex = this.dataIndex;
       }
-      newLs.lastScrollTop = jCont.scrollTop();
+      newLs.lastScrollTop = this.container.scrollTop;
       setLocalState(newLs);
-    });
+    };
+    this.container.addEventListener("scroll", handler);
+    setLocalState({ lastScrollHandler: handler });
   }
 
   renderRows(loadMore) {

--- a/window_main/deck-details.js
+++ b/window_main/deck-details.js
@@ -1,3 +1,5 @@
+const anime = require("animejs");
+
 const { MANA, CARD_RARITIES } = require("../shared/constants");
 const db = require("../shared/database");
 const pd = require("../shared/player-data");
@@ -288,8 +290,12 @@ function openDeck(deck = currentOpenDeck, filters = currentFilters) {
 
   $$(".back")[0].addEventListener("click", () => {
     changeBackground("default");
-    // TODO find alternative to jQuery animate
-    $(".moving_ux").animate({ left: "0px" }, 250, "easeInOutCubic");
+    anime({
+      targets: ".moving_ux",
+      left: 0,
+      easing: "easeInOutCubic",
+      duration: 350
+    });
   });
 }
 

--- a/window_main/decks.js
+++ b/window_main/decks.js
@@ -22,7 +22,8 @@ const {
   hideLoadingBars,
   ipcSend,
   makeResizable,
-  setLocalState
+  setLocalState,
+  showColorpicker
 } = require("./renderer-util");
 
 const byId = id => document.getElementById(id);
@@ -259,35 +260,13 @@ function createTag(div, deckId, tag, showClose = true) {
 
   if (tag) {
     t.addEventListener("click", function(e) {
-      // TODO remove jquery colorpicker
-      const colorPick = $(t);
-      colorPick.spectrum({
-        showInitial: true,
-        showAlpha: false,
-        showButtons: false
-      });
-      colorPick.spectrum("set", tagCol);
-      colorPick.spectrum("show");
-
-      colorPick.on("move.spectrum", (e, color) => {
-        const tag = $(this).text();
-        const col = color.toRgbString();
-        $(".deck_tag").each((index, obj) => {
-          if (tag !== $(obj).text()) return;
-          $(obj).css("background-color", col);
-        });
-      });
-
-      colorPick.on("change.spectrum", (e, color) => {
-        const tag = $(this).text();
-        const col = color.toRgbString();
-        ipcSend("edit_tag", { tag, color: col });
-      });
-
-      colorPick.on("hide.spectrum", () => {
-        colorPick.spectrum("destroy");
-      });
       e.stopPropagation();
+      showColorpicker(
+        tagCol,
+        color => (t.style.backgroundColor = color.rgbString),
+        color => ipcSend("edit_tag", { tag, color: color.rgbString }),
+        () => (t.style.backgroundColor = tagCol)
+      );
     });
   } else {
     t.addEventListener("click", function(e) {

--- a/window_main/decks.js
+++ b/window_main/decks.js
@@ -22,11 +22,11 @@ const {
   hideLoadingBars,
   ipcSend,
   makeResizable,
+  resetMainContainer,
   setLocalState,
   showColorpicker
 } = require("./renderer-util");
 
-const byId = id => document.getElementById(id);
 let filters = Aggregator.getDefaultFilters();
 filters.onlyCurrentDecks = true;
 const tagPrompt = "Add";
@@ -52,9 +52,8 @@ function setFilters(selected = {}) {
 function openDecksTab(_filters = {}, scrollTop = 0) {
   hideLoadingBars();
   const ls = getLocalState();
-  const mainDiv = byId("ux_0");
+  const mainDiv = resetMainContainer();
   mainDiv.classList.add("flex_item");
-  mainDiv.innerHTML = "";
   setFilters(_filters);
 
   const wrap_r = createDiv(["wrapper_column", "sidebar_column_l"]);

--- a/window_main/decks.js
+++ b/window_main/decks.js
@@ -1,4 +1,5 @@
 const _ = require("lodash");
+const anime = require("animejs");
 
 const { MANA, CARD_RARITIES } = require("../shared/constants");
 const pd = require("../shared/player-data");
@@ -248,8 +249,12 @@ function openDeckCallback(id, filters) {
   const deck = pd.deck(id);
   if (!deck) return;
   openDeck(deck, { ...filters, deckId: id });
-  // TODO remove jquery.easing
-  $(".moving_ux").animate({ left: "-100%" }, 250, "easeInOutCubic");
+  anime({
+    targets: ".moving_ux",
+    left: "-100%",
+    easing: "easeInOutCubic",
+    duration: 350
+  });
 }
 
 function createTag(div, deckId, tag, showClose = true) {

--- a/window_main/economy.js
+++ b/window_main/economy.js
@@ -179,12 +179,6 @@ function renderData(container, index) {
   container.appendChild(div);
   rowsAdded++;
 
-  $(".list_economy_awarded").on("mousewheel", function(e) {
-    var delta = parseInt(e.originalEvent.deltaY) / 40;
-    this.scrollLeft += delta;
-    e.preventDefault();
-  });
-
   return rowsAdded;
 }
 
@@ -300,6 +294,10 @@ function createChangeRow(change, economyId) {
   // The next ~200 lines of code will add elements to these two containers
   var flexBottom = createDivision(["flex_bottom"]);
   var flexRight = createDivision(["tiny_scroll", "list_economy_awarded"]);
+  flexRight.addEventListener("mousewheel", function(e) {
+    this.scrollLeft += parseInt(e.deltaY / 2);
+    e.preventDefault();
+  });
 
   let checkGemsPaid = false;
   let checkGoldPaid = false;

--- a/window_main/economy.js
+++ b/window_main/economy.js
@@ -18,6 +18,7 @@ const DataScroller = require("./data-scroller");
 const {
   formatNumber,
   formatPercent,
+  resetMainContainer,
   toggleArchived
 } = require("./renderer-util");
 
@@ -132,7 +133,7 @@ function getPrettyContext(context, full = true) {
 }
 
 function openEconomyTab(dataIndex = 25, scrollTop = 0) {
-  const mainDiv = document.getElementById("ux_0");
+  const mainDiv = resetMainContainer();
   createEconomyUI(mainDiv);
   const dataScroller = new DataScroller(
     mainDiv,
@@ -735,9 +736,6 @@ function createEconomyUI(mainDiv) {
       dayList[daysago].vaultProgress += change.delta.vaultProgressDelta;
     }
   }
-
-  mainDiv.classList.remove("flex_item");
-  mainDiv.innerHTML = "";
 
   let div = createDivision(["list_economy_top", "flex_item"]);
 

--- a/window_main/events.js
+++ b/window_main/events.js
@@ -18,6 +18,7 @@ const StatsPanel = require("./stats-panel");
 const {
   getEventWinLossClass,
   getLocalState,
+  resetMainContainer,
   toggleArchived
 } = require("./renderer-util");
 const { openMatch } = require("./match-details");
@@ -28,9 +29,7 @@ let filteredMatches;
 let sortedEvents;
 
 function openEventsTab(_filters, dataIndex = 25, scrollTop = 0) {
-  const mainDiv = document.getElementById("ux_0");
-  mainDiv.classList.remove("flex_item");
-  mainDiv.innerHTML = "";
+  const mainDiv = resetMainContainer();
   const d = createDivision(["list_fill"]);
   mainDiv.appendChild(d);
 

--- a/window_main/events.js
+++ b/window_main/events.js
@@ -1,3 +1,5 @@
+const anime = require("animejs");
+
 const { MANA } = require("../shared/constants");
 const pd = require("../shared/player-data");
 const { createDivision, queryElementsByClass } = require("../shared/dom-fns");
@@ -293,7 +295,12 @@ function createMatchRow(match) {
 
 function handleOpenMatch(id) {
   openMatch(id);
-  $(".moving_ux").animate({ left: "-100%" }, 250, "easeInOutCubic");
+  anime({
+    targets: ".moving_ux",
+    left: "-100%",
+    easing: "easeInOutCubic",
+    duration: 350
+  });
 }
 
 // This code is executed when an event row is clicked and adds

--- a/window_main/explore.js
+++ b/window_main/explore.js
@@ -259,15 +259,15 @@ function drawFilters() {
    *  Only owned filter
    **/
   let lab = addCheckbox(
-    $(buttonsMiddle),
+    buttonsMiddle,
     "Only owned",
     "settings_owned",
     onlyOwned,
     () => null
   );
-  lab.css("align-self", "center");
-  lab.css("margin-left", "0px");
-  lab.css("margin-right", "32px");
+  lab.style.alignSelf = "center";
+  lab.style.marginLeft = 0;
+  lab.style.marginRight = "32px";
 
   /**
    * Wildcards filters
@@ -297,63 +297,59 @@ function drawFilters() {
   /**
    *  Mana filter
    **/
-  var manas = $('<div class="mana_filters_explore"></div>');
+  const manas = createDivision(["mana_filters_explore"]);
   COLORS_BRIEF.forEach(function(s, i) {
-    var mi = [1, 2, 3, 4, 5];
-    var mf = "";
+    const mi = [1, 2, 3, 4, 5];
+    let mf = "";
     if (!inputMana.includes(mi[i])) {
       mf = "mana_filter_on";
     }
-    var manabutton = $(
-      `<div class="mana_filter ${mf}" style="background-image: url(../images/${s}20.png)"></div>`
-    );
-    manabutton.appendTo(manas);
-    manabutton.click(function() {
-      if (manabutton.hasClass("mana_filter_on")) {
-        manabutton.removeClass("mana_filter_on");
+    const manabutton = createDivision(["mana_filter", mf]);
+    manabutton.style.backgroundImage = "url(../images/${s}20.png)";
+    manabutton.addEventListener("click", function() {
+      if ([...manabutton.classList].includes("mana_filter_on")) {
+        manabutton.classList.remove("mana_filter_on");
         inputMana.push(mi[i]);
       } else {
-        manabutton.addClass("mana_filter_on");
+        manabutton.classList.add("mana_filter_on");
         let n = inputMana.indexOf(mi[i]);
         if (n > -1) {
           inputMana.splice(n, 1);
         }
       }
     });
+    manas.appendChild(manabutton);
   });
-  manas.appendTo(buttonsBottom);
+  buttonsBottom.appendChild(manas);
 
   /**
    *  Rank filter
    **/
   if (inputFilterType !== "Events") {
-    var ranks_filters = $('<div class="mana_filters_explore"></div>');
+    const ranks_filters = createDivision(["mana_filters_explore"]);
     RANKS.forEach(function(rr, index) {
-      var mf = "";
+      let mf = "";
       if (!inputRanks.includes(rr)) {
         mf = "rank_filter_on";
       }
-      var rankbutton = $(
-        `<div title="${rr}" class="rank_filter ${mf}" style="background-position: ${(index +
-          1) *
-          -16}px 0px; background-image: url(../images/ranks_16.png)"></div>`
-      );
-
-      rankbutton.appendTo(ranks_filters);
-      rankbutton.click(function() {
-        if (rankbutton.hasClass("rank_filter_on")) {
-          rankbutton.removeClass("rank_filter_on");
+      const rankbutton = createDivision(["rank_filter", mf], "", { title: rr });
+      rankbutton.style.backgroundPosition = (index + 1) * -16 + "px 0px";
+      rankbutton.style.backgroundImage = "url(../images/ranks_16.png)";
+      rankbutton.addEventListener("click", function() {
+        if ([...rankbutton.classList].includes("rank_filter_on")) {
+          rankbutton.classList.remove("rank_filter_on");
           inputRanks.push(rr);
         } else {
-          rankbutton.addClass("rank_filter_on");
+          rankbutton.classList.add("rank_filter_on");
           let n = inputRanks.indexOf(rr);
           if (n > -1) {
             inputRanks.splice(n, 1);
           }
         }
       });
+      ranks_filters.appendChild(rankbutton);
     });
-    ranks_filters.appendTo(buttonsBottom);
+    buttonsBottom.appendChild(ranks_filters);
   }
 
   /**
@@ -680,17 +676,17 @@ function deckLoad(_deck, index) {
 
   mainDiv.appendChild(div);
 
-  $("." + index).on("mouseenter", function() {
-    $("." + index + "t").css("opacity", 1);
-    $("." + index + "t").css("width", "200px");
+  div.addEventListener("mouseenter", function() {
+    tile.style.opacity = 1;
+    tile.style.width = "200px";
   });
 
-  $("." + index).on("mouseleave", function() {
-    $("." + index + "t").css("opacity", 0.66);
-    $("." + index + "t").css("width", "128px");
+  div.addEventListener("mouseleave", function() {
+    tile.style.opacity = 0.66;
+    tile.style.width = "128px";
   });
 
-  $("." + index).on("click", function() {
+  div.addEventListener("click", function() {
     _deck.mainDeck = removeDuplicates(_deck.mainDeck).sort(compare_cards);
     _deck.sideboard = removeDuplicates(_deck.sideboard).sort(compare_cards);
     openDeck(_deck, null);

--- a/window_main/explore.js
+++ b/window_main/explore.js
@@ -1,4 +1,5 @@
 const _ = require("lodash");
+const anime = require("animejs");
 
 const {
   CARD_RARITIES,
@@ -693,7 +694,12 @@ function deckLoad(_deck, index) {
     _deck.mainDeck = removeDuplicates(_deck.mainDeck).sort(compare_cards);
     _deck.sideboard = removeDuplicates(_deck.sideboard).sort(compare_cards);
     openDeck(_deck, null);
-    $(".moving_ux").animate({ left: "-100%" }, 250, "easeInOutCubic");
+    anime({
+      targets: ".moving_ux",
+      left: "-100%",
+      easing: "easeInOutCubic",
+      duration: 350
+    });
   });
 }
 

--- a/window_main/explore.js
+++ b/window_main/explore.js
@@ -26,6 +26,7 @@ const {
   getWinrateClass,
   hideLoadingBars,
   ipcSend,
+  resetMainContainer,
   setLocalState,
   showLoadingBars
 } = require("./renderer-util");
@@ -68,11 +69,8 @@ function openExploreTab() {
     setLocalState({ exploreData });
   }
 
-  const mainDiv = document.getElementById("ux_0");
+  const mainDiv = resetMainContainer();
   let d;
-
-  mainDiv.classList.remove("flex_item");
-  mainDiv.innerHTML = "";
 
   let divFill = document.createElement("div");
   divFill.classList.add("list_fill");
@@ -120,8 +118,7 @@ function openExploreTab() {
     queryExplore();
   }
 
-  $(mainDiv).off();
-  $(mainDiv).on("scroll", () => {
+  const handler = () => {
     const { exploreData } = getLocalState();
     // do not spam server after reaching end of results
     if (exploreData.results_terminated) return;
@@ -131,7 +128,9 @@ function openExploreTab() {
     ) {
       queryExplore();
     }
-  });
+  };
+  mainDiv.addEventListener("scroll", handler);
+  setLocalState({ lastScrollHandler: handler });
 }
 
 function getEventPrettyName(event) {

--- a/window_main/history.js
+++ b/window_main/history.js
@@ -29,6 +29,7 @@ const {
   ipcSend,
   makeResizable,
   openDraft,
+  resetMainContainer,
   showColorpicker,
   showLoadingBars,
   toggleArchived
@@ -75,8 +76,7 @@ function setFilters(selected = {}) {
 }
 
 function openHistoryTab(_filters = {}, dataIndex = 25, scrollTop = 0) {
-  const mainDiv = byId("ux_0");
-  mainDiv.innerHTML = "";
+  const mainDiv = resetMainContainer();
   mainDiv.classList.add("flex_item");
 
   sortedHistory = [...pd.history];

--- a/window_main/history.js
+++ b/window_main/history.js
@@ -29,6 +29,7 @@ const {
   ipcSend,
   makeResizable,
   openDraft,
+  showColorpicker,
   showLoadingBars,
   toggleArchived
 } = require("./renderer-util");
@@ -450,35 +451,13 @@ function createTag(div, matchId, tags, tag, showClose = true) {
 
   if (tag) {
     t.addEventListener("click", function(e) {
-      // TODO remove jquery colorpicker
-      const colorPick = $(t);
-      colorPick.spectrum({
-        showInitial: true,
-        showAlpha: false,
-        showButtons: false
-      });
-      colorPick.spectrum("set", tagCol);
-      colorPick.spectrum("show");
-
-      colorPick.on("move.spectrum", (e, color) => {
-        const tag = $(this).text();
-        const col = color.toRgbString();
-        $(".deck_tag").each((index, obj) => {
-          if (tag !== $(obj).text()) return;
-          $(obj).css("background-color", col);
-        });
-      });
-
-      colorPick.on("change.spectrum", (e, color) => {
-        const tag = $(this).text();
-        const col = color.toRgbString();
-        ipcSend("edit_tag", { tag, color: col });
-      });
-
-      colorPick.on("hide.spectrum", () => {
-        colorPick.spectrum("destroy");
-      });
       e.stopPropagation();
+      showColorpicker(
+        tagCol,
+        color => (t.style.backgroundColor = color.rgbString),
+        color => ipcSend("edit_tag", { tag, color: color.rgbString }),
+        () => (t.style.backgroundColor = tagCol)
+      );
     });
   } else {
     t.addEventListener("click", function(e) {

--- a/window_main/history.js
+++ b/window_main/history.js
@@ -1,3 +1,5 @@
+const anime = require("animejs");
+
 const autocomplete = require("../shared/autocomplete");
 const { MANA, RANKS } = require("../shared/constants");
 const db = require("../shared/database");
@@ -231,14 +233,22 @@ function renderData(container, index) {
 
 function handleOpenMatch(id) {
   openMatch(id);
-  // TODO find alternative to jQuery animate
-  $(".moving_ux").animate({ left: "-100%" }, 250, "easeInOutCubic");
+  anime({
+    targets: ".moving_ux",
+    left: "-100%",
+    easing: "easeInOutCubic",
+    duration: 350
+  });
 }
 
 function handleOpenDraft(id) {
   openDraft(id);
-  // TODO find alternative to jQuery animate
-  $(".moving_ux").animate({ left: "-100%" }, 250, "easeInOutCubic");
+  anime({
+    targets: ".moving_ux",
+    left: "-100%",
+    easing: "easeInOutCubic",
+    duration: 350
+  });
 }
 
 function attachMatchData(listItem, match) {

--- a/window_main/home.js
+++ b/window_main/home.js
@@ -5,7 +5,12 @@ const { queryElements: $$, createDivision } = require("../shared/dom-fns");
 const { addCardHover } = require("../shared/card-hover");
 const { toHHMMSS, toDDHHMMSS, timestamp } = require("../shared/util");
 const { tournamentCreate } = require("./tournaments");
-const { getLocalState, ipcSend, showLoadingBars } = require("./renderer-util");
+const {
+  getLocalState,
+  ipcSend,
+  resetMainContainer,
+  showLoadingBars
+} = require("./renderer-util");
 
 let usersActive;
 let tournaments_list;
@@ -29,9 +34,7 @@ function requestHome() {
 // Should separate these two into smaller functions
 function openHomeTab(arg, opentab = true) {
   const ls = getLocalState();
-  let mainDiv = document.getElementById("ux_0");
-  mainDiv.classList.remove("flex_item");
-  mainDiv.innerHTML = "";
+  const mainDiv = resetMainContainer();
 
   if (arg) {
     tournaments_list = arg.tournaments;

--- a/window_main/match-details.js
+++ b/window_main/match-details.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const path = require("path");
+const anime = require("animejs");
 
 const { MANA } = require("../shared/constants");
 const db = require("../shared/database");
@@ -340,8 +341,12 @@ function openMatch(id) {
 
   $$(".back")[0].addEventListener("click", () => {
     changeBackground("default");
-    // TODO find alternative to jQuery animate
-    $(".moving_ux").animate({ left: "0px" }, 250, "easeInOutCubic");
+    anime({
+      targets: ".moving_ux",
+      left: 0,
+      easing: "easeInOutCubic",
+      duration: 350
+    });
   });
 }
 

--- a/window_main/renderer-util.js
+++ b/window_main/renderer-util.js
@@ -3,6 +3,7 @@ const path = require("path");
 const { app, ipcRenderer: ipc, remote } = require("electron");
 const _ = require("lodash");
 const striptags = require("striptags");
+const Picker = require("vanilla-picker");
 
 const {
   CARD_TYPE_CODES,
@@ -776,6 +777,65 @@ function changeBackground(arg = "default", grpId = 0) {
     };
     xhr.send();
   }
+}
+
+//
+exports.showColorpicker = showColorpicker;
+function showColorpicker(
+  color,
+  onChange = () => {},
+  onDone = () => {},
+  onCancel = () => {},
+  pickerOptions = {}
+) {
+  const wrapper = $$(".dialog_wrapper")[0];
+  wrapper.style.opacity = 1;
+  wrapper.style.pointerEvents = "all";
+  wrapper.style.display = "block";
+
+  const dialog = $$(".dialog")[0];
+  dialog.innerHTML = "";
+  dialog.style.width = "260px";
+  dialog.style.height = "320px";
+  dialog.style.top = "calc(50% - 100px)";
+  dialog.addEventListener("mousedown", function(e) {
+    e.stopPropagation();
+  });
+
+  const closeDialog = () => {
+    wrapper.style.opacity = 0;
+    wrapper.style.pointerEvents = "none";
+
+    setTimeout(() => {
+      wrapper.style.display = "none";
+      dialog.style.width = "400px";
+      dialog.style.height = "160px";
+      dialog.style.top = "calc(50% - 80px)";
+    }, 250);
+  };
+
+  wrapper.addEventListener("mousedown", function() {
+    onCancel(color);
+    closeDialog();
+  });
+  // https://vanilla-picker.js.org/gen/Picker.html
+  new Picker({
+    alpha: false,
+    color,
+    parent: dialog,
+    popup: false,
+    onChange,
+    onDone: function(color) {
+      onDone(color);
+      closeDialog();
+    },
+    ...pickerOptions
+  });
+  const pickerWrapper = $$(".picker_wrapper")[0];
+  pickerWrapper.style.alignSelf = "center";
+  pickerWrapper.style.margin = "1px";
+  pickerWrapper.style.backgroundColor = "rgb(0,0,0,0)";
+  pickerWrapper.style.boxShadow = "none";
 }
 
 //

--- a/window_main/renderer-util.js
+++ b/window_main/renderer-util.js
@@ -2,6 +2,7 @@ const fs = require("fs");
 const path = require("path");
 const { app, ipcRenderer: ipc, remote } = require("electron");
 const _ = require("lodash");
+const anime = require("animejs");
 const striptags = require("striptags");
 const Picker = require("vanilla-picker");
 
@@ -665,8 +666,12 @@ function openDraft(id, draftPosition = 1) {
 
   $$(".back")[0].addEventListener("click", () => {
     changeBackground("default");
-    // TODO find alternative to jQuery animate
-    $(".moving_ux").animate({ left: "0px" }, 250, "easeInOutCubic");
+    anime({
+      targets: ".moving_ux",
+      left: 0,
+      easing: "easeInOutCubic",
+      duration: 350
+    });
   });
 }
 
@@ -679,8 +684,12 @@ function openActionLog(actionLogId) {
   const top = createDiv(["decklist_top"]);
   const backButton = createDiv(["button", "back"]);
   backButton.addEventListener("click", () => {
-    // TODO remove jquery.easing
-    $(".moving_ux").animate({ left: "-100%" }, 250, "easeInOutCubic");
+    anime({
+      targets: ".moving_ux",
+      left: "-100%",
+      easing: "easeInOutCubic",
+      duration: 350
+    });
   });
   top.appendChild(backButton);
   top.appendChild(createDiv(["deck_name"], "Action Log"));
@@ -717,8 +726,12 @@ function openActionLog(actionLogId) {
     obj.title = db.abilities[grpId] || "";
   });
 
-  // TODO remove jquery.easing
-  $(".moving_ux").animate({ left: "-200%" }, 250, "easeInOutCubic");
+  anime({
+    targets: ".moving_ux",
+    left: "-200%",
+    easing: "easeInOutCubic",
+    duration: 350
+  });
 }
 
 //

--- a/window_main/renderer-util.js
+++ b/window_main/renderer-util.js
@@ -44,6 +44,7 @@ const localState = {
   authToken: "",
   discordTag: null,
   lastDataIndex: 0,
+  lastScrollHandler: null,
   lastScrollTop: 0,
   exploreData: null
 };
@@ -159,6 +160,20 @@ function makeResizable(div, resizeCallback, finalCallback) {
     },
     false
   );
+}
+
+//
+exports.resetMainContainer = resetMainContainer;
+function resetMainContainer() {
+  const container = byId("ux_0");
+  container.innerHTML = "";
+  container.classList.remove("flex_item");
+  const { lastScrollHandler } = getLocalState();
+  if (lastScrollHandler) {
+    container.removeEventListener("scroll", lastScrollHandler);
+    setLocalState({ lastScrollHandler: null });
+  }
+  return container;
 }
 
 //

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -17,7 +17,6 @@ if (!remote.app.isPackaged) {
 }
 window.$ = window.jQuery = require("jquery");
 require("jquery.easing");
-require("spectrum-colorpicker");
 require("time-elements");
 
 const { HIDDEN_PW } = require("../shared/constants");

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -39,6 +39,7 @@ const {
   hideLoadingBars,
   ipcSend,
   pop,
+  resetMainContainer,
   setLocalState,
   showLoadingBars
 } = require("./renderer-util");
@@ -287,7 +288,7 @@ function openTab(tab, filters = {}, dataIndex = 0, scrollTop = 0) {
   showLoadingBars();
   $$(".top_nav_item").forEach(el => el.classList.remove("item_selected"));
   let tabClass = "it" + tab;
-  byId("ux_0").innerHTML = "";
+  resetMainContainer();
   switch (tab) {
     case 0:
       openDecksTab(filters, scrollTop);

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -15,6 +15,8 @@ if (!remote.app.isPackaged) {
   });
   require("devtron").install();
 }
+const anime = require("animejs");
+
 window.$ = window.jQuery = require("jquery");
 require("jquery.easing");
 require("time-elements");
@@ -190,8 +192,12 @@ ipc.on("set_explore_decks", function(event, arg) {
 
 //
 ipc.on("open_course_deck", function(event, arg) {
-  // TODO remove jquery.easing
-  $(".moving_ux").animate({ left: "-100%" }, 250, "easeInOutCubic");
+  anime({
+    targets: ".moving_ux",
+    left: "-100%",
+    easing: "easeInOutCubic",
+    duration: 350
+  });
   arg = arg.CourseDeck;
   arg.colors = get_deck_colors(arg);
   arg.mainDeck.sort(compare_cards);
@@ -474,8 +480,12 @@ ipc.on("popup", function(event, arg, time) {
 //
 function force_open_settings(section = -1) {
   sidebarActive = 6;
-  // TODO remove jquery.easing
-  $(".moving_ux").animate({ left: "0px" }, 250, "easeInOutCubic");
+  anime({
+    targets: ".moving_ux",
+    left: 0,
+    easing: "easeInOutCubic",
+    duration: 350
+  });
   $$(".top_nav_item").forEach(el => el.classList.remove("item_selected"));
   openSettingsTab(section, 0);
 }
@@ -483,8 +493,12 @@ function force_open_settings(section = -1) {
 //
 function force_open_about() {
   sidebarActive = 9;
-  // TODO remove jquery.easing
-  $(".moving_ux").animate({ left: "0px" }, 250, "easeInOutCubic");
+  anime({
+    targets: ".moving_ux",
+    left: 0,
+    easing: "easeInOutCubic",
+    duration: 350
+  });
   $$(".top_nav_item").forEach(el => el.classList.remove("item_selected"));
   openSettingsTab(5, 0);
 }
@@ -583,8 +597,12 @@ ready(function() {
       document.body.style.cursor = "auto";
       const classList = [...this.classList];
       if (!classList.includes("item_selected")) {
-        // TODO remove jquery.easing
-        $(".moving_ux").animate({ left: "0px" }, 250, "easeInOutCubic");
+        anime({
+          targets: ".moving_ux",
+          left: 0,
+          easing: "easeInOutCubic",
+          duration: 350
+        });
         let filters = {};
         if (classList.includes("ith")) {
           sidebarActive = -1;
@@ -621,8 +639,12 @@ ready(function() {
         }
         openTab(sidebarActive, filters);
       } else {
-        // TODO remove jquery.easing
-        $(".moving_ux").animate({ left: "0px" }, 250, "easeInOutCubic");
+        anime({
+          targets: ".moving_ux",
+          left: 0,
+          easing: "easeInOutCubic",
+          duration: 350
+        });
       }
     });
   });
@@ -644,6 +666,10 @@ ipc.on("set_draft_link", function(event, arg) {
 ipc.on("tou_set", function(event, arg) {
   document.body.style.cursor = "auto";
   tournamentOpen(arg);
-  // TODO remove jquery.easing
-  $(".moving_ux").animate({ left: "-100%" }, 250, "easeInOutCubic");
+  anime({
+    targets: ".moving_ux",
+    left: "-100%",
+    easing: "easeInOutCubic",
+    duration: 350
+  });
 });

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -16,9 +16,6 @@ if (!remote.app.isPackaged) {
   require("devtron").install();
 }
 const anime = require("animejs");
-
-window.$ = window.jQuery = require("jquery");
-require("jquery.easing");
 require("time-elements");
 
 const { HIDDEN_PW } = require("../shared/constants");

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -21,7 +21,11 @@ require("time-elements");
 
 const { HIDDEN_PW } = require("../shared/constants");
 const pd = require("../shared/player-data");
-const { queryElements: $$ } = require("../shared/dom-fns");
+const {
+  createDiv,
+  createInput,
+  queryElements: $$
+} = require("../shared/dom-fns");
 const {
   compare_cards,
   get_deck_colors,
@@ -56,6 +60,7 @@ const { openExploreTab, setExploreDecks } = require("./explore");
 const { openCollectionTab } = require("./collection");
 const { openSettingsTab, setCurrentOverlaySettings } = require("./settings");
 
+const byId = id => document.getElementById(id);
 let sidebarActive = -2;
 let loggedIn = false;
 let canLogin = false;
@@ -63,15 +68,15 @@ let lastSettings = {};
 
 //
 ipc.on("clear_pwd", function() {
-  document.getElementById("signin_pass").value = "";
+  byId("signin_pass").value = "";
 });
 
 //
 ipc.on("auth", function(event, arg) {
   setLocalState({ authToken: arg.token });
   if (arg.ok) {
-    $(".message_center").css("display", "flex");
-    $(".authenticate").hide();
+    $$(".message_center")[0].style.display = "flex";
+    $$(".authenticate")[0].style.display = "none";
     loggedIn = true;
   } else {
     canLogin = true;
@@ -95,11 +100,12 @@ ipc.on("too_slow", function() {
     0
   );
 
-  $(".popup").css("left", "calc(50% - 280px)");
-  $(".popup").css("width", "560px");
-  $(".popup").css("pointer-events", "all");
+  const popDiv = $$(".popup")[0];
+  popDiv.style.left = "calc(50% - 280px)";
+  popDiv.style.width = "560px";
+  popDiv.style.pointerEvents = "all";
 
-  $(".trouble_link").click(function() {
+  $$(".trouble_link")[0].addEventListener("click", function() {
     shell.openExternal(
       "https://github.com/Manuel-777/MTG-Arena-Tool/blob/master/TROUBLESHOOTING.md"
     );
@@ -114,18 +120,19 @@ ipc.on("show_login", () => {
 
 //
 function showLogin() {
-  $(".authenticate").show();
-  $(".message_center").css("display", "none");
-  $(".init_loading").hide();
-  $(".button_simple_disabled").addClass("button_simple");
-  $("#signin_user").focus();
+  $$(".authenticate")[0].style.display = "block";
+  $$(".message_center")[0].style.display = "none";
+  $$(".init_loading")[0].style.display = "none";
+
+  $$(".button_simple_disabled")[0].classList.add("button_simple");
+  byId("signin_user").focus();
 }
 
 //
 ipc.on("player_data_updated", () => {
   if (sidebarActive != -99) {
-    $(".top_username").html(pd.name.slice(0, -6));
-    $(".top_username_id").html(pd.name.slice(-6));
+    $$(".top_username")[0].innerHTML = pd.name.slice(0, -6);
+    $$(".top_username_id")[0].innerHTML = pd.name.slice(-6);
 
     let rankOffset;
     let constructed = pd.rank.constructed;
@@ -182,6 +189,7 @@ ipc.on("set_explore_decks", function(event, arg) {
 
 //
 ipc.on("open_course_deck", function(event, arg) {
+  // TODO remove jquery.easing
   $(".moving_ux").animate({ left: "-100%" }, 250, "easeInOutCubic");
   arg = arg.CourseDeck;
   arg.colors = get_deck_colors(arg);
@@ -200,7 +208,7 @@ ipc.on("settings_updated", function() {
   if (lastSettings.back_url !== pd.settings.back_url) {
     changeBackground();
   }
-  $(".main_wrapper").css("background-color", pd.settings.back_color);
+  $$(".main_wrapper")[0].style.backgroundColor = pd.settings.back_color;
   if (sidebarActive === 6) {
     const ls = getLocalState();
     openSettingsTab(-1, ls.lastScrollTop);
@@ -223,20 +231,24 @@ ipc.on("set_update_state", function(event, arg) {
 
 //
 ipc.on("show_notification", function(event, arg) {
-  $(".notification").show();
-  $(".notification").attr("title", arg);
+  const notification = $$(".notification")[0];
+  notification.style.display = "block";
+  notification.title = arg;
 
-  if (arg == "Update available" || arg == "Update downloaded") {
-    $(".notification").click(function() {
+  if (arg === "Update available" || arg === "Update downloaded") {
+    const handler = () => {
       force_open_about();
-    });
+      notification.removeEventListener("click", handler);
+    };
+    notification.addEventListener("click", handler);
   }
 });
 
 //
 ipc.on("hide_notification", function() {
-  $(".notification").hide();
-  $(".notification").attr("title", "");
+  const notification = $$(".notification")[0];
+  notification.style.display = "none";
+  notification.title = "";
 });
 
 //
@@ -257,15 +269,15 @@ ipc.on("force_open_about", function() {
 
 //
 ipc.on("prefill_auth_form", function(event, arg) {
-  document.getElementById("rememberme").checked = arg.remember_me;
-  document.getElementById("signin_user").value = arg.username;
-  document.getElementById("signin_pass").value = arg.password;
+  byId("rememberme").checked = arg.remember_me;
+  byId("signin_user").value = arg.username;
+  byId("signin_pass").value = arg.password;
 });
 
 //
 function rememberMe() {
   const rSettings = {
-    remember_me: document.getElementById("rememberme").checked
+    remember_me: byId("rememberme").checked
   };
   ipcSend("save_app_settings", rSettings);
 }
@@ -273,11 +285,9 @@ function rememberMe() {
 //
 function openTab(tab, filters = {}, dataIndex = 0, scrollTop = 0) {
   showLoadingBars();
-  $(".top_nav_item").each(function() {
-    $(this).removeClass("item_selected");
-  });
+  $$(".top_nav_item").forEach(el => el.classList.remove("item_selected"));
   let tabClass = "it" + tab;
-  $("#ux_0").html("");
+  byId("ux_0").innerHTML = "";
   switch (tab) {
     case 0:
       openDecksTab(filters, scrollTop);
@@ -302,6 +312,7 @@ function openTab(tab, filters = {}, dataIndex = 0, scrollTop = 0) {
       openCollectionTab();
       break;
     case 6:
+      tabClass = "ith";
       openSettingsTab(-1, scrollTop);
       break;
     case -1:
@@ -318,12 +329,12 @@ function openTab(tab, filters = {}, dataIndex = 0, scrollTop = 0) {
       break;
     case -2:
     default:
-      //$(".message_center").css("display", "initial");
+      // $$(".message_center")[0].style.display = "initial";
       hideLoadingBars();
-      $(".init_loading").show();
+      $$(".init_loading")[0].style.display = "block";
       break;
   }
-  $("." + tabClass).addClass("item_selected");
+  $$("." + tabClass)[0].classList.add("item_selected");
   ipcSend("save_user_settings", { last_open_tab: tab });
 }
 
@@ -331,8 +342,8 @@ function openTab(tab, filters = {}, dataIndex = 0, scrollTop = 0) {
 ipc.on("initialize", function() {
   showLoadingBars();
   if (pd.name) {
-    $(".top_username").html(pd.name.slice(0, -6));
-    $(".top_username_id").html(pd.name.slice(-6));
+    $$(".top_username")[0].innerHTML = pd.name.slice(0, -6);
+    $$(".top_username_id")[0].innerHTML = pd.name.slice(-6);
   }
 
   sidebarActive = pd.settings.last_open_tab;
@@ -340,103 +351,96 @@ ipc.on("initialize", function() {
   setLocalState({ totalAgg });
   openTab(sidebarActive);
 
-  $(".top_nav").removeClass("hidden");
-  $(".overflow_ux").removeClass("hidden");
-  $(".message_center").css("display", "none");
-  $(".init_loading").hide();
+  $$(".top_nav")[0].classList.remove("hidden");
+  $$(".overflow_ux")[0].classList.remove("hidden");
+  $$(".message_center")[0].style.display = "none";
+  $$(".init_loading")[0].style.display = "none";
 });
 
 //
-var logDialogOpen = false;
+let logDialogOpen = false;
 ipc.on("no_log", function(event, arg) {
   if (loggedIn) {
-    $(".top_nav").addClass("hidden");
-    $(".overflow_ux").addClass("hidden");
-    $(".message_center").css("display", "flex");
-    $(".message_center").html(
+    $$(".top_nav")[0].classList.add("hidden");
+    $$(".overflow_ux")[0].classList.add("hidden");
+    $$(".message_center")[0].style.display = "flex";
+    $$(".message_center")[0].innerHTML =
       '<div class="message_big red">No Log Found</div><div class="message_sub_16 white">check if it exists at ' +
-        arg +
-        '</div><div class="message_sub_16 white">if it does, try closing MTG Arena and deleting it.</div>'
-    );
+      arg +
+      '</div><div class="message_sub_16 white">if it does, try closing MTG Arena and deleting it.</div>';
   } else if (!logDialogOpen) {
     logDialogOpen = true;
-    $(".dialog_wrapper").css("opacity", 1);
-    $(".dialog_wrapper").css("pointer-events", "all");
-    $(".dialog_wrapper").show();
-    $(".dialog").css("width", "600px");
-    $(".dialog").css("height", "200px");
-    $(".dialog").css("top", "calc(50% - 100px)");
+    $$(".dialog_wrapper")[0].style.opacity = 1;
+    $$(".dialog_wrapper")[0].style.pointerEvents = "all";
+    $$(".dialog_wrapper")[0].style.display = "block";
+    $$(".dialog")[0].style.width = "600px";
+    $$(".dialog")[0].style.height = "200px";
+    $$(".dialog")[0].style.top = "calc(50% - 100px)";
 
-    $(".dialog_wrapper").on("click", function() {
-      console.log(".dialog_wrapper on click");
+    $$(".dialog_wrapper")[0].addEventListener("click", function() {
+      // console.log(".dialog_wrapper on click");
       //e.stopPropagation();
-      $(".dialog_wrapper").css("opacity", 0);
-      $(".dialog_wrapper").css("pointer-events", "none");
-      setTimeout(function() {
-        logDialogOpen = false;
-        $(".dialog_wrapper").hide();
-        $(".dialog").css("width", "500px");
-        $(".dialog").css("height", "160px");
-        $(".dialog").css("top", "calc(50% - 80px)");
-      }, 250);
+      hideDialog();
     });
 
-    $(".dialog").on("click", function(e) {
+    $$(".dialog")[0].addEventListener("click", function(e) {
       e.stopPropagation();
-      console.log(".dialog on click");
+      // console.log(".dialog on click");
     });
 
-    var dialog = $(".dialog");
-    dialog.html("");
+    const dialog = $$(".dialog")[0];
+    dialog.innerHTML = "";
 
-    var cont = $('<div class="dialog_container"></div>');
-
-    cont.append(
-      '<div class="share_title">Enter output_log.txt location:</div>'
+    const cont = createDiv(["dialog_container"]);
+    cont.appendChild(
+      createDiv(["share_title"], "Enter output_log.txt location:")
     );
-    var icd = $('<div class="share_input_container"></div>');
-    var sin = $(
-      '<input style="border-radius: 3px; height: 28px;font-size: 14px;" id="log_input" autofocus autocomplete="off" value="' +
-        arg +
-        '" />'
-    );
-    var but = $('<div class="button_simple">Save</div>');
+    const icd = createDiv(["share_input_container"]);
+    const sin = createInput([], "", {
+      id: "log_input",
+      autofocus: true,
+      autocomplete: "off",
+      value: arg
+    });
+    sin.style.borderRadius = "3px";
+    sin.style.height = "28px";
+    sin.style.fontSize = "14px";
+    icd.appendChild(sin);
+    cont.appendChild(icd);
+    dialog.appendChild(cont);
 
-    sin.appendTo(icd);
-    icd.appendTo(cont);
-
-    cont.appendTo(dialog);
-    but.appendTo(dialog);
-
-    but.click(function() {
-      ipcSend("set_log", document.getElementById("log_input").value);
-      console.log(".dialog_wrapper on click");
+    const but = createDiv(["button_simple"], "Save");
+    but.addEventListener("click", function() {
+      ipcSend("set_log", byId("log_input").value);
+      // console.log(".dialog_wrapper on click");
       //e.stopPropagation();
-      $(".dialog_wrapper").css("opacity", 0);
-      $(".dialog_wrapper").css("pointer-events", "none");
-      setTimeout(function() {
-        logDialogOpen = false;
-        $(".dialog_wrapper").hide();
-        $(".dialog").css("width", "500px");
-        $(".dialog").css("height", "160px");
-        $(".dialog").css("top", "calc(50% - 80px)");
-      }, 250);
+      hideDialog();
     });
+    dialog.appendChild(but);
   }
 });
 
 //
 ipc.on("log_ok", function() {
   logDialogOpen = false;
-  $(".dialog_wrapper").css("opacity", 0);
-  $(".dialog_wrapper").css("pointer-events", "none");
-  setTimeout(function() {
-    $(".dialog_wrapper").hide();
-    $(".dialog").css("width", "500px");
-    $(".dialog").css("height", "160px");
-    $(".dialog").css("top", "calc(50% - 80px)");
-  }, 250);
+  hideDialog();
 });
+
+//
+let dialogTimeout = null;
+function hideDialog() {
+  $$(".dialog_wrapper")[0].style.opacity = 0;
+  $$(".dialog_wrapper")[0].style.pointerEvents = "none";
+  if (dialogTimeout) clearTimeout(dialogTimeout);
+  dialogTimeout = setTimeout(function() {
+    $$(".dialog_wrapper")[0].style.display = "none";
+    $$(".dialog")[0].style.width = "500px";
+    $$(".dialog")[0].style.height = "160px";
+    $$(".dialog")[0].style.top = "calc(50% - 80px)";
+    logDialogOpen = false;
+    dialogTimeout = null;
+  }, 250);
+}
 
 //
 ipc.on("offline", function() {
@@ -446,26 +450,19 @@ ipc.on("offline", function() {
 //
 function showOfflineSplash() {
   hideLoadingBars();
-  $("#ux_0").html(
-    '<div class="message_center" style="display: flex; position: fixed;"><div class="message_unlink"></div><div class="message_big red">Oops, you are offline!</div><div class="message_sub_16 white">You can <a class="signup_link">sign up</a> to access online features.</div></div>'
-  );
-  $(".signup_link").click(function() {
+  byId("ux_0").innerHTML =
+    '<div class="message_center" style="display: flex; position: fixed;"><div class="message_unlink"></div><div class="message_big red">Oops, you are offline!</div><div class="message_sub_16 white">You can <a class="signup_link">sign up</a> to access online features.</div></div>';
+  $$(".signup_link")[0].addEventListener("click", function() {
     shell.openExternal("https://mtgatool.com/signup/");
   });
 }
 
 //
 ipc.on("log_read", function() {
-  if ($(".top_nav").hasClass("hidden")) {
-    $(".top_nav").removeClass("hidden");
-    $(".overflow_ux").removeClass("hidden");
-    $(".message_center").css("display", "none");
-  }
-});
-
-//
-$(".list_deck").on("mouseenter mouseleave", function(e) {
-  $(".deck_tile").trigger(e.type);
+  $$(".top_nav")[0].classList.remove("hidden");
+  $$(".overflow_ux")[0].classList.remove("hidden");
+  $$(".message_center")[0].style.display = "none";
+  $$(".init_loading")[0].style.display = "none";
 });
 
 //
@@ -476,49 +473,41 @@ ipc.on("popup", function(event, arg, time) {
 //
 function force_open_settings(section = -1) {
   sidebarActive = 6;
-  $(".top_nav_item").each(function() {
-    $(this).removeClass("item_selected");
-    if ($(this).hasClass("it6")) {
-      $(this).addClass("item_selected");
-    }
-  });
+  // TODO remove jquery.easing
   $(".moving_ux").animate({ left: "0px" }, 250, "easeInOutCubic");
+  $$(".top_nav_item").forEach(el => el.classList.remove("item_selected"));
   openSettingsTab(section, 0);
 }
 
 //
 function force_open_about() {
   sidebarActive = 9;
-  $(".top_nav_item").each(function() {
-    $(this).removeClass("item_selected");
-    if ($(this).hasClass("it7")) {
-      $(this).addClass("item_selected");
-    }
-  });
+  // TODO remove jquery.easing
   $(".moving_ux").animate({ left: "0px" }, 250, "easeInOutCubic");
+  $$(".top_nav_item").forEach(el => el.classList.remove("item_selected"));
   openSettingsTab(5, 0);
 }
 
 //
 let top_compact = false;
 let resizeTimer;
-window.addEventListener("resize", event => {
+window.addEventListener("resize", () => {
   hideLoadingBars();
   clearTimeout(resizeTimer);
   resizeTimer = setTimeout(() => {
-    if ($(".top_nav_icons").width() < 500) {
+    if ($$(".top_nav_icons")[0].offsetWidth < 530) {
       if (!top_compact) {
-        $("span.top_nav_item_text").css("opacity", 0);
-        $(".top_nav_icon").css("display", "block");
-        $(".top_nav_icon").css("opacity", 1);
+        $$("span.top_nav_item_text").forEach(el => (el.style.opacity = 0));
+        $$(".top_nav_icon").forEach(el => (el.style.display = "block"));
+        $$(".top_nav_icon").forEach(el => (el.style.opacity = 1));
         top_compact = true;
       }
     } else {
       if (top_compact) {
-        $("span.top_nav_item_text").css("opacity", 1);
-        $(".top_nav_icon").css("opacity", 0);
+        $$("span.top_nav_item_text").forEach(el => (el.style.opacity = 1));
+        $$(".top_nav_icon").forEach(el => (el.style.opacity = 0));
         window.setTimeout(() => {
-          $(".top_nav_icon").css("display", false);
+          $$(".top_nav_icon").forEach(el => (el.style.display = "none"));
         }, 500);
         top_compact = false;
       }
@@ -526,25 +515,37 @@ window.addEventListener("resize", event => {
   }, 100);
 });
 
-$(document).ready(function() {
-  $(".signup_link").click(function() {
+function ready(fn) {
+  if (
+    document.attachEvent
+      ? document.readyState === "complete"
+      : document.readyState !== "loading"
+  ) {
+    fn();
+  } else {
+    document.addEventListener("DOMContentLoaded", fn);
+  }
+}
+
+ready(function() {
+  $$(".signup_link")[0].addEventListener("click", function() {
     shell.openExternal("https://mtgatool.com/signup/");
   });
 
-  $(".offline_link").click(function() {
+  $$(".offline_link")[0].addEventListener("click", function() {
     ipcSend("login", { username: "", password: "" });
-    $(".unlink").show();
+    $$(".unlink")[0].style.display = "block";
   });
 
-  $(".forgot_link").click(function() {
+  $$(".forgot_link")[0].addEventListener("click", function() {
     shell.openExternal("https://mtgatool.com/resetpassword/");
   });
 
   function submitAuthenticateForm() {
     if (canLogin) {
-      var user = document.getElementById("signin_user").value;
-      var pass = document.getElementById("signin_pass").value;
-      if (pass != HIDDEN_PW) {
+      const user = byId("signin_user").value;
+      let pass = byId("signin_pass").value;
+      if (pass !== HIDDEN_PW) {
         pass = sha1(pass);
       }
       ipcSend("login", { username: user, password: pass });
@@ -552,75 +553,77 @@ $(document).ready(function() {
     }
   }
 
-  $("#authenticate_form").on("submit", e => {
+  $$("#authenticate_form")[0].addEventListener("submit", e => {
     e.preventDefault();
     submitAuthenticateForm();
   });
 
-  $(".login_link").click(submitAuthenticateForm);
+  $$(".login_link")[0].addEventListener("click", submitAuthenticateForm);
 
   //
-  $(".close").click(function() {
+  $$(".close")[0].addEventListener("click", function() {
     ipcSend("renderer_window_close", 1);
   });
 
   //
-  $(".minimize").click(function() {
+  $$(".minimize")[0].addEventListener("click", function() {
     ipcSend("renderer_window_minimize", 1);
   });
 
   //
-  $(".settings").click(function() {
+  $$(".settings")[0].addEventListener("click", function() {
     force_open_settings();
   });
 
   //
-  $(".top_nav_item").click(function() {
-    $("#ux_0").off();
-    $("#ux_0")[0].removeEventListener("scroll", () => {}, false);
-    $("#history_column").off();
-    changeBackground("default");
-    document.body.style.cursor = "auto";
-    if (!$(this).hasClass("item_selected")) {
-      $(".moving_ux").animate({ left: "0px" }, 250, "easeInOutCubic");
-      let filters = {};
-      if ($(this).hasClass("ith")) {
-        sidebarActive = -1;
-      } else if ($(this).hasClass("it0")) {
-        sidebarActive = 0;
-      } else if ($(this).hasClass("it1")) {
-        sidebarActive = 1;
-      } else if ($(this).hasClass("it2")) {
-        sidebarActive = 2;
-      } else if ($(this).hasClass("it3")) {
-        sidebarActive = 3;
-      } else if ($(this).hasClass("it4")) {
-        sidebarActive = 4;
-      } else if ($(this).hasClass("it5")) {
-        sidebarActive = 5;
-      } else if ($(this).hasClass("it6")) {
-        sidebarActive = 6;
-      } else if ($(this).hasClass("it7")) {
-        sidebarActive = 1;
-        filters = {
-          ...getDefaultFilters(),
-          date: DATE_SEASON,
-          eventId: RANKED_CONST,
-          rankedMode: true
-        };
-      } else if ($(this).hasClass("it8")) {
-        sidebarActive = 1;
-        filters = {
-          ...getDefaultFilters(),
-          date: DATE_SEASON,
-          eventId: RANKED_DRAFT,
-          rankedMode: true
-        };
+  $$(".top_nav_item").forEach(el => {
+    el.addEventListener("click", function() {
+      changeBackground("default");
+      document.body.style.cursor = "auto";
+      const classList = [...this.classList];
+      if (!classList.includes("item_selected")) {
+        // TODO remove jquery.easing
+        $(".moving_ux").animate({ left: "0px" }, 250, "easeInOutCubic");
+        let filters = {};
+        if (classList.includes("ith")) {
+          sidebarActive = -1;
+        } else if (classList.includes("it0")) {
+          sidebarActive = 0;
+        } else if (classList.includes("it1")) {
+          sidebarActive = 1;
+        } else if (classList.includes("it2")) {
+          sidebarActive = 2;
+        } else if (classList.includes("it3")) {
+          sidebarActive = 3;
+        } else if (classList.includes("it4")) {
+          sidebarActive = 4;
+        } else if (classList.includes("it5")) {
+          sidebarActive = 5;
+        } else if (classList.includes("it6")) {
+          sidebarActive = 6;
+        } else if (classList.includes("it7")) {
+          sidebarActive = 1;
+          filters = {
+            ...getDefaultFilters(),
+            date: DATE_SEASON,
+            eventId: RANKED_CONST,
+            rankedMode: true
+          };
+        } else if (classList.includes("it8")) {
+          sidebarActive = 1;
+          filters = {
+            ...getDefaultFilters(),
+            date: DATE_SEASON,
+            eventId: RANKED_DRAFT,
+            rankedMode: true
+          };
+        }
+        openTab(sidebarActive, filters);
+      } else {
+        // TODO remove jquery.easing
+        $(".moving_ux").animate({ left: "0px" }, 250, "easeInOutCubic");
       }
-      openTab(sidebarActive, filters);
-    } else {
-      $(".moving_ux").animate({ left: "0px" }, 250, "easeInOutCubic");
-    }
+    });
   });
 });
 
@@ -633,12 +636,13 @@ $(document).ready(function() {
 //
 ipc.on("set_draft_link", function(event, arg) {
   hideLoadingBars();
-  document.getElementById("share_input").value = arg;
+  byId("share_input").value = arg;
 });
 
 //
 ipc.on("tou_set", function(event, arg) {
   document.body.style.cursor = "auto";
   tournamentOpen(arg);
+  // TODO remove jquery.easing
   $(".moving_ux").animate({ left: "-100%" }, 250, "easeInOutCubic");
 });

--- a/window_main/settings.js
+++ b/window_main/settings.js
@@ -26,11 +26,12 @@ const { get_card_image } = require("../shared/util");
 const byId = id => document.getElementById(id);
 
 const {
-  setLocalState,
   addCheckbox,
   changeBackground,
   hideLoadingBars,
   ipcSend,
+  resetMainContainer,
+  setLocalState,
   showColorpicker
 } = require("./renderer-util");
 
@@ -53,9 +54,8 @@ function openSettingsTab(openSection = lastSettingsSection, scrollTop = 0) {
   }
   changeBackground("default");
   hideLoadingBars();
-  const mainDiv = byId("ux_0");
+  const mainDiv = resetMainContainer();
   mainDiv.classList.add("flex_item");
-  mainDiv.innerHTML = "";
 
   const wrap_l = createDiv(["wrapper_column", "sidebar_column_r"]);
 

--- a/window_main/settings.js
+++ b/window_main/settings.js
@@ -30,7 +30,8 @@ const {
   addCheckbox,
   changeBackground,
   hideLoadingBars,
-  ipcSend
+  ipcSend,
+  showColorpicker
 } = require("./renderer-util");
 
 let lastSettingsSection = 1;
@@ -572,19 +573,23 @@ function appendVisual(section) {
     ["but_container_label"],
     "<span style='margin-right: 32px;'>Background shade:</span>"
   );
-  // TODO remove jQuery colorpicker
-  const colorPick = $('<input type="text" id="flat" class="color_picker" />');
-  colorPick.appendTo($(label));
-  colorPick.spectrum({
-    showInitial: true,
-    showAlpha: true,
-    showButtons: false
+  const colorPick = createInput(["color_picker"], "", {
+    id: "flat",
+    type: "text",
+    value: "Example Content"
   });
-  colorPick.spectrum("set", pd.settings.back_color);
-  colorPick.on("dragstop.spectrum", function(e, color) {
-    $(".main_wrapper").css("background-color", color.toRgbString());
-    updateUserSettings();
+  colorPick.style.backgroundColor = pd.settings.back_color;
+  colorPick.addEventListener("click", function(e) {
+    e.stopPropagation();
+    showColorpicker(
+      pd.settings.back_color,
+      color => (colorPick.style.backgroundColor = color.rgbaString),
+      color => updateUserSettingsBlend({ back_color: color.rgbaString }),
+      () => (colorPick.style.backgroundColor = pd.settings.back_color),
+      { alpha: true }
+    );
   });
+  label.appendChild(colorPick);
   section.appendChild(label);
 
   label = createLabel(["but_container_label"], "List style:");
@@ -817,14 +822,8 @@ function updateUserSettingsBlend(_settings = {}) {
     };
   });
 
-  // TODO remove jQuery colorpicker
-  const back_color = $(".color_picker")
-    .spectrum("get")
-    .toRgbString();
-
   ipcSend("save_user_settings", {
     anon_explore: byId("settings_anon_explore").checked,
-    back_color,
     back_url: byId("query_image").value || "default",
     close_on_match: byId("settings_closeonmatch").checked,
     close_to_tray: byId("settings_closetotray").checked,

--- a/window_main/tournaments.js
+++ b/window_main/tournaments.js
@@ -1,3 +1,5 @@
+const anime = require("animejs");
+
 const { queryElements: $$, createDivision } = require("../shared/dom-fns");
 const { createSelect } = require("../shared/select");
 const deckDrawer = require("../shared/deck-drawer");
@@ -35,7 +37,12 @@ let stateClockInterval = null;
 let lastSeenInterval = null;
 
 function tournamentCreate() {
-  $(".moving_ux").animate({ left: "-100%" }, 250, "easeInOutCubic");
+  anime({
+    targets: ".moving_ux",
+    left: "-100%",
+    easing: "easeInOutCubic",
+    duration: 350
+  });
   let mainDiv = $$("#ux_1")[0];
   mainDiv.innerHTML = "";
   mainDiv.classList.remove("flex_item");
@@ -52,7 +59,12 @@ function tournamentCreate() {
   mainDiv.appendChild(top);
   buttonBack.addEventListener("click", () => {
     changeBackground("default");
-    $(".moving_ux").animate({ left: "0px" }, 250, "easeInOutCubic");
+    anime({
+      targets: ".moving_ux",
+      left: 0,
+      easing: "easeInOutCubic",
+      duration: 350
+    });
   });
 }
 
@@ -154,7 +166,12 @@ function tournamentOpen(t) {
 
   topButtonBack.addEventListener("click", () => {
     changeBackground("default");
-    $(".moving_ux").animate({ left: "0px" }, 250, "easeInOutCubic");
+    anime({
+      targets: ".moving_ux",
+      left: 0,
+      easing: "easeInOutCubic",
+      duration: 350
+    });
   });
 }
 
@@ -734,7 +751,6 @@ function selectTourneyDeck(index) {
   tournamentDeck = _deck.id;
   _deck.mainDeck.sort(compare_cards);
   _deck.sideboard.sort(compare_cards);
-  // drawDeck requires a jquery div... mmm
   drawDeck($$(".join_decklist")[0], _deck, true);
 
   $$(".but_join")[0].classList.add("button_simple");


### PR DESCRIPTION
### Motivation
Remove all the `jquery` from the main window process!
https://github.com/Manuel-777/MTG-Arena-Tool/projects/2#card-18924552
![image](https://user-images.githubusercontent.com/14894693/59787746-fc6c4780-927e-11e9-8d54-f19ad2572a3a.png)
![image](https://user-images.githubusercontent.com/14894693/59787738-f7a79380-927e-11e9-8435-5b33d35cc2f0.png)

### Details
- Depends on #428 and #429 
- replaces `jquery.animate` and `jquery.easing` with https://animejs.com/ (https://github.com/Manuel-777/MTG-Arena-Tool/projects/2#card-22883871)
- replaces `jquery.off` magic for scroll handlers with explicit local state and `removeEventListener` (https://github.com/Manuel-777/MTG-Arena-Tool/projects/2#card-22958330)
- Economy page still had some other lingering jQuery to convert
- Explore page still had some other lingering jQuery to convert
