### PR TITLE
Bugfix mastery track

### DIFF
--- a/window_background/background.js
+++ b/window_background/background.js
@@ -77,7 +77,8 @@ const {
   onLabelInEventGetSeasonAndRankDetail,
   onLabelGetPlayerInventoryGetRewardSchedule,
   onLabelRankUpdated,
-  onLabelTrackProgressUpdated
+  onLabelTrackProgressUpdated,
+  onLabelTrackRewardTierUpdated
 } = require("./labels");
 
 const toolVersion = electron.remote.app
@@ -827,6 +828,11 @@ function onLogEntryFound(entry) {
           case "TrackProgress.Updated":
             json = entry.json();
             onLabelTrackProgressUpdated(entry, json);
+            break;
+
+          case "TrackRewardTier.Updated":
+            json = entry.json();
+            onLabelTrackRewardTierUpdated(entry, json);
             break;
 
           case "Event.DeckSubmit":

--- a/window_background/labels.js
+++ b/window_background/labels.js
@@ -671,6 +671,47 @@ function onLabelTrackProgressUpdated(entry, json) {
   if (debugLog || !firstPass) store.set("economy", economy);
 }
 
+//
+function onLabelTrackRewardTierUpdated(entry, json) {
+  if (!json) return;
+  // console.log(json);
+  const economy = { ...pd.economy };
+
+  const transaction = {
+    context: "Track.RewardTier.Updated",
+    timestamp: entry.timestamp,
+    date: parseWotcTime(entry.timestamp),
+    delta: {},
+    ...json
+  };
+
+  if (transaction.inventoryDelta) {
+    // this is redundant data, removing to save space
+    delete transaction.inventoryDelta;
+  }
+  if (transaction.newTier !== undefined) {
+    economy.trackTier = transaction.newTier;
+  }
+
+  if (transaction.orbCountDiff) {
+    const orbDiff = minifiedDelta(transaction.orbCountDiff);
+    transaction.orbCountDiff = orbDiff;
+    if (orbDiff.currentOrbCount !== undefined) {
+      economy.currentOrbCount = orbDiff.currentOrbCount;
+    }
+  }
+
+  // Construct a unique ID
+  transaction.id = sha1(
+    entry.timestamp + transaction.oldTier + transaction.newTier
+  );
+  saveEconomyTransaction(transaction);
+
+  // console.log(economy);
+  setData({ economy });
+  if (debugLog || !firstPass) store.set("economy", economy);
+}
+
 function onLabelInEventDeckSubmit(entry, json) {
   if (!json) return;
   select_deck(json);
@@ -947,5 +988,6 @@ module.exports = {
   onLabelInEventGetSeasonAndRankDetail,
   onLabelGetPlayerInventoryGetRewardSchedule,
   onLabelRankUpdated,
-  onLabelTrackProgressUpdated
+  onLabelTrackProgressUpdated,
+  onLabelTrackRewardTierUpdated
 };

--- a/window_background/labels.js
+++ b/window_background/labels.js
@@ -621,15 +621,15 @@ function onLabelTrackProgressUpdated(entry, json) {
   if (!json) return;
   // console.log(json);
   const economy = { ...pd.economy };
-  json.forEach(entry => {
-    if (!entry.trackDiff) return; // ignore rewardWebDiff updates for now
+  json.forEach(track => {
+    if (!track.trackDiff) return; // ignore rewardWebDiff updates for now
 
     const transaction = {
       context: "Track Progress",
       timestamp: entry.timestamp,
       date: parseWotcTime(entry.timestamp),
       delta: {},
-      ...entry
+      ...track
     };
 
     const trackDiff = minifiedDelta(transaction.trackDiff);
@@ -639,11 +639,11 @@ function onLabelTrackProgressUpdated(entry, json) {
     }
     transaction.trackDiff = trackDiff;
 
-    if (entry.trackName) {
-      economy.trackName = entry.trackName;
+    if (track.trackName) {
+      economy.trackName = track.trackName;
     }
-    if (entry.trackTier !== undefined) {
-      economy.trackTier = entry.trackTier;
+    if (track.trackTier !== undefined) {
+      economy.trackTier = track.trackTier;
     }
     if (trackDiff.currentLevel !== undefined) {
       economy.currentLevel = trackDiff.currentLevel;

--- a/window_background/labels.js
+++ b/window_background/labels.js
@@ -625,7 +625,7 @@ function onLabelTrackProgressUpdated(entry, json) {
     if (!track.trackDiff) return; // ignore rewardWebDiff updates for now
 
     const transaction = {
-      context: "Track Progress",
+      context: "Track.Progress." + (track.trackName || ""),
       timestamp: entry.timestamp,
       date: parseWotcTime(entry.timestamp),
       delta: {},

--- a/window_main/economy.js
+++ b/window_main/economy.js
@@ -66,13 +66,15 @@ const economyTransactionContextsMap = {
   Store: "Store Transaction",
   "Store.Fulfillment": "Store Transaction",
   "Store.Fulfillment.Chest": "Store Transaction",
+  "Store.Fulfillment.Chest.ProgressionRewards": "Store Transaction",
   "Store.Fulfillment.Boosters": "Store Booster Purchase",
   "Store.Fulfillment.Gems": "Store Gems Purchase",
   "WildCard.Redeem": "Redeem Wildcard",
   "Vault.Complete": "Vault Opening",
   "PlayerReward.OnMatchCompletedWeekly": "Weekly Rewards",
   "PlayerProgression.OrbSpend": "Orb Spend",
-  "Track.Progress": "Track Progress"
+  "Track.Progress": "Track Progress",
+  "Track.RewardTier.Updated": "Mastery Pass Purchase"
 };
 
 const trackCodeMap = {

--- a/window_main/economy.js
+++ b/window_main/economy.js
@@ -23,6 +23,10 @@ const {
 } = require("./renderer-util");
 
 const byId = id => document.getElementById(id);
+const vaultPercentFormat = {
+  minimumFractionDigits: 1,
+  maximumFractionDigits: 1
+};
 var filterEconomy = "All";
 let showArchived = false;
 var daysago = 0;
@@ -254,7 +258,7 @@ function createDayHeader(change) {
   gridVault.appendChild(createDiv(["economy_vault"], "", { title: "Vault" }));
   const vatx = tx.cloneNode(true);
   const deltaPercent = dayList[daysago].vaultProgress / 100.0;
-  vatx.innerHTML = formatPercent(deltaPercent);
+  vatx.innerHTML = formatPercent(deltaPercent, vaultPercentFormat);
   const upcontva = createDiv(["economy_delta"]);
   upcontva.style.width = "auto";
   upcontva.appendChild(vatx);
@@ -665,7 +669,8 @@ function createChangeRow(change, economyId) {
           // only uncommons and commons go to vault
           let vaultProgressDelta =
             card.rarity === "uncommon" ? 1 / 300 : 1 / 900;
-          img.title = "Vault:+" + formatPercent(vaultProgressDelta);
+          img.title =
+            "Vault:+" + formatPercent(vaultProgressDelta, vaultPercentFormat);
         }
 
         d.appendChild(img);
@@ -873,7 +878,7 @@ function createEconomyUI(mainDiv) {
   icva.style.marginLeft = "24px";
   div.appendChild(icva);
   ntx = tx.cloneNode(true);
-  ntx.innerHTML = pd.economy.vault + "%";
+  ntx.innerHTML = formatPercent(pd.economy.vault / 100, vaultPercentFormat);
   div.appendChild(ntx);
 
   const icwcc = createDiv(["economy_wc_med", "wc_common"]);

--- a/window_main/economy.js
+++ b/window_main/economy.js
@@ -162,7 +162,7 @@ function renderData(container, index) {
   const revIndex = sortedChanges.length - index - 1;
   const change = sortedChanges[revIndex];
 
-  if (change === undefined) return 0;
+  if (!change) return 0;
   if (change.archived && !showArchived) return 0;
 
   // print out daily summaries but no sub-events
@@ -184,6 +184,16 @@ function renderData(container, index) {
   if (daysago != differenceInCalendarDays(new Date(), new Date(change.date))) {
     container.appendChild(createDayHeader(change));
     rowsAdded++;
+  }
+
+  // Track Progress txns are mostly redundant with inventory change txns
+  // Non-duplicate data (should be) only on txns with level changes
+  if (selectVal === "Track Progress") {
+    if (!change.trackDiff) return rowsAdded;
+    const lvlDelta = Math.abs(
+      (change.trackDiff.currentLevel || 0) - (change.trackDiff.oldLevel || 0)
+    );
+    if (!lvlDelta) return rowsAdded;
   }
 
   const div = createChangeRow(change, change.id);
@@ -243,11 +253,7 @@ function createDayHeader(change) {
   gridVault.style.gridArea = "1 / 3 / auto / 4";
   gridVault.appendChild(createDiv(["economy_vault"], "", { title: "Vault" }));
   const vatx = tx.cloneNode(true);
-  const rawDelta = dayList[daysago].vaultProgress;
-  // Assume vault can only be redeemed once per day
-  // Rely on modulo arithmetic to derive pure vault gain
-  const delta = rawDelta < 0 ? rawDelta + 100 : rawDelta;
-  const deltaPercent = delta / 100.0;
+  const deltaPercent = dayList[daysago].vaultProgress / 100.0;
   vatx.innerHTML = formatPercent(deltaPercent);
   const upcontva = createDiv(["economy_delta"]);
   upcontva.style.width = "auto";
@@ -504,20 +510,6 @@ function createChangeRow(change, economyId) {
       iclvl.style.lineHeight = "64px";
       flexRight.appendChild(iclvl);
     }
-
-    let expDelta =
-      (change.trackDiff.currentExp || 0) - (change.trackDiff.oldExp || 0);
-    if (expDelta) {
-      // Rely on modulo arithmetic to derive pure exp gain
-      if (expDelta < 0) expDelta += 1000;
-
-      flexRight.appendChild(
-        createDiv(["economy_exp"], "", { title: "Experience" })
-      );
-      bon = createDiv(["economy_sub"], formatNumber(expDelta));
-      bon.style.lineHeight = "64px";
-      flexRight.appendChild(bon);
-    }
   }
 
   if (change.orbCountDiff) {
@@ -531,6 +523,15 @@ function createChangeRow(change, economyId) {
       bon.style.lineHeight = "64px";
       flexRight.appendChild(bon);
     }
+  }
+
+  if (change.xpGained) {
+    flexRight.appendChild(
+      createDiv(["economy_exp"], "", { title: "Experience" })
+    );
+    bon = createDiv(["economy_sub"], formatNumber(change.xpGained));
+    bon.style.lineHeight = "64px";
+    flexRight.appendChild(bon);
   }
 
   if (checkBoosterAdded && change.delta.boosterDelta) {
@@ -798,16 +799,12 @@ function createEconomyUI(mainDiv) {
     if (change.delta.cardsAdded) {
       dayList[daysago].cardsEarned += change.delta.cardsAdded.length;
     }
-    if (change.delta.vaultProgressDelta) {
+    if (change.delta.vaultProgressDelta > 0) {
       dayList[daysago].vaultProgress += change.delta.vaultProgressDelta;
     }
 
-    if (change.trackDiff) {
-      let expDelta =
-        (change.trackDiff.currentExp || 0) - (change.trackDiff.oldExp || 0);
-      // Rely on modulo arithmetic to derive pure exp gain
-      if (expDelta < 0) expDelta += 1000;
-      dayList[daysago].expEarned += expDelta;
+    if (change.xpGained > 0) {
+      dayList[daysago].expEarned += change.xpGained;
     }
   }
   const selectItems = Object.keys(contextCounts);

--- a/window_main/economy.js
+++ b/window_main/economy.js
@@ -71,7 +71,13 @@ const economyTransactionContextsMap = {
   "WildCard.Redeem": "Redeem Wildcard",
   "Vault.Complete": "Vault Opening",
   "PlayerReward.OnMatchCompletedWeekly": "Weekly Rewards",
-  "PlayerProgression.OrbSpend": "Orb Spend"
+  "PlayerProgression.OrbSpend": "Orb Spend",
+  "Track.Progress": "Track Progress"
+};
+
+const trackCodeMap = {
+  BattlePass_M20: "Core Set 2020",
+  EarlyPlayerProgression: "New Player Experience"
 };
 
 function localDateFormat(date) {
@@ -91,6 +97,10 @@ function localDayDateFormat(date) {
     day="numeric">
     ${date.toDateString()}
   </local-time>`;
+}
+
+function getReadableTrack(trackCode) {
+  return trackCodeMap[trackCode] || trackCode;
 }
 
 function getReadableQuest(questCode) {
@@ -129,19 +139,26 @@ function getPrettyContext(context, full = true) {
     return "-";
   }
 
+  if (context.startsWith("Track.Progress")) {
+    const trackCode = context.substring(15);
+    return full
+      ? `Track Progress: ${getReadableTrack(trackCode)}`
+      : "Track Progress";
+  }
+
   if (context.startsWith("Event.Prize")) {
-    var eventCode = context.substring(12);
+    const eventCode = context.substring(12);
     return full ? `Event Prize: ${getReadableEvent(eventCode)}` : "Event Prize";
   }
 
   if (context.startsWith("Quest.Completed")) {
-    var questCode = context.substring(16);
+    const questCode = context.substring(16);
     return full
       ? `Quest Completed: ${getReadableQuest(questCode)}`
       : "Quest Completed";
   }
 
-  var pretty = economyTransactionContextsMap[context];
+  const pretty = economyTransactionContextsMap[context];
 
   // If there's no valid pretty context keep the code as is.
   return pretty || context;

--- a/window_main/renderer-util.js
+++ b/window_main/renderer-util.js
@@ -793,10 +793,9 @@ function showColorpicker(
 
 //
 exports.formatPercent = formatPercent;
-function formatPercent(value, config = {}) {
+function formatPercent(value, config = { maximumSignificantDigits: 2 }) {
   return value.toLocaleString([], {
     style: "percent",
-    maximumSignificantDigits: 2,
     ...config
   });
 }


### PR DESCRIPTION
### Motivation
Wizards gonna Wiz.

> "it seems highly likely to me that we will see the Arena mastery track data model change one more time when they release the next one"

### Dirty Details
- the log contains "inventory change" entries and "track progress" entries
  - both types of entry have lots of redundant data (e.g. gold delta, gem delta, exp delta)
  - each type of entry has some unique data (e.g. orb delta only on "track progress", `aetherizedCards` only on "inventory change"
- since we really want to show all kinds of data to the user, we have to blend the two together
  - original build (before weekly) showed experience delta on "track progress"
  - this PR shows experience delta on "inventory change" and hides all non-level-change "track progress" entries
- bonus bugfix: `labels.onLabelTrackProgressUpdated` correctly uses log entry timestamp
- bonus refactor: Economy page no longer relies on any modulo arithmetic for the vault or exp delta
- bonus bugfix: standardizes all percentage formatting on Economy page
- bonus enhancement: "track progress" context more specific
- bonus enhancement: handles mastery pass purchase transactions


### Before
![image](https://user-images.githubusercontent.com/14894693/61078545-b44fc900-a3d5-11e9-833b-793c9bd2392c.png)

### After
![image](https://user-images.githubusercontent.com/14894693/61078603-d1849780-a3d5-11e9-845d-cd7e8d3ee45a.png)

