### PR TITLE
Flicker Fix

### DIFF
--- a/window_background/background.js
+++ b/window_background/background.js
@@ -329,9 +329,14 @@ ipc.on("overlayBounds", (event, index, bounds) => {
 ipc.on("save_user_settings", function(event, settings) {
   // console.log("save_user_settings");
   ipc_send("show_loading");
+  let refresh = true;
+  if (settings.skip_refresh) {
+    delete settings.skip_refresh;
+    refresh = false;
+  }
   const updated = { ...pd.settings, ...settings };
   store.set("settings", updated);
-  syncSettings(updated);
+  syncSettings(updated, refresh);
   ipc_send("hide_loading");
 });
 

--- a/window_main/filter-panel.js
+++ b/window_main/filter-panel.js
@@ -152,12 +152,18 @@ class FilterPanel {
           showDatepicker(lastWeek, date => {
             const filter = date.toISOString();
             this.onFilterChange({ date: filter }, this.filters);
-            ipcSend("save_user_settings", { last_date_filter: filter });
+            ipcSend("save_user_settings", {
+              last_date_filter: filter,
+              skip_refresh: true
+            });
           });
         } else {
           this.filters.date = filter;
           this.onFilterChange({ date: filter }, this.filters);
-          ipcSend("save_user_settings", { last_date_filter: filter });
+          ipcSend("save_user_settings", {
+            last_date_filter: filter,
+            skip_refresh: true
+          });
         }
       },
       this.prefixId + "_query_date"

--- a/window_main/renderer-util.js
+++ b/window_main/renderer-util.js
@@ -139,7 +139,10 @@ function makeResizable(div, resizeCallback, finalCallback) {
   };
 
   let saveWidth = function(width) {
-    ipcSend("save_user_settings", { right_panel_width: width });
+    ipcSend("save_user_settings", {
+      right_panel_width: width,
+      skip_refresh: true
+    });
   };
 
   div.addEventListener(

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -343,7 +343,10 @@ ipc.on("force_open_tab", function(event, arg) {
   $$(".top_nav_item").forEach(el => el.classList.remove("item_selected"));
   setLocalState({ lastDataIndex: 0, lastScrollTop: 0 });
   openTab(arg);
-  ipcSend("save_user_settings", { last_open_tab: sidebarActive });
+  ipcSend("save_user_settings", {
+    last_open_tab: sidebarActive,
+    skip_refresh: true
+  });
 });
 
 //
@@ -677,7 +680,8 @@ ready(function() {
         openTab(sidebarActive, filters);
         ipcSend("save_user_settings", {
           last_open_tab: sidebarActive,
-          last_date_filter: filters.date
+          last_date_filter: filters.date,
+          skip_refresh: true
         });
       } else {
         anime({

--- a/window_overlay_v3/overlay.js
+++ b/window_overlay_v3/overlay.js
@@ -201,7 +201,7 @@ function saveOverlaysPosition() {
     overlays[index] = newOverlay;
   });
 
-  ipcSend("save_user_settings", { overlays });
+  ipcSend("save_user_settings", { overlays, skip_refresh: true });
 }
 
 ipc.on("close", (event, arg) => {


### PR DESCRIPTION
### Motivation
Some user actions cause a full round-trip to save a setting and then (unnecessarily) refresh main window with exactly that same setting. This results in the user experiencing a moderately annoying "flicker" after doing those actions.
  - Switching between pages in the main window
  - Changing the date filter
  - Resizing the right-side stats panel
  - Toggling out of overlay edit mode
