### PR TITLE
Fix "undefined/4 copies in collection" tooltip

### DIFF
--- a/shared/card-hover.js
+++ b/shared/card-hover.js
@@ -77,7 +77,7 @@ function attachOwnerhipStars(card, starContainer) {
 
   const owned = pd.cards.cards[card.id];
   const acquired = pd.cardsNew[card.id];
-  starContainer.title = `${owned}/4 copies in collection`;
+  starContainer.title = `${owned || 0}/4 copies in collection`;
   if (acquired) {
     starContainer.title += ` (${acquired} recent)`;
   }

--- a/shared/card-hover.js
+++ b/shared/card-hover.js
@@ -76,17 +76,17 @@ function attachOwnerhipStars(card, starContainer) {
   starContainer.style.opacity = 1;
 
   const owned = pd.cards.cards[card.id];
-  const aquired = pd.cardsNew[card.id];
+  const acquired = pd.cardsNew[card.id];
   starContainer.title = `${owned}/4 copies in collection`;
-  if (aquired) {
-    starContainer.title += ` (${aquired} recent)`;
+  if (acquired) {
+    starContainer.title += ` (${acquired} recent)`;
   }
 
   for (let i = 0; i < 4; i++) {
     let color = "gray";
 
     if (i < owned) color = "green";
-    if (aquired && i >= owned - aquired && i < owned) color = "orange";
+    if (acquired && i >= owned - acquired && i < owned) color = "orange";
 
     starContainer.appendChild(createDiv([`inventory_card_quantity_${color}`]));
   }


### PR DESCRIPTION
If the **Advanced Filters>Show Unowned** is turned on, mousing over a card you don't own produces the `starContainer.title` in the PR title.

The other commit on this branch is a minor one - saw the variable was called `aquired` instead of `acquired`.