### PR TITLE
Overlay Charts and Draft Brew Mode

### DIFF
--- a/shared/constants.js
+++ b/shared/constants.js
@@ -625,6 +625,11 @@ exports.OVERLAY_ODDS = 2;
 exports.OVERLAY_SEEN = 3;
 exports.OVERLAY_LOG = 4;
 exports.OVERLAY_DRAFT = 5;
+exports.OVERLAY_DRAFT_BREW = 6;
+exports.OVERLAY_DRAFT_MODES = [
+  exports.OVERLAY_DRAFT,
+  exports.OVERLAY_DRAFT_BREW
+];
 
 exports.ARENA_MODE_IDLE = 0;
 exports.ARENA_MODE_MATCH = 1;

--- a/shared/player-data.js
+++ b/shared/player-data.js
@@ -53,6 +53,7 @@ const overlayCfg = {
   deck: true,
   lands: true,
   keyboard_shortcut: true,
+  mana_curve: false,
   mode: 1,
   ontop: true,
   scale: 100,
@@ -60,7 +61,8 @@ const overlayCfg = {
   show_always: false,
   sideboard: false,
   title: true,
-  top: true
+  top: true,
+  type_counts: false
 };
 
 const defaultCfg = {

--- a/shared/player-data.js
+++ b/shared/player-data.js
@@ -219,7 +219,8 @@ class PlayerData {
     Object.assign(this, {
       ...playerDataDefault,
       ...defaultCfg,
-      defaultCfg: { ...defaultCfg }
+      defaultCfg: { ...defaultCfg },
+      overlayCfg: { ...overlayCfg }
     });
 
     PlayerData.instance = this;

--- a/window_background/background.js
+++ b/window_background/background.js
@@ -481,7 +481,14 @@ function loadPlayerConfig(playerId, serverData = undefined) {
   const playerData = {
     ...pd,
     ...savedData,
-    settings: { ...pd.settings, ...savedData.settings }
+    settings: {
+      ...pd.settings,
+      ...savedData.settings,
+      overlays: savedData.settings.overlays.map(overlay => {
+        // include new default overlay settings
+        return { ...pd.overlayCfg, ...overlay };
+      })
+    }
   };
   syncSettings(playerData.settings);
   pd_set(playerData);

--- a/window_main/deck-details.js
+++ b/window_main/deck-details.js
@@ -10,6 +10,8 @@ const {
 } = require("../shared/dom-fns");
 const deckDrawer = require("../shared/deck-drawer");
 const {
+  deckManaCurve,
+  deckTypesStats,
   get_deck_export,
   get_deck_export_txt,
   get_deck_missing,
@@ -22,8 +24,6 @@ const StatsPanel = require("./stats-panel");
 const {
   changeBackground,
   colorPieChart,
-  deckManaCurve,
-  deckTypesStats,
   drawDeck,
   drawDeckVisual,
   ipcSend,

--- a/window_main/index.css
+++ b/window_main/index.css
@@ -1828,7 +1828,6 @@ a:hover {
 .check_container input {
     position: absolute;
     opacity: 0;
-    cursor: pointer;
 }
 
 /* Create a custom checkbox */
@@ -1844,7 +1843,7 @@ a:hover {
 }
 
 /* On mouse-over, add a grey background color */
-.check_container:hover input ~ .checkmark {
+.check_container:hover input:enabled ~ .checkmark {
     background-color: var(--color-mid-50);
     border: 1px solid var(--color-light);
 }

--- a/window_main/renderer-util.js
+++ b/window_main/renderer-util.js
@@ -633,11 +633,21 @@ function toggleVisibility(...ids) {
 
 //
 exports.addCheckbox = addCheckbox;
-function addCheckbox(div, label, id, def, func) {
+function addCheckbox(div, label, id, def, func, disabled = false) {
   const labelEl = createLabel(["check_container", "hover_label"], label);
+  if (disabled) {
+    labelEl.classList.remove("hover_label");
+    labelEl.style.cursor = "default";
+    labelEl.style.opacity = 0.4;
+  }
 
-  const checkbox = createInput([], "", { type: "checkbox", id, checked: def });
-  checkbox.addEventListener("click", func);
+  const checkbox = createInput([], "", {
+    type: "checkbox",
+    id,
+    checked: def,
+    disabled
+  });
+  if (!disabled) checkbox.addEventListener("click", func);
   labelEl.appendChild(checkbox);
   labelEl.appendChild(createSpan(["checkmark"]));
 

--- a/window_main/renderer-util.js
+++ b/window_main/renderer-util.js
@@ -7,8 +7,6 @@ const striptags = require("striptags");
 const Picker = require("vanilla-picker");
 
 const {
-  CARD_TYPE_CODES,
-  CARD_TYPES,
   COLORS_ALL,
   DRAFT_RANKS,
   MANA_COLORS,
@@ -31,12 +29,7 @@ const {
 const deckDrawer = require("../shared/deck-drawer");
 const cardTypes = require("../shared/card-types");
 const { addCardHover } = require("../shared/card-hover");
-const {
-  add,
-  get_card_image,
-  get_deck_types_ammount,
-  makeId
-} = require("../shared/util");
+const { deckTypesStats, get_card_image, makeId } = require("../shared/util");
 
 const byId = id => document.getElementById(id);
 let popTimeout = null;
@@ -420,116 +413,6 @@ function drawDeckVisual(container, deck, openCallback) {
     normalButton.addEventListener("click", () => openCallback());
     container.appendChild(normalButton);
   }
-}
-
-//
-function get_deck_curve(deck) {
-  var curve = [];
-
-  deck.mainDeck.forEach(function(card) {
-    var grpid = card.id;
-    var cmc = db.card(grpid).cmc;
-    if (curve[cmc] == undefined) curve[cmc] = [0, 0, 0, 0, 0, 0];
-
-    let card_cost = db.card(grpid).cost;
-
-    if (db.card(grpid).type.indexOf("Land") == -1) {
-      card_cost.forEach(function(c) {
-        if (c.indexOf("w") !== -1) curve[cmc][1] += card.quantity;
-        if (c.indexOf("u") !== -1) curve[cmc][2] += card.quantity;
-        if (c.indexOf("b") !== -1) curve[cmc][3] += card.quantity;
-        if (c.indexOf("r") !== -1) curve[cmc][4] += card.quantity;
-        if (c.indexOf("g") !== -1) curve[cmc][5] += card.quantity;
-      });
-
-      curve[cmc][0] += card.quantity;
-    }
-  });
-  /*
-  // Do not account sideboard?
-  deck.sideboard.forEach(function(card) {
-    var grpid = card.id;
-    var cmc = db.card(grpid).cmc;
-    if (curve[cmc] == undefined)  curve[cmc] = 0;
-    curve[cmc] += card.quantity
-
-    if (db.card(grpid).rarity !== 'land') {
-      curve[cmc] += card.quantity
-    }
-  });
-  */
-  //console.log(curve);
-  return curve;
-}
-
-//
-exports.deckManaCurve = deckManaCurve;
-function deckManaCurve(deck) {
-  const manaCounts = get_deck_curve(deck);
-  const curveMax = Math.max(
-    ...manaCounts
-      .filter(v => {
-        if (v == undefined) return false;
-        return true;
-      })
-      .map(v => v[0] || 0)
-  );
-  // console.log("deckManaCurve", manaCounts, curveMax);
-
-  const container = createDiv();
-  const curve = createDiv(["mana_curve"]);
-  const numbers = createDiv(["mana_curve_numbers"]);
-
-  manaCounts.forEach((cost, i) => {
-    const total = cost[0];
-    const manaTotal = cost.reduce(add, 0) - total;
-
-    const curveCol = createDiv(["mana_curve_column"]);
-    curveCol.style.height = (total * 100) / curveMax + "%";
-
-    const curveNum = createDiv(["mana_curve_number"], total > 0 ? total : "");
-    curveCol.appendChild(curveNum);
-
-    MANA_COLORS.forEach((mc, ind) => {
-      if (ind < 5 && cost[ind + 1] > 0) {
-        const col = createDiv(["mana_curve_column_color"]);
-        col.style.height = Math.round((cost[ind + 1] / manaTotal) * 100) + "%";
-        col.style.backgroundColor = mc;
-        curveCol.appendChild(col);
-      }
-    });
-
-    curve.appendChild(curveCol);
-
-    const colNum = createDiv(["mana_curve_column_number"]);
-    const numDiv = createDiv(["mana_s16", "mana_" + i]);
-    numDiv.style.margin = "0 auto !important";
-    colNum.appendChild(numDiv);
-    numbers.appendChild(colNum);
-  });
-
-  container.appendChild(curve);
-  container.appendChild(numbers);
-
-  return container;
-}
-
-//
-exports.deckTypesStats = deckTypesStats;
-function deckTypesStats(deck) {
-  const cardTypes = get_deck_types_ammount(deck);
-  const typesContainer = createDiv(["types_container"]);
-  CARD_TYPE_CODES.forEach((cardTypeKey, index) => {
-    const type = createDiv(["type_icon_cont"]);
-    type.appendChild(
-      createDiv(["type_icon", "type_" + cardTypeKey], "", {
-        title: CARD_TYPES[index]
-      })
-    );
-    type.appendChild(createSpan([], cardTypes[cardTypeKey]));
-    typesContainer.appendChild(type);
-  });
-  return typesContainer;
 }
 
 //

--- a/window_main/settings.js
+++ b/window_main/settings.js
@@ -8,7 +8,9 @@ const {
   OVERLAY_ODDS,
   OVERLAY_SEEN,
   OVERLAY_DRAFT,
+  OVERLAY_DRAFT_BREW,
   OVERLAY_LOG,
+  OVERLAY_DRAFT_MODES,
   COLORS_ALL
 } = require("../shared/constants");
 const db = require("../shared/database");
@@ -355,8 +357,9 @@ function appendOverlay(section) {
     modeOptions[OVERLAY_LEFT] = "Cards Left";
     modeOptions[OVERLAY_ODDS] = "Cards Odds";
     modeOptions[OVERLAY_SEEN] = "Cards Seen";
-    modeOptions[OVERLAY_DRAFT] = "Draft";
+    modeOptions[OVERLAY_DRAFT] = "Draft Pick";
     modeOptions[OVERLAY_LOG] = "Action Log";
+    modeOptions[OVERLAY_DRAFT_BREW] = "Draft Brew";
 
     const modeSelect = createSelect(
       label,
@@ -412,35 +415,56 @@ function appendOverlay(section) {
       "Show title",
       `overlay_${index}_title`,
       settings.title,
-      updateUserSettings
+      updateUserSettings,
+      settings.mode === OVERLAY_DRAFT
     );
     addCheckbox(
       overlaySection,
       "Show deck/lists",
       `overlay_${index}_deck`,
       settings.deck,
-      updateUserSettings
+      updateUserSettings,
+      settings.mode === OVERLAY_DRAFT
     );
     addCheckbox(
       overlaySection,
       "Show clock",
       `overlay_${index}_clock`,
       settings.clock,
-      updateUserSettings
+      updateUserSettings,
+      OVERLAY_DRAFT_MODES.includes(settings.mode)
     );
     addCheckbox(
       overlaySection,
       "Show sideboard",
       `overlay_${index}_sideboard`,
       settings.sideboard,
-      updateUserSettings
+      updateUserSettings,
+      ![OVERLAY_FULL, OVERLAY_LEFT, OVERLAY_ODDS].includes(settings.mode)
     );
     addCheckbox(
       overlaySection,
       "Compact lands",
       `overlay_${index}_lands`,
       settings.lands,
-      updateUserSettings
+      updateUserSettings,
+      ![OVERLAY_FULL, OVERLAY_LEFT, OVERLAY_ODDS].includes(settings.mode)
+    );
+    addCheckbox(
+      overlaySection,
+      "Type counts",
+      `overlay_${index}_type_counts`,
+      settings.type_counts,
+      updateUserSettings,
+      [OVERLAY_LOG, OVERLAY_ODDS, OVERLAY_DRAFT].includes(settings.mode)
+    );
+    addCheckbox(
+      overlaySection,
+      "Mana curve",
+      `overlay_${index}_mana_curve`,
+      settings.mana_curve,
+      updateUserSettings,
+      [OVERLAY_LOG, OVERLAY_ODDS, OVERLAY_DRAFT].includes(settings.mode)
     );
 
     const sliderOpacity = createDiv(["slidecontainer_settings"]);
@@ -818,7 +842,9 @@ function updateUserSettingsBlend(_settings = {}) {
       clock: byId(`overlay_${index}_clock`).checked,
       sideboard: byId(`overlay_${index}_sideboard`).checked,
       ontop: byId(`overlay_${index}_ontop`).checked,
-      lands: byId(`overlay_${index}_lands`).checked
+      lands: byId(`overlay_${index}_lands`).checked,
+      type_counts: byId(`overlay_${index}_type_counts`).checked,
+      mana_curve: byId(`overlay_${index}_mana_curve`).checked
     };
   });
 

--- a/window_overlay/index.css
+++ b/window_overlay/index.css
@@ -107,11 +107,10 @@ body {
     display: flex;
     flex-direction: column;
     justify-content: space-around;
-    bottom: 0;
     width: 100%;
     height: 64px;
     min-height: 64px;
-    top: 64px;
+    top: 0;
     z-index: 40;
 }
 
@@ -311,4 +310,133 @@ body {
     justify-content: space-between;
     flex-flow: row-reverse;
     overflow: hidden;
+}
+
+.mana_curve_container {
+    margin: 6px auto;
+    max-width: 630px;
+    padding-left: 12px;
+    padding-right: 12px;
+    width: calc(100% - 24px);
+}
+
+.mana_curve {
+    display: flex;
+    align-items: flex-end;
+    height: 96px;
+    margin: 0px 4px;
+    padding-bottom: 4px;
+    border-bottom: 2px solid rgba(250, 229, 210, 0.8);
+    width: 100%;
+}
+
+.mana_curve_column {
+    color: #fae5d2;
+    justify-content: space-around;
+    width: -webkit-fill-available;
+    flex-direction: column;
+    margin: 0px 4px;
+    display: flex;
+    flex-direction: column;
+    background-color: rgba(250, 229, 210, 0.8);
+}
+
+.mana_curve_number {
+    opacity: 1;
+    position: relative;
+    height: 0px;
+    top: calc(50% - 8px);
+    text-align: center;
+    font-size: 16px;
+    font-weight: bold;
+    text-shadow: 3px 3px 3px #000000ad;
+    font-family: Beleren;
+}
+
+.mana_curve_numbers {
+    display: flex;
+    align-items: flex-end;
+    height: 24px;
+    width: 100%;
+}
+
+.mana_curve_costs {
+    display: flex;
+    align-items: flex-start;
+    width: 100%;
+
+}
+
+.mana_curve_column_number {
+    font-size: 12px;
+    line-height: 20px;
+    text-align: center;
+    color: #FAE5D2;
+    width: 100%;
+    font-family: "belerenbold";
+}
+
+.mana_curve_column span {
+  align-self: flex-end;
+}
+
+.types_container {
+    margin: 6px auto;
+    max-width: 630px;
+    padding-left: 12px;
+    padding-right: 12px;
+    width: calc(100% - 24px);
+    display: flex;
+    justify-content: space-between;
+}
+
+.type_icon_cont {
+    display: flex;
+    flex-direction: column;
+}
+
+.type_icon {
+    width: 32px;
+    height: 32px;
+    margin-bottom: 8px;
+}
+
+.type_art { background-image: url(../images/type_artifact.png); }
+.type_cre { background-image: url(../images/type_creature.png); }
+.type_enc { background-image: url(../images/type_enchantment.png); }
+.type_ins { background-image: url(../images/type_instant.png); }
+.type_lan { background-image: url(../images/type_land.png); }
+.type_pla { background-image: url(../images/type_planeswalker.png); }
+.type_sor { background-image: url(../images/type_sorcery.png); }
+
+.pie_container {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin: 16px auto;
+    height: 160px;
+}
+
+.pie_container_outer {
+    width: 100%;
+    display: flex;
+    flex-direction: initial;
+    align-items: center;
+    margin: 16px auto;
+    height: 160px;
+}
+
+.pie_container span, .wildcards_cost span , .types_container span {
+    text-align: center;
+    display: block;
+    margin-bottom: 12px;
+    font-family:  var(--main-font-name);
+    font-size: 16px;
+    color: #FAE5D2;
+}
+
+.pie {
+  width: 128px; height: 128px;
+  border-radius: 50%;
 }

--- a/window_overlay/index.html
+++ b/window_overlay/index.html
@@ -37,12 +37,6 @@
             <div class="overlay_deckcolors"></div>
             <div class="overlay_decklist"></div>
 
-            <div class="overlay_draft_container click-on">
-                <div class="draft_prev"></div>
-                <div class="draft_title"></div>
-                <div class="draft_next"></div>
-            </div>
-
             <div class="overlay_clock_container click-on">
                 <div class="clock_prev"></div>
                 <div class="clock_turn"></div>

--- a/window_overlay/overlay-process.js
+++ b/window_overlay/overlay-process.js
@@ -5,7 +5,7 @@ const {
   ARENA_MODE_IDLE,
   ARENA_MODE_MATCH,
   ARENA_MODE_DRAFT,
-  OVERLAY_DRAFT,
+  OVERLAY_DRAFT_MODES,
   COLORS_ALL
 } = require("../shared/constants");
 
@@ -120,10 +120,13 @@ class OverlayProcess {
 
   updateVisible() {
     const { settings, window: overlay } = this;
+    if (!settings) return;
 
     const currentModeApplies =
-      (settings.mode === OVERLAY_DRAFT && arenaState === ARENA_MODE_DRAFT) ||
-      (settings.mode !== OVERLAY_DRAFT && arenaState === ARENA_MODE_MATCH);
+      (OVERLAY_DRAFT_MODES.includes(settings.mode) &&
+        arenaState === ARENA_MODE_DRAFT) ||
+      (!OVERLAY_DRAFT_MODES.includes(settings.mode) &&
+        arenaState === ARENA_MODE_MATCH);
 
     const shouldShow =
       settings.show && (currentModeApplies || settings.show_always);


### PR DESCRIPTION
### Overlay Charts
Adds optional type counts and mana curve charts (cloned from the deck details page):

#### Type Counts and Mana Curve Charts
<img width="208" alt="Annotation 2019-06-21 013422" src="https://user-images.githubusercontent.com/14894693/59971753-0f10a600-9537-11e9-8f50-34b11896b763.png">

#### New Overlay Settings
![image](https://user-images.githubusercontent.com/14894693/59971752-09b35b80-9537-11e9-9479-316a2c67677a.png)

### Draft Brew Mode
Adds a new overlay mode to track all current picks and give the user summary stats about them.
![image](https://user-images.githubusercontent.com/14894693/59971771-6ca4f280-9537-11e9-8028-4a7f4b0dc326.png)

### Other Misc
- Bugfix: adding new overlay default settings will now correctly populate existing user settings
- Enhancement: settings page checkboxes now show a disabled state when they have no effect on the current overlay mode
- Renamed old "Draft" mode to "Draft Pick" to distinguish from new "Draft Brew" mode.
- Refactors to further split apart overlay render updates for match/draft modes
  - Only render draft pick controls in "Draft Pick" mode
  - Stop updating match logic all the time in draft overlays, etc.
