### PR TITLE
Data Refresh Bugfixes

### DIFF
--- a/main.js
+++ b/main.js
@@ -41,6 +41,8 @@ const ipc = electron.ipcMain;
 
 var mainLoaded = false;
 var backLoaded = false;
+const ARENA_MODE_IDLE = 0; // copied from constants.js
+let arenaState = ARENA_MODE_IDLE;
 
 const singleLock = app.requestSingleInstanceLock();
 
@@ -185,7 +187,13 @@ function startApp() {
         break;
 
       case "player_data_refresh":
-        mainWindow.webContents.send("player_data_refresh");
+        // HACK WARNING!
+        // during Arena matches and drafts we deliberately let the main window state
+        // "go stale" instead of auto-refreshing. This allows players to use deck
+        // details or collections pages without being constantly "reset" to main tab
+        if (arenaState === ARENA_MODE_IDLE) {
+          mainWindow.webContents.send("player_data_refresh");
+        }
         if (overlay) overlay.webContents.send("player_data_refresh");
         break;
 
@@ -209,6 +217,7 @@ function startApp() {
 
       case "set_arena_state":
         mainWindow.webContents.send("player_data_refresh");
+        arenaState = arg;
         if (overlay) overlay.webContents.send("set_arena_state", arg);
         break;
 

--- a/window_main/renderer.js
+++ b/window_main/renderer.js
@@ -289,28 +289,23 @@ ipc.on("settings_updated", function() {
   lastSettings = { ...pd.settings };
 });
 
-let playerDataRefreshTimeout = null;
+let lastDataRefresh = null;
 
 //
 ipc.on("player_data_refresh", () => {
+  // ignore signal before user login
   if (sidebarActive === MAIN_LOGIN) return;
 
-  clearTimeout(playerDataRefreshTimeout);
-  playerDataRefreshTimeout = setTimeout(playerDataRefresh, 1000);
-});
+  // limit refresh to one per second
+  const ts = Date.now();
+  const lastRefreshTooRecent = lastDataRefresh && ts - lastDataRefresh < 1000;
+  if (lastRefreshTooRecent) return;
 
-function playerDataRefresh() {
   const ls = getLocalState();
   updateTopBar();
-  changeBackground("default");
-  anime({
-    targets: ".moving_ux",
-    left: 0,
-    easing: EASING_DEFAULT,
-    duration: 350
-  });
   openTab(sidebarActive, {}, ls.lastDataIndex, ls.lastScrollTop);
-}
+  lastDataRefresh = ts;
+});
 
 //
 ipc.on("set_update_state", function(event, arg) {


### PR DESCRIPTION
### Motivation
![image](https://user-images.githubusercontent.com/14894693/64035662-302cde80-cb06-11e9-8386-4868e945071d.png)

### Approach
- Allow main window to "go stale" based on the last-known Arena client state.
- Refresh handler no longer resets back to "non-details" view
- Adjust refresh handler logic to better handle periods of high IPC traffic (e.g. starting a draft)
  - move from async back to sync
  - change limiting logic from "only run if it has been quiet for at least one second" to "only run if it has not run for at least one second"