### PR TITLE
bugfix multiple overlays migration

### DIFF
--- a/window_background/background.js
+++ b/window_background/background.js
@@ -493,15 +493,20 @@ function loadPlayerConfig(playerId, serverData = undefined) {
   });
 
   const savedData = store.get();
+  const savedOverlays = savedData.settings.overlays || [];
   const playerData = {
     ...pd,
     ...savedData,
     settings: {
       ...pd.settings,
       ...savedData.settings,
-      overlays: savedData.settings.overlays.map(overlay => {
-        // include new default overlay settings
-        return { ...pd.overlayCfg, ...overlay };
+      overlays: pd.settings.overlays.map((overlay, index) => {
+        if (index < savedOverlays.length) {
+          // blend in new default overlay settings
+          return { ...overlay, ...savedOverlays[index] };
+        } else {
+          return overlay;
+        }
       })
     }
   };


### PR DESCRIPTION
The code I added to allow us to gracefully introduce new default settings to multiple overlays failed to correctly handle the case for users that had not yet migrated into the multiple overlay world. This bugfix handles all cases correctly.

Bonus:
 - now you can add new defaults to the individual custom overlays instead of just `overlayCfg`
 - if we add a 6th overlay, this should also correctly handle that case