### PR TITLE
add filter for "no archetype"

### DIFF
--- a/window_main/aggregator.js
+++ b/window_main/aggregator.js
@@ -31,6 +31,7 @@ const SINGLE_MATCH_EVENTS = [
 const DATE_LAST_30 = "Last 30 Days";
 const DATE_SEASON = "Current Season";
 const DATE_ALL_TIME = "All Time";
+const NO_ARCH = "No Archetype";
 
 const now = new Date();
 const then = new Date();
@@ -222,15 +223,23 @@ class Aggregator {
     const passesPlayerDeckFilter = this.filterDeck(match.playerDeck);
     if (!passesPlayerDeckFilter) return false;
 
+    if (
+      match.type === "draft" &&
+      (arch !== DEFAULT_ARCH || Object.values(oppColors).some(color => color))
+    )
+      return false;
+
     const passesOppDeckFilter = this._filterDeckByColors(
       match.oppDeck,
       oppColors
     );
     if (!passesOppDeckFilter) return false;
 
-    const matchTags = match.tags || ["Unknown"];
     const passesArchFilter =
-      arch === DEFAULT_ARCH || (matchTags.length && arch === matchTags[0]);
+      arch === DEFAULT_ARCH ||
+      (match.tags && match.tags.length && arch === match.tags[0]) ||
+      ((!match.tags || !match.tags.length || !match.tags[0]) &&
+        arch === NO_ARCH);
     if (!passesArchFilter) return false;
 
     return this.filterDate(match.date);
@@ -277,9 +286,11 @@ class Aggregator {
     this._eventIds = [...Object.keys(this.eventLastPlayed)];
     this._eventIds.sort(this.compareEvents);
 
-    const archList = [...Object.keys(this.archCounts)];
+    const archList = Object.keys(this.archCounts).filter(
+      arch => arch !== NO_ARCH
+    );
     archList.sort();
-    this.archs = [DEFAULT_ARCH, ...archList];
+    this.archs = [DEFAULT_ARCH, NO_ARCH, ...archList];
 
     for (const deckId in this.deckMap) {
       const deck = pd.deck(deckId) || this.deckMap[deckId];
@@ -368,18 +379,22 @@ class Aggregator {
         statsToUpdate.push(this.colorStats[colors]);
       }
       // process archetype
-      if (match.tags && match.tags.length) {
-        const tag = match.tags[0] || "Unknown";
-        this.archCounts[tag] = (this.archCounts[tag] || 0) + 1;
-        if (!(tag in this.tagStats)) {
-          this.tagStats[tag] = {
-            ...Aggregator.getDefaultStats(),
-            colors,
-            tag
-          };
-        }
-        statsToUpdate.push(this.tagStats[tag]);
+      const tag =
+        match.tags && match.tags.length ? match.tags[0] || NO_ARCH : NO_ARCH;
+      this.archCounts[tag] = (this.archCounts[tag] || 0) + 1;
+      if (!(tag in this.tagStats)) {
+        this.tagStats[tag] = {
+          ...Aggregator.getDefaultStats(),
+          colors,
+          tag
+        };
+      } else {
+        this.tagStats[tag].colors = [
+          ...new Set([...this.tagStats[tag].colors, ...colors])
+        ];
       }
+      if (!statsToUpdate.includes(this.tagStats[tag]))
+        statsToUpdate.push(this.tagStats[tag]);
     }
     // update relevant stats
     statsToUpdate.forEach(stats => {
@@ -481,5 +496,6 @@ Aggregator.ALL_EVENT_TRACKS = ALL_EVENT_TRACKS;
 Aggregator.DATE_LAST_30 = DATE_LAST_30;
 Aggregator.DATE_SEASON = DATE_SEASON;
 Aggregator.DATE_ALL_TIME = DATE_ALL_TIME;
+Aggregator.NO_ARCH = NO_ARCH;
 
 module.exports = Aggregator;

--- a/window_main/filter-panel.js
+++ b/window_main/filter-panel.js
@@ -16,6 +16,7 @@ const {
   DATE_LAST_30,
   DATE_ALL_TIME,
   DATE_SEASON,
+  NO_ARCH,
   getDefaultFilters
 } = require("./aggregator");
 
@@ -62,6 +63,7 @@ class FilterPanel {
     if (showCount && tag in this.archCounts) {
       tagString += ` (${this.archCounts[tag]})`;
     }
+    if (tag === NO_ARCH) return tagString;
     return `<div class="deck_tag" style="${style}">${tagString}</div>`;
   }
 

--- a/window_main/history.js
+++ b/window_main/history.js
@@ -36,7 +36,14 @@ const {
 const { openMatch } = require("./match-details");
 
 const byId = id => document.getElementById(id);
-const { DEFAULT_DECK, RANKED_CONST, RANKED_DRAFT, DATE_SEASON } = Aggregator;
+const {
+  DEFAULT_DECK,
+  DEFAULT_ARCH,
+  NO_ARCH,
+  RANKED_CONST,
+  RANKED_DRAFT,
+  DATE_SEASON
+} = Aggregator;
 let filters = Aggregator.getDefaultFilters();
 let filteredMatches;
 let sortedHistory;
@@ -299,7 +306,10 @@ function attachMatchData(listItem, match) {
 
   // Set tag
   const totalAgg = getLocalState().totalAgg;
-  const allTags = [...totalAgg.archs, ...db.archetypes.map(arch => arch.name)];
+  const allTags = [
+    ...totalAgg.archs.filter(arch => arch !== NO_ARCH && arch !== DEFAULT_ARCH),
+    ...db.archetypes.map(arch => arch.name)
+  ];
   const tags = [...new Set(allTags)].map(tag => {
     const count = totalAgg.archCounts[tag] || 0;
     return { tag, q: count };
@@ -498,7 +508,7 @@ function createTag(div, matchId, tags, tag, showClose = true) {
 function addTag(matchid, tag) {
   const match = pd.match(matchid);
   if (!match || !tag) return;
-  if (tag === tagPrompt) return;
+  if ([tagPrompt, NO_ARCH, DEFAULT_ARCH].includes(tag)) return;
   if (match.tags && match.tags.includes(tag)) return;
 
   ipcSend("add_history_tag", { matchid, tag });


### PR DESCRIPTION
### Motivation
When attempting to clean up mis-tagged matches, I end up removing tags and having matches "fall through the cracks". This filter helps me find the untagged matches and sort them later.

### Demo
![image](https://user-images.githubusercontent.com/14894693/61243770-8d5b0500-a6fd-11e9-8293-f51753a8b62a.png)

### Bonus Misc
- stats panel "Frequent Matchups" tag colors now shows union of all colors in matches with that tag (before it showed colors from most recent deck only)
- draft replays no longer show up when users specify a opp color or archetype filter
- bugfix autocomplete should not suggest "all archetypes" or "no archetype"
