### PR TITLE
Deck Winrate Confidence Intervals

### DIFF
--- a/shared/stats-fns.js
+++ b/shared/stats-fns.js
@@ -131,3 +131,16 @@ function hypergeometricSignificance(
   let retVal = math.subtract(1, math.multiply(weightedAverage, 2));
   return returnBig ? retVal : math.number(retVal);
 }
+
+// Computes the Wald Interval aka Normal Approximation Interval
+// Useful for quickly estimating the 95% confidence interval
+// Can produce bad results when sample-size < 20
+// https://en.wikipedia.org/wiki/Binomial_proportion_confidence_interval#Normal_approximation_interval
+// https://www.channelfireball.com/articles/magic-math-how-many-games-do-you-need-for-statistical-significance-in-playtesting/
+exports.normalApproximationInterval = normalApproximationInterval;
+function normalApproximationInterval(matches, wins) {
+  if (!matches) return { winrate: 0, interval: 0 };
+  const winrate = wins / matches;
+  const interval = 1.96 * Math.sqrt((winrate * (1 - winrate)) / matches);
+  return { winrate, interval };
+}

--- a/window_main/aggregator.js
+++ b/window_main/aggregator.js
@@ -20,6 +20,7 @@ const {
   getReadableEvent,
   getRecentDeckName
 } = require("../shared/util");
+const { normalApproximationInterval } = require("../shared/stats-fns");
 
 // Default filter values
 const DEFAULT_DECK = "All Decks";
@@ -68,11 +69,12 @@ class Aggregator {
 
   static finishStats(stats) {
     const { wins, total } = stats;
-    let winrate = 0;
-    if (total) {
-      winrate = Math.round((wins / total) * 100) / 100;
-    }
-    stats.winrate = winrate;
+    const { winrate, interval } = normalApproximationInterval(total, wins);
+    const roundWinrate = x => Math.round(x * 100) / 100;
+    stats.winrate = roundWinrate(winrate);
+    stats.interval = roundWinrate(interval);
+    stats.winrateLow = roundWinrate(winrate - interval);
+    stats.winrateHigh = roundWinrate(winrate + interval);
   }
 
   static getDefaultColorFilter() {

--- a/window_main/decks.js
+++ b/window_main/decks.js
@@ -211,12 +211,15 @@ function openDecksTab(_filters = {}, scrollTop = 0) {
       let colClass = getWinrateClass(dwr.winrate);
       deckWinrateDiv.innerHTML = `${dwr.wins}:${
         dwr.losses
-      } <span class="${colClass}_bright">(${formatPercent(
+      } (<span class="${colClass}_bright">${formatPercent(
         dwr.winrate
-      )})</span>`;
-      deckWinrateDiv.title = `${dwr.wins} matches won : ${
-        dwr.losses
-      } matches lost`;
+      )}</span> <i style="opacity:0.6;">&plusmn; ${formatPercent(
+        dwr.interval
+      )}</i>)`;
+      deckWinrateDiv.title = `${formatPercent(
+        dwr.winrateLow
+      )} to ${formatPercent(dwr.winrateHigh)} with 95% confidence
+(estimated actual winrate bounds, assuming a normal distribution)`;
       listItem.rightTop.appendChild(deckWinrateDiv);
 
       const deckWinrateLastDiv = createDiv(
@@ -230,9 +233,10 @@ function openDecksTab(_filters = {}, scrollTop = 0) {
         deckWinrateLastDiv.innerHTML += `<span class="${colClass}_bright">${formatPercent(
           drwr.winrate
         )}</span>`;
-        deckWinrateLastDiv.title = `${drwr.wins} matches won : ${
-          drwr.losses
-        } matches lost`;
+        deckWinrateLastDiv.title = `${formatPercent(
+          drwr.winrateLow
+        )} to ${formatPercent(drwr.winrateHigh)} with 95% confidence
+(estimated actual winrate bounds, assuming a normal distribution)`;
       } else {
         deckWinrateLastDiv.innerHTML += "<span>--</span>";
         deckWinrateLastDiv.title = "no data yet";


### PR DESCRIPTION
### Motivation
This PR aims to add a simple secondary metric to help users gauge how "reliable" the primary winrate metric is for each deck. The math is a from-scratch implementation of the Wald Interval. (Warning: this type of math is not my specialty!)

https://www.channelfireball.com/articles/magic-math-how-many-games-do-you-need-for-statistical-significance-in-playtesting/
https://en.wikipedia.org/wiki/Binomial_proportion_confidence_interval#Normal_approximation_interval

### Demo
![image](https://user-images.githubusercontent.com/14894693/63063973-dc8a8600-beb3-11e9-89fc-15bf5af9aa2a.png)
![image](https://user-images.githubusercontent.com/14894693/63063976-e44a2a80-beb3-11e9-91cf-4af969367372.png)

 