### PR TITLE
bugfix player_data_refresh background

### DIFF
--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -270,6 +270,7 @@ ipc.on("player_data_refresh", () => {
   if (sidebarActive === MAIN_LOGIN) return;
   const ls = getLocalState();
   updateTopBar();
+  changeBackground("default");
   anime({
     targets: ".moving_ux",
     left: 0,


### PR DESCRIPTION
This PR fixes an issue with certain "details"-level pages in the main window.
1. Navigate to deck details page, collections stats page, or any details-level page with a custom background
2. Complete an Arena match
3. mtgatool should automatically refresh the data and navigate back to the top-level page (e.g. my decks)
BUG: the background will stay on the custom image
EXPECTED: the background image should return to the default (lavarunner or custom image)