### PR TITLE
bugfix show deck updates when user skips deck list

### DIFF
--- a/window_background/labels.js
+++ b/window_background/labels.js
@@ -491,6 +491,11 @@ function onLabelInDeckUpdateDeck(entry, json) {
 
     setData({ deck_changes, deck_changes_index });
   }
+
+  const deckData = { ..._deck, ...json };
+  const decks = { ...pd.decks, [json.id]: deckData };
+  if (debugLog || !firstPass) store.set("decks." + json.id, deckData);
+  setData({ decks });
 }
 
 function onLabelInDeckUpdateDeckV3(entry, json) {


### PR DESCRIPTION
### Motivation
This set of actions will cause the mtgatool to have the incorrect version of a deck (until the next time the user restarts Arena or visits their decks page in Arena):
1. Launch Arena
2. Edit a deck and make a change
3. Navigate away using something other than the okay button
4. Accept and save changes when prompted
5. Close Arena
6. mtgatool will have the outdated version of the deck

expected behavior: mtgatool has the most recent version of the deck

### Approach
This minor bugfix keeps the mtgatool deck state more consistent by adding an update to affected deck at the end of `onLabelInDeckUpdateDeck` (instead of waiting for the next `onLabelInDeckGetDeckLists`).