### PR TITLE
Precon decks

### DIFF
--- a/shared/database.js
+++ b/shared/database.js
@@ -11,14 +11,17 @@ class Database {
     this.handleSetDb = this.handleSetDb.bind(this);
     this.handleSetRewardResets = this.handleSetRewardResets.bind(this);
     this.handleSetSeason = this.handleSetSeason.bind(this);
+    this.handleSetPreconDecks = this.handleSetPreconDecks.bind(this);
     if (ipc) ipc.on("set_active_events", this.handleSetActiveEvents);
     if (ipc) ipc.on("set_db", this.handleSetDb);
     if (ipc) ipc.on("set_reward_resets", this.handleSetRewardResets);
     if (ipc) ipc.on("set_season", this.handleSetSeason);
+    if (ipc) ipc.on("set_precon_decks", this.handleSetPreconDecks);
 
     this.rewards_daily_ends = new Date();
     this.rewards_weekly_ends = new Date();
     this.activeEvents = [];
+    this.preconDecks = [];
 
     const dbUri = `${__dirname}/../resources/database.json`;
     const defaultDb = fs.readFileSync(dbUri, "utf8");
@@ -55,6 +58,18 @@ class Database {
       this.season = arg;
     } catch (e) {
       console.log("Error parsing metadata", e);
+    }
+  }
+
+  handleSetPreconDecks(_event, arg) {
+    if (!arg || !arg.length) return;
+    try {
+      this.preconDecks = {};
+      arg.forEach(deck => (this.preconDecks[deck.id] = deck));
+      // console.log(this.preconDecks);
+    } catch (e) {
+      console.log("Error parsing JSON:", arg);
+      return false;
     }
   }
 

--- a/window_background/background.js
+++ b/window_background/background.js
@@ -55,6 +55,7 @@ const {
   onLabelInEventGetCombinedRankInfo,
   onLabelInDeckGetDeckLists,
   onLabelInDeckGetDeckListsV3,
+  onLabelInDeckGetPreconDecks,
   onLabelInEventGetPlayerCourses,
   onLabelInEventGetPlayerCoursesV2,
   onLabelInDeckUpdateDeck,
@@ -783,6 +784,13 @@ function onLogEntryFound(entry) {
             if (entry.arrow == "<==") {
               json = entry.json();
               onLabelInDeckGetDeckListsV3(entry, json);
+            }
+            break;
+
+          case "Deck.GetPreconDecks":
+            if (entry.arrow == "<==") {
+              json = entry.json();
+              onLabelInDeckGetPreconDecks(entry, json);
             }
             break;
 

--- a/window_background/labels.js
+++ b/window_background/labels.js
@@ -346,6 +346,12 @@ function onLabelInDeckGetDeckListsV3(entry, json) {
   onLabelInDeckGetDeckLists(entry, json.map(d => convert_deck_from_v3(d)));
 }
 
+function onLabelInDeckGetPreconDecks(entry, json) {
+  if (!json) return;
+  ipc_send("set_precon_decks", json);
+  // console.log(json);
+}
+
 function onLabelInEventGetPlayerCourses(entry, json) {
   if (!json) return;
 
@@ -966,6 +972,7 @@ module.exports = {
   onLabelInEventGetCombinedRankInfo,
   onLabelInDeckGetDeckLists,
   onLabelInDeckGetDeckListsV3,
+  onLabelInDeckGetPreconDecks,
   onLabelInEventGetPlayerCourses,
   onLabelInEventGetPlayerCoursesV2,
   onLabelInDeckUpdateDeck,


### PR DESCRIPTION
### Motivation
This PR is a (mediocre) attempt at ingesting and displaying Arena preconstructed decks. This was largely prompted by Planar Vacation event 1.

### Approach
- add wrapper fns in `background`, `labels`, and `database` to capture "Deck.GetPreconDecks"
- add brute-force prettify fn in `player-data` that uses precon data when serving decks or matches

### Demo
![image](https://user-images.githubusercontent.com/14894693/62011681-5985d380-b130-11e9-9079-e8a61f0354b9.png)
![image](https://user-images.githubusercontent.com/14894693/62011682-5db1f100-b130-11e9-907f-4779c900c651.png)

