### PR TITLE
bugfix record opp deck archetype

### DIFF
--- a/window_background/background.js
+++ b/window_background/background.js
@@ -1377,6 +1377,7 @@ function getOppDeck() {
     console.log(_deck.colors);
     currentMatch.oppArchetype = getColorArchetype(_deck.colors);
   }
+  deckSave.archetype = currentMatch.oppArchetype;
 
   return deckSave;
 }


### PR DESCRIPTION
### Motivation
We need to record the fancy new opp archetype to restore the match auto-tags in history.

### Demo
![image](https://user-images.githubusercontent.com/14894693/59816077-952ab380-92cf-11e9-8d1b-bd18aaa15b90.png)


this may have originally stopped working here: https://github.com/lusbenjamin/MTG-Arena-Tool/commit/020d26fa00a0d78be47a2dd292c80f19a5fb1f25