### PR TITLE
common code for dialogs

### DIFF
--- a/window_main/history.js
+++ b/window_main/history.js
@@ -5,11 +5,7 @@ const { MANA, RANKS, EASING_DEFAULT } = require("../shared/constants");
 const db = require("../shared/database");
 const pd = require("../shared/player-data");
 const { createSelect } = require("../shared/select");
-const {
-  createDiv,
-  createInput,
-  queryElements: $$
-} = require("../shared/dom-fns");
+const { createDiv, createInput } = require("../shared/dom-fns");
 const {
   get_deck_colors,
   get_rank_index_16,
@@ -30,6 +26,7 @@ const {
   getTagColor,
   ipcSend,
   makeResizable,
+  openDialog,
   openDraft,
   resetMainContainer,
   showColorpicker,
@@ -353,36 +350,10 @@ function attachDraftData(listItem, draft) {
   const replayShareButton = createDiv(["list_draft_share", draft.id + "dr"]);
   replayShareButton.addEventListener("click", e => {
     e.stopPropagation();
-    const wrapper = $$(".dialog_wrapper")[0];
-    wrapper.style.opacity = 1;
-    wrapper.style.pointerEvents = "all";
-    wrapper.style.display = "block";
+    const cont = createDiv(["dialog_content"]);
+    cont.style.width = "500px";
 
-    const dialog = $$(".dialog")[0];
-    dialog.innerHTML = "";
-    dialog.style.opacity = 1;
-    dialog.style.width = "500px";
-    dialog.style.height = "200px";
-    dialog.style.top = "calc(50% - 100px)";
-    dialog.addEventListener("click", function(e) {
-      e.stopPropagation();
-    });
-
-    wrapper.addEventListener("click", function() {
-      wrapper.style.opacity = 0;
-      wrapper.style.pointerEvents = "none";
-
-      setTimeout(() => {
-        wrapper.style.display = "none";
-        dialog.style.width = "400px";
-        dialog.style.height = "160px";
-        dialog.style.top = "calc(50% - 80px)";
-      }, 250);
-    });
-
-    const cont = createDiv(["dialog_container"]);
-
-    cont.append(createDiv(["share_title"], "Link For sharing:"));
+    cont.append(createDiv(["share_title"], "Link for sharing:"));
     const icd = createDiv(["share_input_container"]);
     const linkInput = createInput([], "", {
       id: "share_input",
@@ -406,7 +377,7 @@ function attachDraftData(listItem, draft) {
       "expire_select"
     );
 
-    dialog.appendChild(cont);
+    openDialog(cont);
     draftShareLink(draft.id);
   });
   listItem.right.after(replayShareButton);

--- a/window_main/index.css
+++ b/window_main/index.css
@@ -2107,32 +2107,32 @@ a:hover {
     background-color: rgba(0, 0, 0, 0.6);
     width: 100%;
     height: 100%;
-    -webkit-transition: all .15s cubic-bezier(1, 0.35, 0.35, 1);
 }
 
 .dialog {
     z-index: 40;
-    display: flex;
+    opacity: 0;
     position: relative;
-    flex-direction: column;
     top: calc(50% - 80px);
     margin: auto;
-    width: 400px;
-    height: 160px;
     background-color: var(--color-back);
     border: 1px solid var(--color-light-50);
     border-radius: 5px;
     box-shadow: 0px 2px 16px 0px black;
-    -webkit-transition: all .25s cubic-bezier(1, 0.35, 0.35, 1);
 }
 
-.dialog_container {
-    margin: 16px;
+.dialog_content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 400px;
+    margin: 16px auto;
 }
 
 .share_input_container {
     display: flex;
     height: 32px;
+    width: 100%;
     margin: 8px 0px;
 }
 
@@ -3358,6 +3358,7 @@ a:hover {
 .wnew_prev {
     background: url(../images/prev.png) no-repeat;
     background-position: left;
+    right: 50%;
 }
 
 .wnew_next {

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -47,9 +47,11 @@ const {
 
 const {
   changeBackground,
+  closeDialog,
   getLocalState,
   hideLoadingBars,
   ipcSend,
+  openDialog,
   pop,
   resetMainContainer,
   setLocalState,
@@ -421,31 +423,13 @@ ipc.on("no_log", function(event, arg) {
       '</div><div class="message_sub_16 white">if it does, try closing MTG Arena and deleting it.</div>';
   } else if (!logDialogOpen) {
     logDialogOpen = true;
-    $$(".dialog_wrapper")[0].style.opacity = 1;
-    $$(".dialog_wrapper")[0].style.pointerEvents = "all";
-    $$(".dialog_wrapper")[0].style.display = "block";
-    $$(".dialog")[0].style.width = "600px";
-    $$(".dialog")[0].style.height = "200px";
-    $$(".dialog")[0].style.top = "calc(50% - 100px)";
 
-    $$(".dialog_wrapper")[0].addEventListener("click", function() {
-      // console.log(".dialog_wrapper on click");
-      //e.stopPropagation();
-      hideDialog();
-    });
+    const cont = createDiv(["dialog_content"]);
+    cont.style.width = "600px";
 
-    $$(".dialog")[0].addEventListener("click", function(e) {
-      e.stopPropagation();
-      // console.log(".dialog on click");
-    });
-
-    const dialog = $$(".dialog")[0];
-    dialog.innerHTML = "";
-
-    const cont = createDiv(["dialog_container"]);
-    cont.appendChild(
-      createDiv(["share_title"], "Enter output_log.txt location:")
-    );
+    const title = createDiv(["share_title"], "Enter output_log.txt location:");
+    title.style.margin = "12px auto";
+    cont.appendChild(title);
     const icd = createDiv(["share_input_container"]);
     const sin = createInput([], "", {
       id: "log_input",
@@ -456,42 +440,23 @@ ipc.on("no_log", function(event, arg) {
     sin.style.borderRadius = "3px";
     sin.style.height = "28px";
     sin.style.fontSize = "14px";
+    sin.style.margin = 0;
     icd.appendChild(sin);
     cont.appendChild(icd);
-    dialog.appendChild(cont);
 
     const but = createDiv(["button_simple"], "Save");
+    but.style.marginLeft = "auto";
+    but.style.marginRight = "auto";
     but.addEventListener("click", function() {
       ipcSend("set_log", byId("log_input").value);
-      // console.log(".dialog_wrapper on click");
-      //e.stopPropagation();
-      hideDialog();
+      closeDialog();
+      logDialogOpen = false;
     });
-    dialog.appendChild(but);
+    cont.appendChild(but);
+
+    openDialog(cont, () => (logDialogOpen = false));
   }
 });
-
-//
-ipc.on("log_ok", function() {
-  logDialogOpen = false;
-  hideDialog();
-});
-
-//
-let dialogTimeout = null;
-function hideDialog() {
-  $$(".dialog_wrapper")[0].style.opacity = 0;
-  $$(".dialog_wrapper")[0].style.pointerEvents = "none";
-  if (dialogTimeout) clearTimeout(dialogTimeout);
-  dialogTimeout = setTimeout(function() {
-    $$(".dialog_wrapper")[0].style.display = "none";
-    $$(".dialog")[0].style.width = "500px";
-    $$(".dialog")[0].style.height = "160px";
-    $$(".dialog")[0].style.top = "calc(50% - 80px)";
-    logDialogOpen = false;
-    dialogTimeout = null;
-  }, 250);
-}
 
 //
 ipc.on("offline", function() {

--- a/window_main/whats-new.js
+++ b/window_main/whats-new.js
@@ -1,5 +1,7 @@
-const { createDiv, queryElements } = require("../shared/dom-fns");
 const { remote } = require("electron");
+
+const { createDiv, queryElements } = require("../shared/dom-fns");
+const { openDialog } = require("./renderer-util");
 
 // We should clear this on releases and fill as we add new features
 const screens = [
@@ -26,17 +28,11 @@ let selectedScreen = 0;
 function showWhatsNew() {
   // Only show if we actually do have stuff to show
   if (screens.length == 0) return;
-  const dialog = queryElements(".dialog")[0];
-  dialog.innerHTML = "";
-  dialog.style.opacity = 1;
-  dialog.style.width = "80vw";
-  dialog.style.height = "80vh";
-  dialog.style.top = "10vh";
-  dialog.style.justifyContent = "center";
-  dialog.style.overflow = "hidden";
-  dialog.addEventListener("click", function(e) {
-    e.stopPropagation();
-  });
+  const cont = createDiv(["dialog_content"]);
+  cont.style.width = "80vw";
+  cont.style.height = "80vh";
+  cont.style.justifyContent = "center";
+  cont.style.overflow = "hidden";
 
   let title = createDiv(["wnew_title"], "What is new?");
   let subVersion = createDiv(
@@ -45,7 +41,7 @@ function showWhatsNew() {
   );
   let scrollerContainer = createDiv(["wnew_scroller"]);
   scrollerContainer.style.width = screens.length * 100 + "%";
-  scrollerContainer.style.left = selectedScreen * -100 + "%";
+  scrollerContainer.style.left = 100 + selectedScreen * -100 + "%";
 
   let scrollerPosCont = createDiv(["wnew_scroller_pos_cont"]);
   let prev = createDiv(["wnew_prev"]);
@@ -74,7 +70,7 @@ function showWhatsNew() {
 
   let updateScroller = function() {
     let scrollerContainer = queryElements(".wnew_scroller")[0];
-    scrollerContainer.style.left = selectedScreen * -100 + "%";
+    scrollerContainer.style.left = 100 + selectedScreen * -100 + "%";
 
     screens.forEach((sc, index) => {
       let pName = ".pos_ball_" + index;
@@ -98,29 +94,14 @@ function showWhatsNew() {
     updateScroller();
   });
 
-  dialog.appendChild(title);
-  dialog.appendChild(subVersion);
-  dialog.appendChild(scrollerContainer);
-  dialog.appendChild(scrollerPosCont);
-  dialog.appendChild(prev);
-  dialog.appendChild(next);
+  cont.appendChild(title);
+  cont.appendChild(subVersion);
+  cont.appendChild(scrollerContainer);
+  cont.appendChild(scrollerPosCont);
+  cont.appendChild(prev);
+  cont.appendChild(next);
 
-  const wrapper = queryElements(".dialog_wrapper")[0];
-  wrapper.style.opacity = 1;
-  wrapper.style.pointerEvents = "all";
-  wrapper.style.display = "block";
-
-  wrapper.addEventListener("click", function() {
-    wrapper.style.opacity = 0;
-    wrapper.style.pointerEvents = "none";
-
-    setTimeout(() => {
-      wrapper.style.display = "none";
-      dialog.style.width = "400px";
-      dialog.style.height = "160px";
-      dialog.style.top = "calc(50% - 80px)";
-    }, 250);
-  });
+  openDialog(cont);
 }
 
 module.exports = { showWhatsNew };


### PR DESCRIPTION
### Motivation
A few recent bugs related to dialogs showed us that we have a bunch of copy-paste code that would be easier to maintain if we converted it into a couple of common functions.

### Approach
Create common dialog fns using `anime`:
- `renderer-util.openDialog` (w optional custom close handler)
- `renderer-util.closeDialog`

Replaces existing copy-paste dialog code with the new common code for these dialogs:
- custom location for `output_log.txt` (before login)
- color picker for tags on decks and history page
- draft replay link share on history page
- what's new dialog (settings >> about page)