### PR TITLE
static_events bugfixes archival logic and lore completion

### DIFF
--- a/shared/player-data.js
+++ b/shared/player-data.js
@@ -141,6 +141,7 @@ const defaultCfg = {
   decks_tags: {},
   decks_last_used: [],
   static_decks: [],
+  static_events: [],
   tags_colors: {}
 };
 
@@ -334,7 +335,11 @@ class PlayerData {
 
   event(id) {
     if (!this.eventExists(id)) return false;
-    return { ...this[id], type: "Event" };
+    return {
+      ...this[id],
+      custom: !this.static_events.includes(id),
+      type: "Event"
+    };
   }
 
   eventExists(id) {

--- a/window_background/labels.js
+++ b/window_background/labels.js
@@ -349,13 +349,18 @@ function onLabelInDeckGetDeckListsV3(entry, json) {
 function onLabelInEventGetPlayerCourses(entry, json) {
   if (!json) return;
 
+  const static_events = [];
   json.forEach(course => {
     if (course.CurrentEventState != "PreMatch") {
       if (course.CourseDeck != null) {
         addCustomDeck(course.CourseDeck);
       }
     }
+    if (course.Id) static_events.push(course.Id);
   });
+
+  setData({ static_events });
+  if (debugLog || !firstPass) store.set("static_events", static_events);
 }
 
 function onLabelInEventGetPlayerCoursesV2(entry, json) {

--- a/window_main/economy.js
+++ b/window_main/economy.js
@@ -117,7 +117,7 @@ function getPrettyContext(context, full = true) {
   if (context == undefined || !context) {
     return "-";
   }
-  
+
   if (context.startsWith("Event.Prize")) {
     var eventCode = context.substring(12);
     return full ? `Event Prize: ${getReadableEvent(eventCode)}` : "Event Prize";

--- a/window_main/events.js
+++ b/window_main/events.js
@@ -100,19 +100,23 @@ function renderData(container, index) {
     return 0;
   }
 
-  var tileGrpid = course.CourseDeck.deckTileId;
+  const tileGrpid = course.CourseDeck.deckTileId;
+  let listItem;
+  if (course.custom) {
+    const archiveCallback = id => {
+      toggleArchived(id);
+    };
 
-  const archiveCallback = id => {
-    toggleArchived(id);
-  };
-
-  const listItem = new ListItem(
-    tileGrpid,
-    course.id,
-    expandEvent,
-    archiveCallback,
-    course.archived
-  );
+    listItem = new ListItem(
+      tileGrpid,
+      course.id,
+      expandEvent,
+      archiveCallback,
+      course.archived
+    );
+  } else {
+    listItem = new ListItem(tileGrpid, course.id, expandEvent);
+  }
   listItem.divideLeft();
   listItem.divideRight();
   attachEventData(listItem, course);
@@ -193,7 +197,7 @@ function attachEventData(listItem, course) {
   });
 
   var eventState = course.CurrentEventState;
-  if (eventState == "DoneWithMatches" || eventState == 2) {
+  if (course.custom || eventState === "DoneWithMatches" || eventState === 2) {
     listItem.rightTop.appendChild(createDiv(["list_event_phase"], "Completed"));
   } else {
     listItem.rightTop.appendChild(


### PR DESCRIPTION
This PR imitates our logical approach to decks in order to fix a few issues with events.
- adds `static_events` and populates based on most recent `onLabelInEventGetPlayerCourses`
- events page now only lets the user archive "custom" (non-static) events
  - this prevents confusing "I-thought-I-archived-this-why-did-it-reappear" behavior
- events page now displays old (non-static) events as completed
  - this takes care of wacky new lingering Lore events and other edge cases for players with old data

### Demo
![image](https://user-images.githubusercontent.com/14894693/60389509-1411b000-9a77-11e9-930f-86ec75887921.png)

