### PR TITLE
[BUGFIX] Fixes action log share icon location reference

### DIFF
--- a/window_main/index.css
+++ b/window_main/index.css
@@ -536,7 +536,7 @@ span.top_nav_item_text {
     width: 40px;
     height: 40px;
     margin: auto auto auto 8px;
-    background: url(file:///C:/Users/Manuh/Desktop/MTG%20Arena%20Tool/MTG-Arena-Tool/window_main/../images/share.png);
+    background: url(../images/share.png);
     -webkit-transition: all .2s ease-in;
 }
 


### PR DESCRIPTION
Fixes an issue where the Action Log share icon css link reference was broken, causing the share icon to not display.