### PR TITLE
bugfix only default match tags to oppDeck.archetype once

### DIFF
--- a/window_background/background.js
+++ b/window_background/background.js
@@ -1632,7 +1632,11 @@ function saveMatch(id) {
   match.playerDeck = currentMatch.player.originalDeck.getSave();
   match.oppDeck = getOppDeck();
 
-  if (match.oppDeck.archetype && match.oppDeck.archetype !== "-") {
+  if (
+    (!match.tags || !match.tags.length) &&
+    match.oppDeck.archetype &&
+    match.oppDeck.archetype !== "-"
+  ) {
     match.tags = [match.oppDeck.archetype];
   }
 


### PR DESCRIPTION
### Motivation
https://discordapp.com/channels/463844727654187020/467737642306371584/599836586061987840
![image](https://user-images.githubusercontent.com/14894693/61233801-444b8680-a6e6-11e9-8736-9ad70976391f.png)

### Approach
It is likely that MattEng has "Read entire Arena log during launch" enabled and the occasional problems with deck archetype being reverted are happening with matches currently in the Arena log. This bugfix ensures that the tool will only attempt to set the default archetype if it is not already set.