### PR TITLE
Added data corruption function and code to use it

### DIFF
--- a/window_main/events.js
+++ b/window_main/events.js
@@ -161,16 +161,15 @@ function courseDataIsCorrupt(course) {
     return true;
   }
   // Try getting the match indices, if any are false return true.
-  if(wlGate.ProcessedMatchIds.map(getMatchesHistoryIndex).some(x => !x)) {
+  if (wlGate.ProcessedMatchIds.map(getMatchesHistoryIndex).some(x => !x)) {
     return true;
   }
-  
+
   return false;
 }
 
 // Given a courses object returns all of the matches' stats
 function getCourseStats(course) {
-
   const stats = { wins: 0, losses: 0, gameWins: 0, gameLosses: 0, duration: 0 };
   const wlGate = getWlGate(course);
 

--- a/window_main/events.js
+++ b/window_main/events.js
@@ -153,12 +153,40 @@ function getWlGate(course) {
   return wlGate;
 }
 
-// Given a courses object returns all of the matches
-function getCourseStats(course) {
+function courseDataIsCorrupt(course) {
+  // Returns true if we are missing some match data
+  // This happens when we get the end of an event but miss match data.
   const wlGate = getWlGate(course);
-  let matchesList = wlGate ? wlGate.ProcessedMatchIds : undefined;
-  const stats = { wins: 0, losses: 0, duration: 0 };
-  if (!matchesList) return stats;
+  if (!wlGate || !wlGate.ProcessedMatchIds) {
+    return true;
+  }
+  // Try getting the match indices, if any are false return true.
+  if(wlGate.ProcessedMatchIds.map(getMatchesHistoryIndex).some(x => !x)) {
+    return true;
+  }
+  
+  return false;
+}
+
+// Given a courses object returns all of the matches' stats
+function getCourseStats(course) {
+
+  const stats = { wins: 0, losses: 0, gameWins: 0, gameLosses: 0, duration: 0 };
+  const wlGate = getWlGate(course);
+
+  if (!wlGate) return stats;
+
+  let matchesList = wlGate.ProcessedMatchIds;
+
+  if (courseDataIsCorrupt(course)) {
+    // If there's no matches list we can't count duration.
+    // If the data is corrupt fallback on wlgate data.
+    stats.wins = wlGate.CurrentWins || 0;
+    stats.losses = wlGate.CurrentLosses || 0;
+    stats.gameWins = undefined; // we cannot say 0
+    stats.gameLosses = undefined;
+    return stats;
+  }
 
   matchesList
     .map(getMatchesHistoryIndex)
@@ -179,7 +207,10 @@ function getCourseStats(course) {
       } else if (match.player.win < match.opponent.win) {
         stats.losses++;
       }
+      stats.gameWins += match.player.win;
+      stats.gameLosses += match.opponent.win;
     });
+
   return stats;
 }
 
@@ -215,11 +246,6 @@ function attachEventData(listItem, course) {
   );
 
   let { wins, losses } = stats;
-  const wlGate = getWlGate(course);
-  if (filters.showArchived && wlGate) {
-    wins = wlGate.CurrentWins;
-    losses = wlGate.CurrentLosses;
-  }
   wins = wins || 0;
   losses = losses || 0;
   const wl = `${wins}:${losses}`;


### PR DESCRIPTION
Events statistics are bugged when matches are completely missing from the data.

Original bug report: https://discordapp.com/channels/463844727654187020/467737642306371584/612857344111542292
Related discussion: https://discordapp.com/channels/463844727654187020/506793351786266624/614751255574609931

This fix removes the archive code and puts the logic in the getCourseStats. This function now checks if an event is corrupt and only falls back if so.

Example from one of my events with missing matches:

![image](https://user-images.githubusercontent.com/766048/63635776-7bef0c00-c65e-11e9-9cda-fb1e3417fb44.png)

There's no way of knowing the event duration so it's probably best to leave as 0. Maybe put a custom message saying the event is missing data.