### PR TITLE
bugfix remove extraneous IPC signals from renderer.openTab

### DIFF
--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -356,7 +356,6 @@ function openTab(tab, filters = {}, dataIndex = 0, scrollTop = 0) {
   }
   if ($$("." + tabClass)[0])
     $$("." + tabClass)[0].classList.add("item_selected");
-  ipcSend("save_user_settings", { last_open_tab: tab });
 }
 
 //
@@ -656,6 +655,7 @@ ready(function() {
           };
         }
         openTab(sidebarActive, filters);
+        ipcSend("save_user_settings", { last_open_tab: sidebarActive });
       } else {
         anime({
           targets: ".moving_ux",


### PR DESCRIPTION
### Motivation
Currently `master` does this every time player data changes:
1. background sends `"player_data_refresh"`
2. main window reloads current tab at current position
3. main window sends `"save_user_settings"` to re-remember that same tab was the most recently opened one.
4. background responds and writes the store...
5. ...all the downstream settings update stuff happens

This PR eliminates all of the excess steps 3+ and only sets the `last_open_tab` in the UI click handler.