### PR TITLE
Offline auto-login

### DIFF
--- a/main.js
+++ b/main.js
@@ -35,7 +35,6 @@ var mainTimeout = null;
 
 var tray = null;
 var closeToTray = true;
-let autoLogin = false;
 let launchToTray = false;
 
 const ipc = electron.ipcMain;
@@ -209,9 +208,6 @@ function startApp() {
       case "set_db":
         mainWindow.webContents.send("set_db", arg);
         overlayMux();
-        if (autoLogin) {
-          background.webContents.send("auto_login");
-        }
         break;
 
       case "popup":
@@ -355,7 +351,6 @@ function startApp() {
 function initialize(settings) {
   console.log("MAIN:  Initializing");
   closeToTray = settings.close_to_tray;
-  autoLogin = settings.auto_login;
   launchToTray = settings.launch_to_tray;
   if (!launchToTray) showWindow();
 }
@@ -366,7 +361,6 @@ function setSettings(settings) {
     openAtLogin: settings.startup
   });
   closeToTray = settings.close_to_tray;
-  autoLogin = settings.auto_login;
   launchToTray = settings.launch_to_tray;
   mainWindow.webContents.send("settings_updated");
 

--- a/shared/shared.css
+++ b/shared/shared.css
@@ -233,7 +233,7 @@ label {
     top: -400%;
 }
 
-.signup_link {
+.signup_link, .privacy_link, .launch_login_link{
     color: rgb(220, 195, 150);
     cursor: pointer;
 }

--- a/window_background/background.js
+++ b/window_background/background.js
@@ -264,25 +264,6 @@ ipc.on("start_background", function() {
   ) {
     ipc_send("show_whats_new");
   }
-
-  let username = "";
-  let password = "";
-  const remember_me = pd.settings.remember_me;
-
-  if (remember_me) {
-    username = rstore.get("email");
-    const token = rstore.get("token");
-    if (username != "" && token != "") {
-      password = HIDDEN_PW;
-      tokenAuth = token;
-    }
-  }
-
-  ipc_send("prefill_auth_form", {
-    username,
-    password,
-    remember_me
-  });
 });
 
 function offlineLogin() {
@@ -290,23 +271,6 @@ function offlineLogin() {
   loadPlayerConfig(pd.arenaId);
   setData({ userName: "", offline: true });
 }
-
-//
-ipc.on("auto_login", () => {
-  if (!pd.settings.auto_login) return;
-
-  tokenAuth = rstore.get("token");
-  ipc_send("popup", {
-    text: "Logging in automatically...",
-    time: 0,
-    progress: 2
-  });
-  if (pd.settings.remember_me) {
-    httpApi.httpAuth(rstore.get("email"), HIDDEN_PW);
-  } else {
-    offlineLogin();
-  }
-});
 
 //
 ipc.on("login", function(event, arg) {
@@ -333,6 +297,7 @@ ipc.on("request_draft_link", function(event, obj) {
 
 //
 ipc.on("windowBounds", (event, windowBounds) => {
+  if (firstPass) return;
   setData({ windowBounds }, false);
   store.set("windowBounds", windowBounds);
 });
@@ -544,6 +509,7 @@ function loadPlayerConfig(playerId, serverData = undefined) {
   };
   syncSettings(playerData.settings, true);
   setData(playerData, false);
+  ipc_send("renderer_set_bounds", pd.windowBounds);
 
   ipc_send("popup", {
     text: "Player history loaded.",
@@ -1036,15 +1002,55 @@ async function logLoop() {
     ipc_send("ipc_log", `Initial log parse: ${key}=${parsedData[key]}`);
   }
   setData(parsedData, false);
-  ipc_send("popup", { text: "Found Arena log for " + pd.name, time: 0 });
 
-  if (pd.arenaId) {
-    clearInterval(logLoopInterval);
-  }
   prevLogSize = size;
 
-  if (firstPass && pd.name === null) {
-    ipc_send("popup", { text: "output_log contains no player data", time: 0 });
+  if (!pd.arenaId || !pd.name) {
+    ipc_send("popup", {
+      text: "output_log.txt contains no player data",
+      time: 0
+    });
+    return;
+  }
+
+  ipc_send("popup", { text: "Found Arena log for " + pd.name, time: 0 });
+  clearInterval(logLoopInterval);
+
+  let username = "";
+  let password = "";
+  const { auto_login, remember_me } = pd.settings;
+  if (remember_me) {
+    username = rstore.get("email");
+    const token = rstore.get("token");
+    if (username != "" && token != "") {
+      password = HIDDEN_PW;
+      tokenAuth = token;
+    }
+  }
+
+  ipc_send("prefill_auth_form", {
+    username,
+    password,
+    remember_me
+  });
+  ipc_send("show_login", true);
+
+  if (auto_login) {
+    if (remember_me && username && tokenAuth) {
+      ipc_send("popup", {
+        text: "Logging in automatically...",
+        time: 0,
+        progress: 2
+      });
+      httpApi.httpAuth(username, HIDDEN_PW);
+    } else {
+      ipc_send("popup", {
+        text: "Launching offline mode automatically...",
+        time: 0,
+        progress: 2
+      });
+      offlineLogin();
+    }
   }
 }
 
@@ -1731,9 +1737,9 @@ function finishLoading() {
       ipc_send("set_arena_state", ARENA_MODE_DRAFT);
     }
 
-    ipc_send("renderer_set_bounds", pd.windowBounds);
     ipc_send("set_settings", pd.settings);
-    ipc_send("initialize", 1);
+    ipc_send("initialize");
+    ipc_send("player_data_refresh");
 
     if (pd.name) {
       httpApi.httpSetPlayer(

--- a/window_background/http-api.js
+++ b/window_background/http-api.js
@@ -38,7 +38,7 @@ function httpBasic() {
         _headers.method != "get_database" &&
         debugLog == false
       ) {
-        setData({ offline: true });
+        if (!pd.offline) setData({ offline: true });
         callback({
           message: "Settings dont allow sending data! > " + _headers.method
         });
@@ -255,7 +255,9 @@ function httpBasic() {
                 });
                 db.handleSetDb(null, results);
                 ipc_send("set_db", results);
-                ipc_send("show_login", true);
+                // autologin users may beat the metadata request
+                // manually trigger a UI refresh just in case
+                ipc_send("player_data_refresh");
               }
             } else if (_headers.method == "tou_join") {
               ipc_send("popup", {
@@ -319,9 +321,6 @@ function httpBasic() {
         });
       });
       req.on("error", function(e) {
-        if (_headers.method == "get_database") {
-          ipc_send("show_login", true);
-        }
         console.error(`problem with request: ${e.message}`);
         if (!metadataState) {
           ipc_send("popup", {

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -143,7 +143,30 @@ function showLogin() {
 }
 
 //
+function updateNavIcons() {
+  if ($$(".top_nav_icons")[0].offsetWidth < 530) {
+    if (!top_compact) {
+      $$("span.top_nav_item_text").forEach(el => (el.style.opacity = 0));
+      $$(".top_nav_icon").forEach(el => (el.style.display = "block"));
+      $$(".top_nav_icon").forEach(el => (el.style.opacity = 1));
+      top_compact = true;
+    }
+  } else {
+    if (top_compact) {
+      $$("span.top_nav_item_text").forEach(el => (el.style.opacity = 1));
+      $$(".top_nav_icon").forEach(el => (el.style.opacity = 0));
+      window.setTimeout(() => {
+        $$(".top_nav_icon").forEach(el => (el.style.display = "none"));
+      }, 500);
+      top_compact = false;
+    }
+  }
+}
+
+//
 function updateTopBar() {
+  updateNavIcons();
+
   if (pd.offline || !pd.settings.send_data) {
     $$(".unlink")[0].style.display = "block";
   }
@@ -242,10 +265,15 @@ ipc.on("settings_updated", function() {
 
 //
 ipc.on("player_data_refresh", () => {
+  if (sidebarActive === MAIN_LOGIN) return;
   const ls = getLocalState();
-  if (sidebarActive !== MAIN_LOGIN) {
-    updateTopBar();
-  }
+  updateTopBar();
+  anime({
+    targets: ".moving_ux",
+    left: 0,
+    easing: EASING_DEFAULT,
+    duration: 350
+  });
   openTab(sidebarActive, {}, ls.lastDataIndex, ls.lastScrollTop);
 });
 
@@ -501,8 +529,28 @@ ipc.on("offline", function() {
 //
 function showOfflineSplash() {
   hideLoadingBars();
-  byId("ux_0").innerHTML =
-    '<div class="message_center_offline" style="display: flex; position: fixed;"><div class="message_unlink"></div><div class="message_big red">Oops, you are offline!</div><div class="message_sub_16 white">You can <a class="signup_link">sign up</a> to access online features.</div></div>';
+  byId("ux_0").innerHTML = `
+  <div class="message_center_offline" style="display: flex; position: fixed;">
+    <div class="message_unlink"></div>
+    <div class="message_big red">Oops, you are offline!</div>
+    <div class="message_sub_16 white">To access online features:</div>
+    <div class="message_sub_16 white">If you are logged in, you may need to <a class="privacy_link">enable online sharing</a> and restart.</div>
+    <div class="message_sub_16 white">If you are in offline mode, you can <a class="launch_login_link">login to your account</a>.</div>
+    <div class="message_sub_16 white">If you need an account, you can <a class="signup_link">sign up here</a>.</div>
+  </div>`;
+  $$(".privacy_link")[0].addEventListener("click", function() {
+    force_open_settings(4);
+  });
+  $$(".launch_login_link")[0].addEventListener("click", function() {
+    const clearAppSettings = {
+      remember_me: false,
+      auto_login: false,
+      launch_to_tray: false
+    };
+    ipcSend("save_app_settings", clearAppSettings);
+    remote.app.relaunch();
+    remote.app.exit(0);
+  });
   $$(".signup_link")[0].addEventListener("click", function() {
     shell.openExternal("https://mtgatool.com/signup/");
   });
@@ -553,25 +601,7 @@ let resizeTimer;
 window.addEventListener("resize", () => {
   hideLoadingBars();
   clearTimeout(resizeTimer);
-  resizeTimer = setTimeout(() => {
-    if ($$(".top_nav_icons")[0].offsetWidth < 530) {
-      if (!top_compact) {
-        $$("span.top_nav_item_text").forEach(el => (el.style.opacity = 0));
-        $$(".top_nav_icon").forEach(el => (el.style.display = "block"));
-        $$(".top_nav_icon").forEach(el => (el.style.opacity = 1));
-        top_compact = true;
-      }
-    } else {
-      if (top_compact) {
-        $$("span.top_nav_item_text").forEach(el => (el.style.opacity = 1));
-        $$(".top_nav_icon").forEach(el => (el.style.opacity = 0));
-        window.setTimeout(() => {
-          $$(".top_nav_icon").forEach(el => (el.style.display = "none"));
-        }, 500);
-        top_compact = false;
-      }
-    }
-  }, 100);
+  resizeTimer = setTimeout(updateNavIcons, 100);
 });
 
 function ready(fn) {

--- a/window_main/settings.js
+++ b/window_main/settings.js
@@ -169,7 +169,7 @@ function appendBehaviour(section) {
   );
   addCheckbox(
     section,
-    "Login automatically",
+    "Login/offline mode automatically",
     "settings_autologin",
     pd.settings.auto_login,
     updateAppSettings
@@ -747,7 +747,7 @@ function appendPrivacy(section) {
   );
   addCheckbox(
     section,
-    "Online sharing&nbsp;<i>(when disabled, blocks any connections with our servers)</i>",
+    "Online sharing&nbsp;<i>(when disabled, uses offline mode and only contacts our servers to fetch Arena metadata)</i>",
     "settings_senddata",
     pd.settings.send_data,
     updateUserSettings


### PR DESCRIPTION
### Motivation
This is a grudge match. I attempted to get auto-login to work as one of my first contributions to the project, and ever since I have been struggling to get this feature to work for users in offline mode. A few different users have requested this, most recently in https://github.com/Manuel-777/MTG-Arena-Tool/issues/443.

### Approach
The delicate tangle of bootstraps and spaghetti code at the launch of our app continues to baffle me, but here is my latest idea:
- Change the first time we let users access the login page / initiate the auto-login feature:
  - used to be when we receive a response for the initial metadata DB request (or timeout)
  - now when we complete a successful initial pull of `arenaID` and `name` from the fast `logLoop`

### Bonuses
- Update settings help text to make sharing settings and auto-login clearer
- Update offline splash page to give more practical suggestions in a variety of cases
- bugfix: do not spam the user with UI refreshes when a bunch of queries fail at once
- bugfix: ensure nav bar icons are always in the correct sized mode for certain edge cases
