### PR TITLE
centralize player_data_refresh IPC

### DIFF
--- a/window_background/background-util.js
+++ b/window_background/background-util.js
@@ -1,5 +1,7 @@
 /*
 global
+  debugLog
+  firstPass
   logLanguage
 */
 // Utility functions that belong only to background
@@ -99,12 +101,13 @@ const overlayWhitelist = [
 
 // convenience fn to update player data singletons in all processes
 // (update is destructive, be sure to use spread syntax if necessary)
-function setData(data) {
+function setData(data, refresh = debugLog || !firstPass) {
   const cleanData = _.omit(data, dataBlacklist);
   pd.handleSetData(null, cleanData);
   ipc_send("set_player_data", cleanData, IPC_MAIN);
   const overlayData = _.pick(cleanData, overlayWhitelist);
   ipc_send("set_player_data", overlayData, IPC_OVERLAY);
+  if (refresh) ipc_send("player_data_refresh");
 }
 
 module.exports = {

--- a/window_background/background.js
+++ b/window_background/background.js
@@ -606,7 +606,7 @@ function syncUserData(data) {
     });
   if (debugLog || !firstPass) store.set("draft_index", draft_index);
 
-  setData({ courses_index, draft_index, matches_index });
+  setData({ courses_index, draft_index, economy_index, matches_index });
 }
 
 // Merges settings and updates singletons across processes

--- a/window_background/http-api.js
+++ b/window_background/http-api.js
@@ -208,8 +208,7 @@ function httpBasic() {
                   serverData.drafts = parsedResult.drafts;
                   serverData.economy = parsedResult.economy;
                 }
-                setData(data);
-                ipc_send("player_data_updated");
+                setData(data, false);
                 loadPlayerConfig(pd.arenaId, serverData);
                 ipc_send("set_discord_tag", parsedResult.discord_tag);
                 httpNotificationsPull();
@@ -397,7 +396,7 @@ function notificationSetTimeout() {
 
 function httpAuth(userName, pass) {
   var _id = makeId(6);
-  setData({ userName });
+  setData({ userName }, false);
   httpAsync.push({
     reqId: _id,
     method: "auth",

--- a/window_background/labels.js
+++ b/window_background/labels.js
@@ -222,7 +222,7 @@ function onLabelOutLogInfo(entry, json) {
   if (json.params.messageName === "Client.SceneChange") {
     const { toSceneName } = json.params.payloadObject;
     if (toSceneName === "Home") {
-      if (!firstPass) ipc_send("set_arena_state", ARENA_MODE_IDLE);
+      if (debugLog || !firstPass) ipc_send("set_arena_state", ARENA_MODE_IDLE);
       duringMatch = false;
       endDraft();
     }
@@ -298,7 +298,6 @@ function onLabelInEventGetCombinedRankInfo(entry, json) {
 
   setData({ rank });
   if (debugLog || !firstPass) store.set("rank", rank);
-  ipc_send("player_data_updated");
 }
 
 function onLabelInEventGetActiveEvents(entry, json) {
@@ -324,7 +323,6 @@ function onLabelRankUpdated(entry, json) {
 
   setData({ rank });
   if (debugLog || !firstPass) store.set("rank", rank);
-  ipc_send("player_data_updated");
 }
 
 function onLabelInDeckGetDeckLists(entry, json) {
@@ -341,7 +339,6 @@ function onLabelInDeckGetDeckLists(entry, json) {
 
   setData({ decks, static_decks });
   if (debugLog || !firstPass) store.set("static_decks", static_decks);
-  if (debugLog || !firstPass) ipc_send("player_data_refresh");
 }
 
 function onLabelInDeckGetDeckListsV3(entry, json) {
@@ -488,7 +485,6 @@ function onLabelInDeckUpdateDeck(entry, json) {
       store.set("deck_changes_index", deck_changes_index);
 
     setData({ deck_changes, deck_changes_index });
-    if (!firstPass) ipc_send("player_data_refresh");
   }
 }
 
@@ -553,7 +549,6 @@ function onLabelInPlayerInventoryGetPlayerInventory(entry, json) {
   };
   setData({ economy });
   if (debugLog || !firstPass) store.set("economy", economy);
-  if (debugLog || !firstPass) ipc_send("player_data_refresh");
 }
 
 function onLabelInPlayerInventoryGetPlayerCardsV3(entry, json) {
@@ -590,7 +585,6 @@ function onLabelInPlayerInventoryGetPlayerCardsV3(entry, json) {
   });
 
   setData({ cards, cardsNew });
-  if (!firstPass) ipc_send("player_data_refresh");
 }
 
 function onLabelInEventDeckSubmit(entry, json) {
@@ -790,7 +784,7 @@ function onLabelMatchGameRoomStateChangedEvent(entry, json) {
     });
 
     clear_deck();
-    if (!firstPass) ipc_send("set_arena_state", ARENA_MODE_IDLE);
+    if (debugLog || !firstPass) ipc_send("set_arena_state", ARENA_MODE_IDLE);
     matchCompletedOnGameNumber = json.finalMatchResult.resultList.length - 1;
     saveMatch(json.finalMatchResult.matchId + "-" + pd.arenaId);
   }

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -173,13 +173,6 @@ function updateTopBar() {
 }
 
 //
-ipc.on("player_data_updated", () => {
-  if (sidebarActive != -99) {
-    updateTopBar();
-  }
-});
-
-//
 ipc.on("set_home", function(event, arg) {
   hideLoadingBars();
 
@@ -233,6 +226,9 @@ ipc.on("settings_updated", function() {
 //
 ipc.on("player_data_refresh", () => {
   const ls = getLocalState();
+  if (sidebarActive !== -99) {
+    updateTopBar();
+  }
   openTab(sidebarActive, {}, ls.lastDataIndex, ls.lastScrollTop);
 });
 


### PR DESCRIPTION
### Motivation
This is a "relatively safe" refactor focused on centralizing our `"player_data_refresh"` signals.

### Approach
- `background-util.setData` now takes explicit `refresh` param which sends `"player_data_refresh"`
  - smart default to `debugLog || !firstpass`
- remove (now redundant) old calls to `ipc_send`
- in places where we called `setData` _without_ an old call to `ipc_send`, prevent refresh signal if necessary

### Bonus Refactors
- combined `"player_data_updated"` and `"player_data_refresh"`
- `syncSettings` also accepts a `refresh` param
- grouped together some adjacent calls to `setData` to minimize signals
- removed last traces of deprecated `decks_index` from code
- made sure some other `firstPass` logic respected `debugLog`