### PR TITLE
Bugfix overly window visibility logic

### DIFF
--- a/window_background/background.js
+++ b/window_background/background.js
@@ -1257,10 +1257,6 @@ function processMatch(json, matchBeginTime) {
   actionLog(-99, new Date(), "");
 
   if (debugLog || !firstPass) {
-    if (playerData.settings.close_on_match) {
-      ipc_send("renderer_hide", 1);
-    }
-
     ipc_send("set_arena_state", ARENA_MODE_MATCH);
   }
 
@@ -1715,9 +1711,6 @@ function finishLoading() {
     });
 
     if (duringMatch) {
-      if (playerData.settings.close_on_match) {
-        ipc_send("renderer_hide", 1);
-      }
       ipc_send("set_arena_state", ARENA_MODE_MATCH);
       update_deck(false);
     } else if (duringDraft) {


### PR DESCRIPTION
### Motivation
In order to support as many environments as possible, we now attempt to hide the entire overlay window when it is "empty". This PR bugfixes some of the edge cases that were not handled correctly, for example the simplest to reproduce is:
  1. Adjust overlay settings so that only one is enabled, it is NOT set to "Always on", and it should appear during a match (e.g. "Library" mode).
  2. Start Arena
  3. Start any match
  4. Overlay will not appear

### Approach
Instead of trying to store and check what the last overlay visibility state was, this PR always checks the current state of the window and compares it to the current arena state and settings.
