### PR TITLE
Optimize get_deck_colors

### DIFF
--- a/shared/player-data.js
+++ b/shared/player-data.js
@@ -175,54 +175,45 @@ const defaultDeck = JSON.parse(
     ',"description":null,"format":"Standard","colors":[],"id":"00000000-0000-0000-0000-000000000000","isValid":false,"lastUpdated":"2018-05-31T00:06:29.7456958","lockedForEdit":false,"lockedForUse":false,"mainDeck":[],"name":"Undefined","resourceId":"00000000-0000-0000-0000-000000000000","sideboard":[]}'
 );
 
-// cloned from util to avoid circular dependency
-// TODO refactor to recombine
-function get_deck_colors(deck) {
-  var colorIndices = [];
-  try {
-    deck.mainDeck.forEach(card => {
-      if (card.quantity < 1) {
-        return;
+// Cannot use Deck/ColorList classes because it would cause circular dependency
+// tweaked for heavy use in player-data/aggregator
+function getDeckColors(deck) {
+  const colorSet = new Set();
+
+  deck.mainDeck.forEach(card => {
+    if (card.quantity < 1) {
+      return;
+    }
+
+    let cardData = db.card(card.id);
+
+    if (!cardData) {
+      return;
+    }
+
+    let isLand = cardData.type.indexOf("Land") !== -1;
+    let frame = cardData.frame;
+    if (isLand && frame.length < 3) {
+      frame.forEach(colorIndex => colorSet.add(colorIndex));
+    }
+
+    cardData.cost.forEach(cost => {
+      if (cost === "w") {
+        colorSet.add(WHITE);
+      } else if (cost === "u") {
+        colorSet.add(BLUE);
+      } else if (cost === "b") {
+        colorSet.add(BLACK);
+      } else if (cost === "r") {
+        colorSet.add(RED);
+      } else if (cost === "g") {
+        colorSet.add(GREEN);
       }
-
-      let cardData = db.card(card.id);
-
-      if (!cardData) {
-        return;
-      }
-
-      let isLand = cardData.type.indexOf("Land") !== -1;
-      let frame = cardData.frame;
-      if (isLand && frame.length < 3) {
-        colorIndices = colorIndices.concat(frame);
-      }
-
-      cardData.cost.forEach(cost => {
-        if (cost === "w") {
-          colorIndices.push(WHITE);
-        } else if (cost === "u") {
-          colorIndices.push(BLUE);
-        } else if (cost === "b") {
-          colorIndices.push(BLACK);
-        } else if (cost === "r") {
-          colorIndices.push(RED);
-        } else if (cost === "g") {
-          colorIndices.push(GREEN);
-        }
-      });
     });
+  });
 
-    colorIndices = Array.from(new Set(colorIndices));
-    colorIndices.sort((a, b) => {
-      return a - b;
-    });
-  } catch (e) {
-    // FIXME: Errors shouldn't be caught silently. If this is an
-    //        expected error then there should be a test to catch only that error.
-    colorIndices = [];
-  }
-
-  deck.colors = colorIndices;
+  const colorIndices = [...colorSet];
+  colorIndices.sort();
   return colorIndices;
 }
 
@@ -385,7 +376,7 @@ class PlayerData {
     const deckData = {
       ...preconData,
       ...this.decks[id],
-      colors: get_deck_colors(this.decks[id]),
+      colors: getDeckColors(this.decks[id]),
       custom: !this.static_decks.includes(id),
       tags: this.decks_tags[id] || []
     };
@@ -437,10 +428,10 @@ class PlayerData {
       ...preconData,
       ...matchData.playerDeck
     });
-    playerDeck.colors = get_deck_colors(playerDeck);
+    playerDeck.colors = getDeckColors(playerDeck);
 
     const oppDeck = { ...defaultDeck, ...matchData.oppDeck };
-    oppDeck.colors = get_deck_colors(oppDeck);
+    oppDeck.colors = getDeckColors(oppDeck);
 
     return {
       ...matchData,

--- a/window_main/aggregator.js
+++ b/window_main/aggregator.js
@@ -15,11 +15,7 @@ const {
 } = require("../shared/constants");
 const db = require("../shared/database");
 const pd = require("../shared/player-data");
-const {
-  get_deck_colors,
-  getReadableEvent,
-  getRecentDeckName
-} = require("../shared/util");
+const { getReadableEvent, getRecentDeckName } = require("../shared/util");
 const { normalApproximationInterval } = require("../shared/stats-fns");
 
 // Default filter values
@@ -152,11 +148,7 @@ class Aggregator {
 
     // Normalize deck colors into matching data format
     const deckColorCodes = Aggregator.getDefaultColorFilter();
-    if (deck.colors instanceof Array) {
-      deck.colors.forEach(i => (deckColorCodes[COLORS_ALL[i - 1]] = true));
-    } else if (deck.colors instanceof Object) {
-      Object.assign(deckColorCodes, deck.colors);
-    }
+    deck.colors.forEach(i => (deckColorCodes[COLORS_ALL[i - 1]] = true));
 
     return Object.entries(_colors).every(([color, value]) => {
       if (color === "multi") return true;
@@ -373,7 +365,7 @@ class Aggregator {
     }
     // process opponent data
     if (match.oppDeck) {
-      const colors = get_deck_colors(match.oppDeck);
+      const colors = match.oppDeck.colors;
       if (colors && colors.length) {
         colors.sort();
         if (!(colors in this.colorStats)) {

--- a/window_main/renderer-util.js
+++ b/window_main/renderer-util.js
@@ -37,7 +37,6 @@ const {
   deckTypesStats,
   formatRank,
   getCardArtCrop,
-  get_deck_colors,
   get_rank_index_16,
   getCardImage,
   getReadableEvent,
@@ -1023,7 +1022,7 @@ function attachMatchData(listItem, match) {
   listItem.rightBottom.appendChild(matchTime);
 
   // Opp colors
-  get_deck_colors(match.oppDeck).forEach(color => {
+  match.oppDeck.colors.forEach(color => {
     const m = createDiv(["mana_s20", "mana_" + MANA[color]]);
     listItem.rightBottom.appendChild(m);
   });


### PR DESCRIPTION
### Motivation
This PR makes loading the Decks, History, and Events pages slightly faster by optimizing the `get_deck_colors` code a bit.

The final result in empirical tests in the dev console showed about a 30% speed-up for my worst case scenario.

### Approach
- eliminates redundant calls to `get_deck_colors` downstream of `player-data`
- speeds up `player-data.getDeckColors` a bit with some loop optimizations
- only re-computes `deck.colors` if it does not already exist in the correct format