### PR TITLE
bugfix util.get_card_image handles missing metadata

### DIFF
--- a/shared/util.js
+++ b/shared/util.js
@@ -22,13 +22,14 @@ function get_card_image(cardObj) {
     cardObj = db.card(cardObj);
   }
 
-  if (!cardObj) {
-    return "../images/notfound.png";
-  } else {
-    return (
+  try {
+    let ret =
       "https://img.scryfall.com/cards" +
-      cardObj.images[pd.settings.cards_quality]
-    );
+      cardObj.images[pd.settings.cards_quality];
+    return ret;
+  } catch (e) {
+    console.log("Cant find card art: ", cardObj);
+    return "../images/notfound.png";
   }
 }
 


### PR DESCRIPTION
This is a copy-pasted solution extracted from `overlays-v3`, originally found here: https://github.com/Manuel-777/MTG-Arena-Tool/commit/d715f36d575c5d38e416ffcf9e86faecadd29cbc#diff-358facbbb49d9521d719dd54a0266d4cL23