### PR TITLE
Date fns refactors

### DIFF
--- a/shared/util.js
+++ b/shared/util.js
@@ -1,3 +1,5 @@
+const formatDistanceStrict = require("date-fns/formatDistanceStrict");
+
 const {
   FORMATS,
   BLACK,
@@ -570,25 +572,9 @@ function get_deck_export_txt(deck) {
 
 //
 exports.timeSince = timeSince;
-function timeSince(_date) {
-  var seconds = Math.floor((new Date() - _date) / 1000);
-
-  var interval = Math.floor(seconds / 31536000);
-  if (interval == 1) return interval + " year";
-  if (interval > 0) return interval + " years";
-  interval = Math.floor(seconds / 2592000);
-  if (interval == 1) return interval + " month";
-  if (interval > 0) return interval + " months";
-  interval = Math.floor(seconds / 86400);
-  if (interval == 1) return interval + " day";
-  if (interval > 0) return interval + " days";
-  interval = Math.floor(seconds / 3600);
-  if (interval == 1) return interval + " hour";
-  if (interval > 0) return interval + " hours";
-  interval = Math.floor(seconds / 60);
-  if (interval == 1) return interval + " minute";
-  if (interval > 0) return interval + " minutes";
-  return Math.floor(seconds) + " seconds";
+function timeSince(_date, options = { addSuffix: true, includeSeconds: true }) {
+  // https://date-fns.org/v2.0.0-alpha.27/docs/formatDistanceStrict
+  return formatDistanceStrict(_date, new Date(), options);
 }
 
 //

--- a/window_background/background-util.js
+++ b/window_background/background-util.js
@@ -2,12 +2,12 @@
 global
   debugLog
   firstPass
-  logLanguage
 */
 // Utility functions that belong only to background
 const { ipcRenderer: ipc } = require("electron");
 const _ = require("lodash");
-const parse = require("date-fns").parse;
+const parse = require("date-fns/parse");
+const isValid = require("date-fns/isValid");
 
 const {
   IPC_BACKGROUND,
@@ -30,26 +30,18 @@ let dateLangs = [
 
 // throws an error if it fails
 function parseWotcTime(dateStr) {
-  let date = parse(dateStr, dateLangs[0], new Date());
+  // Try parsing input with each format (in order) and return first valid result
+  dateLangs.forEach(lang => {
+    const test = parse(dateStr, lang, new Date());
+    if (isValid(test) && !isNaN(test.getTime())) {
+      //console.log(`Log datetime language detected: ${lang}`, dateStr, test);
+      return test;
+    }
+  });
 
-  // This is to detect language when the one read does not match or logLanguage is not yet set
   // Defaults to current time if none matches
-  if (!date || isNaN(date.getTime())) {
-    dateLangs.forEach(lang => {
-      let test = parse(dateStr, lang, new Date());
-      if (test && !isNaN(test.getTime())) {
-        //logLanguage = lang;
-        //console.log(`Log datetime language detected: ${lang}`, dateStr, test);
-        date = test;
-      }
-    });
-  }
-
-  if (!date || isNaN(date.getTime())) {
-    // console.log(`Invalid date ('${dateStr}') - using current date as backup.`);
-    date = new Date();
-  }
-  return date;
+  // console.log(`Invalid date ('${dateStr}') - using current date as backup.`);
+  return new Date();
 }
 
 function normaliseFields(iterator) {

--- a/window_background/background.js
+++ b/window_background/background.js
@@ -1,5 +1,6 @@
 const electron = require("electron");
 const { remote, ipcRenderer: ipc } = require("electron");
+const format = require("date-fns/format");
 
 if (!remote.app.isPackaged) {
   const { openNewGitHubIssue, debugInfo } = require("electron-util");
@@ -1148,15 +1149,12 @@ function actionLog(seat, time, str, grpId = 0) {
   if (seat == -99) {
     currentActionLog = "version: 1\r\n";
   } else {
-    var hh = ("0" + time.getHours()).slice(-2);
-    var mm = ("0" + time.getMinutes()).slice(-2);
-    var ss = ("0" + time.getSeconds()).slice(-2);
     /*
     str = str.replace(/(<([^>]+)>)/gi, "");
     */
 
     currentActionLog += `${seat}\r\n`;
-    currentActionLog += `${hh}:${mm}:${ss}\r\n`;
+    currentActionLog += `${format(time, "HH:mm:ss")}\r\n`;
     currentActionLog += `${str}\r\n`;
 
     try {

--- a/window_background/labels.js
+++ b/window_background/labels.js
@@ -38,11 +38,14 @@
     firstPass
     debugLog
 */
-const { ARENA_MODE_IDLE } = require("../shared/constants");
 const _ = require("lodash");
+const differenceInDays = require("date-fns/differenceInDays");
+
+const { ARENA_MODE_IDLE } = require("../shared/constants");
 const db = require("../shared/database");
 const CardsList = require("../shared/cards-list");
 const { get_deck_colors, objectClone, replaceAll } = require("../shared/util");
+
 const {
   httpSetMythicRank,
   httpSubmitCourse,
@@ -565,16 +568,15 @@ function onLabelInPlayerInventoryGetPlayerInventory(entry, json) {
 
 function onLabelInPlayerInventoryGetPlayerCardsV3(entry, json) {
   if (!json) return;
-
-  const date = new Date(pd.cards.cards_time);
   const now = new Date();
-  const diff = Math.abs(now.getTime() - date.getTime());
-  const days = Math.floor(diff / (1000 * 3600 * 24));
 
   let cards_before = pd.cards.cards_before;
   // If a day has passed since last update
-  if (pd.cards.cards_time !== 0 && days > 0) {
-    cards_before = pd.cards.cards;
+  if (pd.cards.cards_time) {
+    const date = new Date(pd.cards.cards_time);
+    if (differenceInDays(now, date) > 0) {
+      cards_before = pd.cards.cards;
+    }
   }
 
   const cards = {

--- a/window_main/aggregator.js
+++ b/window_main/aggregator.js
@@ -1,3 +1,10 @@
+const compareDesc = require("date-fns/compareDesc");
+const isAfter = require("date-fns/isAfter");
+const isEqual = require("date-fns/isEqual");
+const max = require("date-fns/max");
+const startOfDay = require("date-fns/startOfDay");
+const subDays = require("date-fns/subDays");
+
 const {
   COLORS_ALL,
   COLORS_BRIEF,
@@ -37,6 +44,8 @@ const SINGLE_MATCH_EVENTS = [
 const CONSTRUCTED_EVENTS = ["Ladder", "Traditional_Ladder"];
 // Archetype constants
 const NO_ARCH = "No Archetype";
+
+const dateMax = (a, b) => (a && b ? max([a, b]) : a || b);
 
 class Aggregator {
   constructor(filters) {
@@ -119,24 +128,18 @@ class Aggregator {
     const { date } = this.filters;
     let dateFilter = null;
     const now = new Date();
-    if (date === DATE_SEASON) {
+    if (date === DATE_ALL_TIME) {
+      return true;
+    } else if (date === DATE_SEASON) {
       dateFilter = db.season_starts;
     } else if (date === DATE_LAST_30) {
-      const then = new Date();
-      then.setDate(now.getDate() - 30);
-      dateFilter = then.toISOString();
+      dateFilter = startOfDay(subDays(now, 30));
     } else if (date === DATE_LAST_DAY) {
-      const then = new Date();
-      then.setDate(now.getDate() - 1);
-      dateFilter = then.toISOString();
+      dateFilter = subDays(now, 1);
     } else {
-      dateFilter = date;
+      dateFilter = new Date(date);
     }
-    return (
-      date === DATE_ALL_TIME ||
-      dateFilter === null ||
-      new Date(_date) >= new Date(dateFilter)
-    );
+    return isAfter(new Date(_date), dateFilter);
   }
 
   _filterDeckByColors(deck, _colors) {
@@ -312,13 +315,11 @@ class Aggregator {
     }
     // process event data
     if (match.eventId) {
-      let eventIsMoreRecent = true;
-      if (match.eventId in this.eventLastPlayed) {
-        eventIsMoreRecent = match.date > this.eventLastPlayed[match.eventId];
-      }
-      if (eventIsMoreRecent) {
-        this.eventLastPlayed[match.eventId] = match.date;
-      }
+      this.eventLastPlayed[match.eventId] = dateMax(
+        new Date(match.date),
+        this.eventLastPlayed[match.eventId]
+      );
+
       // process rank data
       if (match.player && match.player.rank) {
         const rank = match.player.rank.toLowerCase();
@@ -344,14 +345,11 @@ class Aggregator {
     // process deck data
     if (match.playerDeck && match.playerDeck.id) {
       const id = match.playerDeck.id;
-      let deckIsMoreRecent = true;
-      if (id in this.deckLastPlayed) {
-        deckIsMoreRecent = match.date > this.deckLastPlayed[id];
-      }
-      if (deckIsMoreRecent) {
-        this.deckMap[id] = match.playerDeck;
-        this.deckLastPlayed[id] = match.date;
-      }
+      this.deckMap[id] = match.playerDeck;
+      this.deckLastPlayed[id] = dateMax(
+        new Date(match.date),
+        this.deckLastPlayed[id]
+      );
       if (pd.deckExists(id)) {
         const currentDeck = pd.deck(match.playerDeck.id);
         if (!(id in this.deckStats)) {
@@ -361,7 +359,10 @@ class Aggregator {
         if (!(id in this.deckRecentStats)) {
           this.deckRecentStats[id] = Aggregator.getDefaultStats();
         }
-        if (currentDeck.lastUpdated && match.date > currentDeck.lastUpdated) {
+        if (
+          currentDeck.lastUpdated &&
+          isAfter(new Date(match.date), new Date(currentDeck.lastUpdated))
+        ) {
           statsToUpdate.push(this.deckRecentStats[id]);
         }
       }
@@ -417,38 +418,25 @@ class Aggregator {
   }
 
   compareDecks(a, b) {
-    const dateMax = (a, b) => (a > b ? a : b);
-    const aDate = dateMax(this.deckLastPlayed[a.id], a.lastUpdated);
-    const bDate = dateMax(this.deckLastPlayed[b.id], b.lastUpdated);
-    if (aDate && bDate && aDate !== bDate) {
-      return new Date(bDate) - new Date(aDate);
+    const aDate = dateMax(this.deckLastPlayed[a.id], new Date(a.lastUpdated));
+    const bDate = dateMax(this.deckLastPlayed[b.id], new Date(b.lastUpdated));
+    if (aDate && bDate && !isEqual(aDate, bDate)) {
+      return compareDesc(aDate, bDate);
     }
     const aName = getRecentDeckName(a.id);
     const bName = getRecentDeckName(b.id);
-    if (aName) {
-      return aName.localeCompare(bName);
-    }
-    // a is invalid, sort b first
-    if (bName) return 1;
-    // neither valid, leave in place
-    return 0;
+    return aName.localeCompare(bName);
   }
 
   compareEvents(a, b) {
     const aDate = this.eventLastPlayed[a];
     const bDate = this.eventLastPlayed[b];
-    if (aDate && bDate && aDate !== bDate) {
-      return new Date(bDate) - new Date(aDate);
+    if (aDate && bDate && !isEqual(aDate, bDate)) {
+      return compareDesc(aDate, bDate);
     }
     const aName = getReadableEvent(a);
     const bName = getReadableEvent(b);
-    if (aName) {
-      return aName.localeCompare(bName);
-    }
-    // a is invalid, sort b first
-    if (bName) return 1;
-    // neither valid, leave in place
-    return 0;
+    return aName.localeCompare(bName);
   }
 
   get matches() {

--- a/window_main/deck-details.js
+++ b/window_main/deck-details.js
@@ -413,7 +413,7 @@ function setChangesTimeline(deckId) {
       title.innerHTML = change.label;
     } else {
       title.innerHTML =
-        nc + " changes, " + timeSince(Date.parse(change.date)) + " ago.";
+        nc + " changes, " + timeSince(Date.parse(change.date)) + ".";
     }
     datbox.appendChild(title);
     datbox.appendChild(data);

--- a/window_main/economy.js
+++ b/window_main/economy.js
@@ -1,6 +1,8 @@
 const { shell } = require("electron");
 
-const { differenceInCalendarDays } = require("date-fns");
+const differenceInCalendarDays = require("date-fns/differenceInCalendarDays");
+const startOfDay = require("date-fns/startOfDay");
+const compareAsc = require("date-fns/compareAsc");
 
 const db = require("../shared/database");
 const pd = require("../shared/player-data");
@@ -234,7 +236,8 @@ function renderData(container, index) {
 }
 
 function createDayHeader(change) {
-  daysago = differenceInCalendarDays(new Date(), new Date(change.date));
+  const timestamp = new Date(change.date);
+  daysago = differenceInCalendarDays(new Date(), timestamp);
   const headerGrid = createDiv(["economy_title"]);
 
   const tx = createDiv(["economy_sub"]);
@@ -251,9 +254,7 @@ function createDayHeader(change) {
   if (daysago == 0) gridTitle.innerHTML = "Today";
   if (daysago == 1) gridTitle.innerHTML = "Yesterday";
   if (daysago > 1) {
-    let date = new Date(change.date);
-    date = new Date(date.setHours(0, 0, 0, 0));
-    gridTitle.innerHTML = localDayDateFormat(date);
+    gridTitle.innerHTML = localDayDateFormat(startOfDay(timestamp));
   }
   headerGrid.appendChild(gridTitle);
 
@@ -970,8 +971,7 @@ function createEconomyUI(mainDiv) {
 function compare_economy(a, b) {
   if (a === undefined) return 0;
   if (b === undefined) return 0;
-
-  return Date.parse(a.date) - Date.parse(b.date);
+  return compareAsc(new Date(a.date), new Date(b.date));
 }
 
 module.exports = {

--- a/window_main/events.js
+++ b/window_main/events.js
@@ -210,7 +210,7 @@ function attachEventData(listItem, course) {
   listItem.rightBottom.appendChild(
     createDiv(
       ["list_match_time"],
-      timeSince(new Date(course.date)) + " ago - " + toMMSS(stats.duration)
+      timeSince(new Date(course.date)) + " - " + toMMSS(stats.duration)
     )
   );
 
@@ -274,7 +274,7 @@ function createMatchRow(match) {
 
   let timeDiv = createDiv(
     ["list_match_time"],
-    timeSince(new Date(match.date)) + " ago - " + toMMSS(match.duration)
+    timeSince(new Date(match.date)) + " - " + toMMSS(match.duration)
   );
   matchRow.rightBottom.appendChild(timeDiv);
 

--- a/window_main/history.js
+++ b/window_main/history.js
@@ -299,7 +299,7 @@ function attachMatchData(listItem, match) {
   // Match time
   const matchTime = createDiv(
     ["list_match_time"],
-    timeSince(new Date(match.date)) + " ago - " + toMMSS(match.duration)
+    timeSince(new Date(match.date)) + " - " + toMMSS(match.duration)
   );
   listItem.rightBottom.appendChild(matchTime);
 
@@ -357,7 +357,7 @@ function attachDraftData(listItem, draft) {
 
   const draftTimeDiv = createDiv(
     ["list_match_time"],
-    timeSince(new Date(draft.date)) + " ago."
+    timeSince(new Date(draft.date)) + "."
   );
   listItem.rightBottom.appendChild(draftTimeDiv);
 

--- a/window_overlay/overlay.js
+++ b/window_overlay/overlay.js
@@ -1,4 +1,5 @@
 const { ipcRenderer: ipc, webFrame, remote } = require("electron");
+const format = require("date-fns/format");
 
 if (!remote.app.isPackaged) {
   const { openNewGitHubIssue, debugInfo } = require("electron-util");
@@ -419,14 +420,11 @@ function updateMatchView() {
     let initalTime = actionLog[0] ? new Date(actionLog[0].time) : new Date();
     actionLog.forEach(log => {
       const _date = new Date(log.time);
-      const hh = ("0" + _date.getHours()).slice(-2);
-      const mm = ("0" + _date.getMinutes()).slice(-2);
-      const ss = ("0" + _date.getSeconds()).slice(-2);
       const secondsPast = Math.round((_date - initalTime) / 1000);
 
       const box = createDiv(["actionlog", "log_p" + log.seat]);
       const time = createDiv(["actionlog_time"], secondsPast + "s", {
-        title: `${hh}:${mm}:${ss}`
+        title: format(_date, "HH:mm:ss")
       });
       const str = createDiv(["actionlog_text"], log.str);
 


### PR DESCRIPTION
### Motivation
This PR refactors several places where we manually implemented date-related logic with equivalent (or superior) alternatives from [our `date-fns` library](https://date-fns.org/v2.0.0-alpha.27/docs/Getting-Started).

### Warning
Since this touches several critical areas across all 3 processes, we should wait to merge this until we can tolerate some potential instability (especially for our non-US-English users).