### PR TITLE
cache latest metadata

### DIFF
--- a/shared/database.js
+++ b/shared/database.js
@@ -1,9 +1,12 @@
 const path = require("path");
-const { remote, ipcRenderer: ipc } = require("electron");
+const { app, remote, ipcRenderer: ipc } = require("electron");
 const fs = require("fs");
 const _ = require("lodash");
 
-const cachePath = path.join(remote.app.getPath("userData"), "database.json");
+const cachePath =
+  app || (remote && remote.app)
+    ? path.join((app || remote.app).getPath("userData"), "database.json")
+    : null;
 
 // Some other things should go here later, like updating from MTGA Servers themselves.
 class Database {
@@ -27,7 +30,7 @@ class Database {
     this.preconDecks = [];
 
     let dbUri = `${__dirname}/../resources/database.json`;
-    if (fs.existsSync(cachePath)) {
+    if (cachePath && fs.existsSync(cachePath)) {
       dbUri = cachePath;
     }
     const defaultDb = fs.readFileSync(dbUri, "utf8");
@@ -49,7 +52,9 @@ class Database {
   handleSetDb(_event, arg) {
     try {
       this.data = JSON.parse(arg);
-      fs.writeFileSync(cachePath, arg);
+      if (cachePath) {
+        fs.writeFileSync(cachePath, arg);
+      }
     } catch (e) {
       console.log("Error parsing metadata", e);
     }

--- a/shared/database.js
+++ b/shared/database.js
@@ -52,11 +52,18 @@ class Database {
   handleSetDb(_event, arg) {
     try {
       this.data = JSON.parse(arg);
-      if (cachePath) {
-        fs.writeFileSync(cachePath, arg);
-      }
     } catch (e) {
       console.log("Error parsing metadata", e);
+    }
+  }
+
+  updateCache(data) {
+    try {
+      if (cachePath) {
+        fs.writeFileSync(cachePath, data);
+      }
+    } catch (e) {
+      console.log("Error saving metadata", e);
     }
   }
 

--- a/shared/database.js
+++ b/shared/database.js
@@ -149,6 +149,10 @@ class Database {
     );
   }
 
+  get version() {
+    return Number(this.data.version);
+  }
+
   card(id) {
     return this.data.cards[id] || false;
   }

--- a/shared/database.js
+++ b/shared/database.js
@@ -1,6 +1,9 @@
-const { ipcRenderer: ipc } = require("electron");
+const path = require("path");
+const { remote, ipcRenderer: ipc } = require("electron");
 const fs = require("fs");
 const _ = require("lodash");
+
+const cachePath = path.join(remote.app.getPath("userData"), "database.json");
 
 // Some other things should go here later, like updating from MTGA Servers themselves.
 class Database {
@@ -23,7 +26,10 @@ class Database {
     this.activeEvents = [];
     this.preconDecks = [];
 
-    const dbUri = `${__dirname}/../resources/database.json`;
+    let dbUri = `${__dirname}/../resources/database.json`;
+    if (fs.existsSync(cachePath)) {
+      dbUri = cachePath;
+    }
     const defaultDb = fs.readFileSync(dbUri, "utf8");
     this.handleSetDb(null, defaultDb);
 
@@ -43,6 +49,7 @@ class Database {
   handleSetDb(_event, arg) {
     try {
       this.data = JSON.parse(arg);
+      fs.writeFileSync(cachePath, arg);
     } catch (e) {
       console.log("Error parsing metadata", e);
     }

--- a/window_background/background.js
+++ b/window_background/background.js
@@ -217,7 +217,7 @@ ipc.on("start_background", function() {
 
   // start http
   httpApi.httpBasic();
-  httpApi.httpGetDatabase();
+  httpApi.httpGetDatabaseVersion();
   ipc_send("popup", { text: "Downloading metadata", time: 0 });
 
   // Check if it is the first time we open this version

--- a/window_background/http-api.js
+++ b/window_background/http-api.js
@@ -258,6 +258,7 @@ function httpBasic() {
                   progress: -1
                 });
                 db.handleSetDb(null, results);
+                db.updateCache(results);
                 ipc_send("set_db", results);
                 // autologin users may beat the metadata request
                 // manually trigger a UI refresh just in case

--- a/window_background/http-api.js
+++ b/window_background/http-api.js
@@ -174,6 +174,21 @@ function httpBasic() {
               });
               ipc_send("set_discord_tag", "");
             }
+            if (_headers.method == "get_database_version") {
+              // Compare parsedResult.version with stored version
+              if (parsedResult.latest > db.version) {
+                console.log(
+                  `Downloading latest database (had v${db.version}, found v${
+                    parsedResult.latest
+                  })`
+                );
+                httpGetDatabase();
+              } else {
+                console.log(
+                  `Database up to date (${db.version}), skipping download.`
+                );
+              }
+            }
             if (_headers.method == "notifications") {
               notificationProcess(parsedResult);
             }
@@ -545,6 +560,15 @@ function httpGetDatabase() {
   httpAsync.push({ reqId: _id, method: "get_database" });
 }
 
+function httpGetDatabaseVersion() {
+  var _id = makeId(6);
+  httpAsync.push({
+    reqId: _id,
+    method: "get_database_version",
+    method_path: "/database/latest/"
+  });
+}
+
 function httpDraftShareLink(did, exp) {
   var _id = makeId(6);
   httpAsync.push({
@@ -688,6 +712,7 @@ module.exports = {
   httpSetEconomy,
   httpDeleteData,
   httpGetDatabase,
+  httpGetDatabaseVersion,
   httpHomeGet,
   httpDraftShareLink,
   httpLogShareLink,


### PR DESCRIPTION
### Motivation
Sometimes our remote hosting service goes down. Sometimes this also happens when the latest stable or beta release depends on the most recent metadata database to run correctly (the distributed source code `database.json` is stale in some way that causes the tool to break). This PR attempts to better handle those scenarios by keeping a cached version of the latest meatadata database alongside the other JSON stores.

### Demo
![image](https://user-images.githubusercontent.com/14894693/63370681-96ac4280-c337-11e9-8a8f-edb0bc16315b.png)
