### PR TITLE
bugfix draft replays handle drafts without tileID

### DIFF
--- a/window_main/history.js
+++ b/window_main/history.js
@@ -3,6 +3,7 @@ const anime = require("animejs");
 const autocomplete = require("../shared/autocomplete");
 const {
   DATE_SEASON,
+  DEFAULT_TILE,
   EASING_DEFAULT,
   MANA,
   RANKS
@@ -216,7 +217,11 @@ function renderData(container, index) {
     tileGrpid = match.playerDeck.deckTileId;
     clickCallback = handleOpenMatch;
   } else {
-    tileGrpid = db.sets[match.set].tile;
+    if (match.set in db.sets && db.sets[match.set].tile) {
+      tileGrpid = db.sets[match.set].tile;
+    } else {
+      tileGrpid = DEFAULT_TILE;
+    }
     clickCallback = handleOpenDraft;
   }
   const deleteCallback = id => {

--- a/window_main/renderer-util.js
+++ b/window_main/renderer-util.js
@@ -9,6 +9,7 @@ const Picker = require("vanilla-picker");
 const {
   COLORS_ALL,
   DRAFT_RANKS,
+  DEFAULT_TILE,
   MANA_COLORS,
   PACK_SIZES,
   IPC_MAIN,
@@ -457,7 +458,12 @@ function openDraft(id, draftPosition = 1) {
 
   const draft = pd.draft(id);
   if (!draft) return;
-  const tileGrpid = db.sets[draft.set].tile;
+  let tileGrpid;
+  if (draft.set in db.sets && db.sets[draft.set].tile) {
+    tileGrpid = db.sets[draft.set].tile;
+  } else {
+    tileGrpid = DEFAULT_TILE;
+  }
   if (db.card(tileGrpid)) {
     changeBackground("", tileGrpid);
   }


### PR DESCRIPTION
### Motivation
A few times in the past, we have not had metadata available for a draft format "in time" for users to record drafts correctly. The most recent example of this was the War of the Spark Omniscience Draft that happened about 21 days ago. This PR handles a few edge cases to ensure that such drafts with partially complete info can still be handled gracefully.