### PR TITLE
decks page only estimates actual winrate for good sample sizes

### DIFF
--- a/window_main/decks.js
+++ b/window_main/decks.js
@@ -220,7 +220,7 @@ function openDecksTab(_filters = {}, scrollTop = 0) {
       } else {
         // sample size is too small (garbage results)
         interval = "???";
-        tooltip = "play at least 20 games to estimated actual winrate";
+        tooltip = "play at least 20 games to estimate actual winrate";
       }
       let colClass = getWinrateClass(dwr.winrate);
       deckWinrateDiv.innerHTML = `${dwr.wins}:${


### PR DESCRIPTION
### Motivation
https://discordapp.com/channels/463844727654187020/463844728287395851/615146038617178123
![image](https://user-images.githubusercontent.com/14894693/64478430-43baf380-d15d-11e9-81aa-ee9898e14aba.png)

The Wald Interval math only yields reasonable results for sample sizes >= 20. This PR updates the logic on the Decks page to only show the interval when it makes sense.
- only shows interval if there are at least 20 games
- tooltip explains small sample size limitation
- changed "since last edit" tooltip to display the last edit date instead of the interval (since the date is hard to find anywhere else and the sample size is almost always too small to use for the interval anyways).

### Demo
![image](https://user-images.githubusercontent.com/14894693/64478424-2c7c0600-d15d-11e9-80c4-947eefa3a4ce.png)
![image](https://user-images.githubusercontent.com/14894693/64478425-30a82380-d15d-11e9-9e97-9cd5c8fa4edc.png)
