### PR TITLE
bugfix ranked estimates on history page

### DIFF
--- a/window_main/history.js
+++ b/window_main/history.js
@@ -1,7 +1,12 @@
 const anime = require("animejs");
 
 const autocomplete = require("../shared/autocomplete");
-const { MANA, RANKS, EASING_DEFAULT } = require("../shared/constants");
+const {
+  DATE_SEASON,
+  EASING_DEFAULT,
+  MANA,
+  RANKS
+} = require("../shared/constants");
 const db = require("../shared/database");
 const pd = require("../shared/player-data");
 const { createSelect } = require("../shared/select");
@@ -22,7 +27,6 @@ const ListItem = require("./list-item");
 const StatsPanel = require("./stats-panel");
 const {
   formatPercent,
-  getLocalState,
   getTagColor,
   ipcSend,
   makeResizable,
@@ -41,8 +45,7 @@ const {
   DEFAULT_ARCH,
   NO_ARCH,
   RANKED_CONST,
-  RANKED_DRAFT,
-  DATE_SEASON
+  RANKED_DRAFT
 } = Aggregator;
 let filters = Aggregator.getDefaultFilters();
 let filteredMatches;


### PR DESCRIPTION
Fixes a bug that prevented the ranked estimates from showing up on the stats panel on the history page. I introduced the bug in https://github.com/Manuel-777/MTG-Arena-Tool/pull/481 😿 .

### Demo of Fix
![image](https://user-images.githubusercontent.com/14894693/61592591-11900b00-ab8a-11e9-8353-73a15de2c6c5.png)
