### PR TITLE
bugfix duplicate app settings in user settings

### DIFF
--- a/shared/player-data.js
+++ b/shared/player-data.js
@@ -1,5 +1,6 @@
 const electron = require("electron");
 const ipc = electron.ipcRenderer;
+const _ = require("lodash");
 
 const {
   CARD_TILE_FLAT,
@@ -281,6 +282,16 @@ class PlayerData {
       if (blacklistKeys.includes(key)) return;
       data[key] = value;
     });
+
+    const settingsBlacklistKeys = [
+      "toolVersion",
+      "auto_login",
+      "launch_to_tray",
+      "remember_me",
+      "beta_channel"
+    ];
+    data.settings = _.omit(data.settings, settingsBlacklistKeys);
+
     // console.log(data);
     return data;
   }

--- a/window_background/background.js
+++ b/window_background/background.js
@@ -523,21 +523,24 @@ function loadPlayerConfig(playerId, serverData = undefined) {
 
   const savedData = store.get();
   const savedOverlays = savedData.settings.overlays || [];
+  const appSettings = rstore.get("settings");
+  const settings = {
+    ...pd.settings,
+    ...savedData.settings,
+    ...appSettings,
+    overlays: pd.settings.overlays.map((overlay, index) => {
+      if (index < savedOverlays.length) {
+        // blend in new default overlay settings
+        return { ...overlay, ...savedOverlays[index] };
+      } else {
+        return overlay;
+      }
+    })
+  };
   const playerData = {
     ...pd,
     ...savedData,
-    settings: {
-      ...pd.settings,
-      ...savedData.settings,
-      overlays: pd.settings.overlays.map((overlay, index) => {
-        if (index < savedOverlays.length) {
-          // blend in new default overlay settings
-          return { ...overlay, ...savedOverlays[index] };
-        } else {
-          return overlay;
-        }
-      })
-    }
+    settings
   };
   syncSettings(playerData.settings, true);
   setData(playerData, false);


### PR DESCRIPTION
### Motivation
During one of my earlier refactors involving the player data store, I accidentally let the application-level settings get copied over into the user-level settings. This PR fixes the problem and keeps the two separate in the JSON files again.

I believe the easiest way to see this bug in action is:
1. Launch app and check to make sure "Login automatically" is enabled
2. Exit app
3. Launch app and go back to settings
4. Disable "Login automatically"
5. Exit app, relaunch, manually login as expected
6. Go back to settings
7. "Login automatically" is incorrectly shown as enabled

Expected:
7. "Login automatically" is shown as disabled (the way we left it in step 4).

### Demo of fix
![image](https://user-images.githubusercontent.com/14894693/60626707-7da7fc00-9da0-11e9-9de7-23d5e4b9c3a3.png)
