### PR TITLE
Urgent Draft Bugfix

### DIFF
--- a/shared/player-data.js
+++ b/shared/player-data.js
@@ -409,7 +409,7 @@ class PlayerData {
   }
 
   draftExists(id) {
-    return id in this;
+    return this.draft_index.includes(id) && id in this;
   }
 
   event(id) {


### PR DESCRIPTION
### Motivation
Drafting features stopped working on `master` around September 4 (after Eldraine Arena patch). This problem also affects the current stable release 2.9.3.
https://discordapp.com/channels/463844727654187020/467737642306371584/619777592731369512
![image](https://user-images.githubusercontent.com/14894693/64560397-4a806c80-d2fd-11e9-96f3-451c0561baa8.png)


I believe the root cause was [our attempt to optimize performance by relaxing the existence logic for all documents](https://github.com/Manuel-777/MTG-Arena-Tool/commit/84da82c4dab4ad53b510eff597b7659d873f8c09). Although this was harmless in most cases, drafts require bizarre swap-space logic that still depends on the strict existence logic originally dictated by `drafts_index`. 

This bugfix simply re-applies the stricter index check for drafts. It worked end-to-end for my manual test discussed here:
https://discordapp.com/channels/463844727654187020/467737642306371584/620645546595581962
Working shared replay at end of draft: https://mtgatool.com/draft/uc819s