### PR TITLE
Settings Page Cleanup

### DIFF
--- a/window_background/background.js
+++ b/window_background/background.js
@@ -290,6 +290,28 @@ ipc.on("overlayBounds", (event, index, bounds) => {
 });
 
 //
+ipc.on("save_overlay_settings", function(event, settings) {
+  // console.log("save_overlay_settings");
+  if (settings.index === undefined) return;
+  ipc_send("show_loading");
+
+  const { index } = settings;
+  const overlays = playerData.settings.overlays.map((overlay, _index) => {
+    if (_index === index) {
+      const updatedOverlay = { ...overlay, ...settings };
+      delete updatedOverlay.index;
+      return updatedOverlay;
+    }
+    return overlay;
+  });
+
+  const updated = { ...playerData.settings, overlays };
+  store.set("settings", updated);
+  syncSettings(updated);
+  ipc_send("hide_loading");
+});
+
+//
 ipc.on("save_user_settings", function(event, settings) {
   // console.log("save_user_settings");
   ipc_send("show_loading");


### PR DESCRIPTION
### Motivation
Our current settings page is a bit of a mess with how it handles updates:
  - changing most settings "submits the entire form" (including inputs on hidden pages/tabs)
  - a few settings update themselves individually
  - most overlay settings mutate the memory singleton directly

This PR standardizes the settings page so that each setting explicitly handles updating itself. This should be more obvious to extend for other contributors and easier to maintain in the long run.

Misc Notes:
  - created a new convenience background update handler for "save_overlay_settings" to avoid mutation
  - also standardized how text inputs handle "Enter" key events
  - did not manually test on multiple displays
