### PR TITLE
Enhance First Pass

### DIFF
--- a/shared/database.js
+++ b/shared/database.js
@@ -17,6 +17,7 @@ class Database {
 
     this.rewards_daily_ends = new Date();
     this.rewards_weekly_ends = new Date();
+    this.activeEvents = [];
 
     const dbUri = `${__dirname}/../resources/database.json`;
     const defaultDb = fs.readFileSync(dbUri, "utf8");

--- a/shared/player-data.js
+++ b/shared/player-data.js
@@ -273,7 +273,7 @@ class PlayerData {
       if (blacklistKeys.includes(key)) return;
       data[key] = value;
     });
-    console.log(data);
+    // console.log(data);
     return data;
   }
 

--- a/shared/player-data.js
+++ b/shared/player-data.js
@@ -22,27 +22,8 @@ const playerDataDefault = {
   userName: "",
   arenaId: "",
   arenaVersion: "",
-  offline: false,
   patreon: false,
-  patreon_tier: 0,
-  rank: {
-    constructed: {
-      rank: "",
-      tier: 0,
-      step: 0,
-      won: 0,
-      lost: 0,
-      drawn: 0
-    },
-    limited: {
-      rank: "",
-      tier: 0,
-      step: 0,
-      won: 0,
-      lost: 0,
-      drawn: 0
-    }
-  }
+  patreon_tier: 0
 };
 
 const overlayCfg = {
@@ -85,6 +66,7 @@ const defaultCfg = {
     right_panel_width: 400,
     last_open_tab: -1,
     card_tile_style: CARD_TILE_FLAT,
+    skip_firstpass: false,
     overlays: [
       {
         ...overlayCfg,
@@ -131,6 +113,25 @@ const defaultCfg = {
     wcRare: 0,
     wcMythic: 0
   },
+  offline: false,
+  rank: {
+    constructed: {
+      rank: "",
+      tier: 0,
+      step: 0,
+      won: 0,
+      lost: 0,
+      drawn: 0
+    },
+    limited: {
+      rank: "",
+      tier: 0,
+      step: 0,
+      won: 0,
+      lost: 0,
+      drawn: 0
+    }
+  },
   deck_changes: {},
   deck_changes_index: [],
   courses_index: [],
@@ -139,7 +140,6 @@ const defaultCfg = {
   gems_history: [],
   gold_history: [],
   decks: {},
-  decks_index: [],
   decks_tags: {},
   decks_last_used: [],
   static_decks: [],
@@ -258,6 +258,23 @@ class PlayerData {
 
   get history() {
     return [...this.matches, ...this.drafts];
+  }
+
+  get data() {
+    const data = {};
+    const blacklistKeys = [
+      "defaultCfg",
+      "overlayCfg",
+      "windowBounds",
+      ...Object.keys(playerDataDefault)
+    ];
+    Object.entries(this).forEach(([key, value]) => {
+      if (value instanceof Function) return;
+      if (blacklistKeys.includes(key)) return;
+      data[key] = value;
+    });
+    console.log(data);
+    return data;
   }
 
   change(id) {

--- a/shared/player-data.js
+++ b/shared/player-data.js
@@ -22,6 +22,7 @@ const playerDataDefault = {
   userName: "",
   arenaId: "",
   arenaVersion: "",
+  offline: false,
   patreon: false,
   patreon_tier: 0
 };
@@ -113,7 +114,6 @@ const defaultCfg = {
     wcRare: 0,
     wcMythic: 0
   },
-  offline: false,
   rank: {
     constructed: {
       rank: "",

--- a/window_background/arena-log-watcher.js
+++ b/window_background/arena-log-watcher.js
@@ -1,12 +1,9 @@
-/*
-global
-  skipFirstPass
-*/
 const fs = require("fs");
 const { promisify } = require("util");
 const { StringDecoder } = require("string_decoder");
 const queue = require("queue");
 const ArenaLogDecoder = require("./arena-log-decoder");
+const pd = require("../shared/player-data");
 
 const fsAsync = {
   close: promisify(fs.close),
@@ -52,7 +49,7 @@ function start({ path, chunkSize, onLogEntry, onError, onFinish }) {
       position = 0;
     }
     while (position < size) {
-      if (!skipFirstPass) {
+      if (!pd.settings.skip_firstpass) {
         const buffer = await readChunk(
           path,
           position,

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -130,43 +130,52 @@ function showLogin() {
 }
 
 //
-ipc.on("player_data_updated", () => {
-  if (sidebarActive != -99) {
+function updateTopBar() {
+  if (pd.name) {
     $$(".top_username")[0].innerHTML = pd.name.slice(0, -6);
     $$(".top_username_id")[0].innerHTML = pd.name.slice(-6);
+  }
 
+  if (pd.rank) {
     let rankOffset;
-    let constructed = pd.rank.constructed;
+    const constructed = pd.rank.constructed;
     rankOffset = get_rank_index(constructed.rank, constructed.tier);
-    let constructedRankIcon = $$(".top_constructed_rank")[0];
+    const constructedRankIcon = $$(".top_constructed_rank")[0];
     constructedRankIcon.style.backgroundPosition = rankOffset * -48 + "px 0px";
     constructedRankIcon.setAttribute(
       "title",
       constructed.rank + " " + constructed.tier
     );
 
-    let limited = pd.rank.limited;
+    const limited = pd.rank.limited;
     rankOffset = get_rank_index(limited.rank, limited.tier);
-    let limitedRankIcon = $$(".top_limited_rank")[0];
+    const limitedRankIcon = $$(".top_limited_rank")[0];
     limitedRankIcon.style.backgroundPosition = rankOffset * -48 + "px 0px";
     limitedRankIcon.setAttribute("title", limited.rank + " " + limited.tier);
+  }
 
-    let patreonIcon = $$(".top_patreon")[0];
-    if (pd.patreon) {
-      let xoff = -40 * pd.patreon_tier;
-      let title = "Patreon Basic Tier";
+  const patreonIcon = $$(".top_patreon")[0];
+  if (pd.patreon) {
+    const xoff = -40 * pd.patreon_tier;
+    let title = "Patreon Basic Tier";
 
-      if (pd.patreon_tier == 1) title = "Patreon Standard Tier";
-      if (pd.patreon_tier == 2) title = "Patreon Modern Tier";
-      if (pd.patreon_tier == 3) title = "Patreon Legacy Tier";
-      if (pd.patreon_tier == 4) title = "Patreon Vintage Tier";
+    if (pd.patreon_tier === 1) title = "Patreon Standard Tier";
+    if (pd.patreon_tier === 2) title = "Patreon Modern Tier";
+    if (pd.patreon_tier === 3) title = "Patreon Legacy Tier";
+    if (pd.patreon_tier === 4) title = "Patreon Vintage Tier";
 
-      patreonIcon.style.backgroundPosition = xoff + "px 0px";
-      patreonIcon.setAttribute("title", title);
-      patreonIcon.style.display = "block";
-    } else {
-      patreonIcon.style.display = "none";
-    }
+    patreonIcon.style.backgroundPosition = xoff + "px 0px";
+    patreonIcon.setAttribute("title", title);
+    patreonIcon.style.display = "block";
+  } else {
+    patreonIcon.style.display = "none";
+  }
+}
+
+//
+ipc.on("player_data_updated", () => {
+  if (sidebarActive != -99) {
+    updateTopBar();
   }
 });
 
@@ -339,17 +348,15 @@ function openTab(tab, filters = {}, dataIndex = 0, scrollTop = 0) {
       $$(".init_loading")[0].style.display = "block";
       break;
   }
-  $$("." + tabClass)[0].classList.add("item_selected");
+  if ($$("." + tabClass)[0])
+    $$("." + tabClass)[0].classList.add("item_selected");
   ipcSend("save_user_settings", { last_open_tab: tab });
 }
 
 //
 ipc.on("initialize", function() {
   showLoadingBars();
-  if (pd.name) {
-    $$(".top_username")[0].innerHTML = pd.name.slice(0, -6);
-    $$(".top_username_id")[0].innerHTML = pd.name.slice(-6);
-  }
+  updateTopBar();
 
   sidebarActive = pd.settings.last_open_tab;
   const totalAgg = createAllMatches();

--- a/window_main/settings.js
+++ b/window_main/settings.js
@@ -188,18 +188,21 @@ function appendBehaviour(section) {
   );
   addCheckbox(
     section,
-    "Read log on login",
+    "Read entire Arena log during launch",
     "settings_readlogonlogin",
     !pd.settings.skip_firstpass,
     updateUserSettings
   );
   const helpDiv = createDiv(
     ["settings_note"],
-    `<i>Reading the log on startup can take a while, disabling this will make
-    mtgatool load instantly, but you may have have to play with Arena to load
-    some data, like Rank, wildcards and decklists.
-    <b>This feature makes mtgatool read games when it was closed.</b></i>`
+    `<p><i>Enabling this ensures that mtgatool will not miss any data still
+    available in your Arena log, even when mtgatool is launched while Arena is
+    running <b>(Recommended)</b>.</p>
+    <p>Disabling this will make mtgatool launch more quickly by skipping your
+    preexisting Arena log and only reading new log data. <b>This may miss data
+    if you launch mtgatool during an Arena session.</i></p>`
   );
+  helpDiv.style.paddingLeft = "35px";
   section.appendChild(helpDiv);
 
   addCheckbox(


### PR DESCRIPTION
### Motivation
This PR optimizes several parts of the initial tool launch. It has 2 major goals:
- For users who always read the entire log, make it ~~blazingly fast~~ a little faster
- For users with `skip_firstpass`, make it more robust upon launch

### Approach
- Add default values and move several fields into `player-data` storage: e.g. `rank`, `economy`, `static_decks`, `newCards`, etc.
  - Since we load all `player-data` in bulk, this automatically makes `skip_firstpass` much more robust (e.g. displays wildcards, decks, and ranks immediately)
  - Adds `store.set` calls to keep these fields up-to-date like other fields. This would make reading the log all at once even slower except...
- During `firstpass`, skip all IO calls to `store` except one giant `store.get` at the beginning and one giant `store.set` at the end
- Also add a better description of the `skip_firstpass` feature to the settings page:
![image](https://user-images.githubusercontent.com/14894693/59983851-e345fc80-95d8-11e9-9e6e-5608fe33984c.png)
