### PR TITLE
bugfix overlays launch properly when tool starts mid match

### DIFF
--- a/window_background/background.js
+++ b/window_background/background.js
@@ -508,7 +508,7 @@ function loadPlayerConfig(playerId, serverData = undefined) {
       })
     }
   };
-  syncSettings(playerData.settings, false);
+  syncSettings(playerData.settings, true);
   setData(playerData, false);
 
   ipc_send("popup", {
@@ -1689,9 +1689,9 @@ function finishLoading() {
       }
       ipc_send("set_arena_state", ARENA_MODE_MATCH);
       update_deck(false);
+    } else if (duringDraft) {
+      ipc_send("set_arena_state", ARENA_MODE_DRAFT);
     }
-
-    if (duringDraft) ipc_send("set_arena_state", ARENA_MODE_DRAFT);
 
     ipc_send("renderer_set_bounds", pd.windowBounds);
     ipc_send("set_settings", pd.settings);


### PR DESCRIPTION
This fixes the logic for showing overlays when the tool is launched mid-Arena-match
(I may have broken it during #448)