### PR TITLE
rename player-data fns and pd_set

### DIFF
--- a/window_background/background-util.js
+++ b/window_background/background-util.js
@@ -77,7 +77,12 @@ function ipc_send(method, arg, to = IPC_MAIN) {
   ipc.send("ipc_switch", method, IPC_BACKGROUND, arg, to);
 }
 
-const dataBlacklist = ["changes", "drafts", "events", "matches"];
+const dataBlacklist = [
+  "transactionList",
+  "draftList",
+  "eventList",
+  "matchList"
+];
 
 const overlayWhitelist = [
   "name",
@@ -94,7 +99,7 @@ const overlayWhitelist = [
 
 // convenience fn to update player data singletons in all processes
 // (update is destructive, be sure to use spread syntax if necessary)
-function pd_set(data) {
+function setData(data) {
   const cleanData = _.omit(data, dataBlacklist);
   pd.handleSetData(null, cleanData);
   ipc_send("set_player_data", cleanData, IPC_MAIN);
@@ -106,6 +111,6 @@ module.exports = {
   ipc_send,
   normaliseFields,
   parseWotcTime,
-  pd_set,
+  setData,
   unleakString
 };

--- a/window_background/http-api.js
+++ b/window_background/http-api.js
@@ -15,7 +15,7 @@ const async = require("async");
 const qs = require("qs");
 
 const { makeId } = require("../shared/util");
-const { ipc_send, pd_set } = require("./background-util");
+const { ipc_send, setData } = require("./background-util");
 
 let metadataState = false;
 
@@ -38,7 +38,7 @@ function httpBasic() {
         _headers.method != "get_database" &&
         debugLog == false
       ) {
-        pd_set({ offline: true });
+        setData({ offline: true });
         callback({
           message: "Settings dont allow sending data! > " + _headers.method
         });
@@ -208,7 +208,7 @@ function httpBasic() {
                   serverData.drafts = parsedResult.drafts;
                   serverData.economy = parsedResult.economy;
                 }
-                pd_set(data);
+                setData(data);
                 ipc_send("player_data_updated");
                 loadPlayerConfig(pd.arenaId, serverData);
                 ipc_send("set_discord_tag", parsedResult.discord_tag);
@@ -397,7 +397,7 @@ function notificationSetTimeout() {
 
 function httpAuth(userName, pass) {
   var _id = makeId(6);
-  pd_set({ userName });
+  setData({ userName });
   httpAsync.push({
     reqId: _id,
     method: "auth",

--- a/window_background/labels.js
+++ b/window_background/labels.js
@@ -52,7 +52,7 @@ const {
   ipc_send,
   normaliseFields,
   parseWotcTime,
-  pd_set
+  setData
 } = require("./background-util");
 //
 function convert_deck_from_v3(deck) {
@@ -296,7 +296,7 @@ function onLabelInEventGetCombinedRankInfo(entry, json) {
   rank.limited.lost = json.limitedMatchesLost;
   rank.limited.drawn = json.limitedMatchesDrawn;
 
-  pd_set({ rank });
+  setData({ rank });
   if (debugLog || !firstPass) store.set("rank", rank);
   ipc_send("player_data_updated");
 }
@@ -322,7 +322,7 @@ function onLabelRankUpdated(entry, json) {
     rank.limited.step = json.newStep;
   }
 
-  pd_set({ rank });
+  setData({ rank });
   if (debugLog || !firstPass) store.set("rank", rank);
   ipc_send("player_data_updated");
 }
@@ -339,7 +339,7 @@ function onLabelInDeckGetDeckLists(entry, json) {
     static_decks.push(deck.id);
   });
 
-  pd_set({ decks, static_decks });
+  setData({ decks, static_decks });
   if (debugLog || !firstPass) store.set("static_decks", static_decks);
   if (debugLog || !firstPass) ipc_send("player_data_refresh");
 }
@@ -487,7 +487,7 @@ function onLabelInDeckUpdateDeck(entry, json) {
     if (debugLog || !firstPass)
       store.set("deck_changes_index", deck_changes_index);
 
-    pd_set({ deck_changes, deck_changes_index });
+    setData({ deck_changes, deck_changes_index });
     if (!firstPass) ipc_send("player_data_refresh");
   }
 }
@@ -551,7 +551,7 @@ function onLabelInPlayerInventoryGetPlayerInventory(entry, json) {
     wcRare: json.wcRare,
     wcMythic: json.wcMythic
   };
-  pd_set({ economy });
+  setData({ economy });
   if (debugLog || !firstPass) store.set("economy", economy);
   if (debugLog || !firstPass) ipc_send("player_data_refresh");
 }
@@ -589,7 +589,7 @@ function onLabelInPlayerInventoryGetPlayerCardsV3(entry, json) {
     }
   });
 
-  pd_set({ cards, cardsNew });
+  setData({ cards, cardsNew });
   if (!firstPass) ipc_send("player_data_refresh");
 }
 

--- a/window_main/economy.js
+++ b/window_main/economy.js
@@ -149,8 +149,7 @@ function renderData(container, index) {
   // for performance reasons, we leave changes order mostly alone
   // to display most-recent-first, we use a reverse index
   const revIndex = sortedChanges.length - index - 1;
-  const economyId = sortedChanges[revIndex];
-  const change = pd.change(economyId);
+  const change = sortedChanges[revIndex];
 
   if (change === undefined) return 0;
   if (change.archived && !showArchived) return 0;
@@ -176,7 +175,7 @@ function renderData(container, index) {
     rowsAdded++;
   }
 
-  var div = createChangeRow(change, economyId);
+  const div = createChangeRow(change, change.id);
   container.appendChild(div);
   rowsAdded++;
 
@@ -691,15 +690,14 @@ function createChangeRow(change, economyId) {
 function createEconomyUI(mainDiv) {
   daysago = -999;
   dayList = [];
-  sortedChanges = [...pd.economy_index];
+  sortedChanges = [...pd.transactionList];
   sortedChanges.sort(compare_economy);
 
   var topSelectItems = ["All", "Day Summaries"];
   var selectItems = [];
 
   for (var n = 0; n < sortedChanges.length; n++) {
-    const economyId = sortedChanges[n];
-    const change = pd.change(economyId);
+    const change = sortedChanges[n];
     if (change === undefined) continue;
     if (change.archived && !showArchived) continue;
 
@@ -841,15 +839,8 @@ function createEconomyUI(mainDiv) {
   daysago = -1;
 }
 
-// Compare two economy events OR the IDs of two economy events.
-// If two IDs are specified then events are retrieved from `economyHistory`
+// Compare two economy events
 function compare_economy(a, b) {
-  if (a === undefined) return 0;
-  if (b === undefined) return 0;
-
-  a = pd.change(a);
-  b = pd.change(b);
-
   if (a === undefined) return 0;
   if (b === undefined) return 0;
 

--- a/window_main/events.js
+++ b/window_main/events.js
@@ -35,7 +35,7 @@ function openEventsTab(_filters, dataIndex = 25, scrollTop = 0) {
   const d = createDiv(["list_fill"]);
   mainDiv.appendChild(d);
 
-  sortedEvents = [...pd.events];
+  sortedEvents = [...pd.eventList];
   sortedEvents.sort(compare_courses);
   filters = { ...filters, ..._filters };
   filteredMatches = new Aggregator(filters);


### PR DESCRIPTION
### Motivation
This PR does some minor refactors:
- renames `pd_set` to `setData`
- standardizes several field names on `player-data`
- remove some deprecated fields from `player-data.defaultCfg`