### PR TITLE
bugfix settings page log locale format ux

### DIFF
--- a/window_background/background-util.js
+++ b/window_background/background-util.js
@@ -159,6 +159,7 @@ function setData(data, refresh = debugLog || !firstPass) {
 }
 
 module.exports = {
+  getDateFormat,
   ipc_send,
   normaliseFields,
   parseWotcTime,

--- a/window_background/background.js
+++ b/window_background/background.js
@@ -46,6 +46,7 @@ const {
   MAIN_DECKS
 } = require("../shared/constants");
 const {
+  getDateFormat,
   ipc_send,
   setData,
   unleakString,
@@ -948,7 +949,12 @@ function onLogEntryFound(entry) {
           default:
             break;
         }
-        setData({ last_log_timestamp: entry.timestamp });
+        if (entry.timestamp) {
+          setData({
+            last_log_timestamp: entry.timestamp,
+            last_log_format: getDateFormat(entry.timestamp)
+          });
+        }
       } catch (err) {
         console.log(entry.label, entry.position, entry.json());
         console.error(err);

--- a/window_main/settings.js
+++ b/window_main/settings.js
@@ -421,28 +421,33 @@ function appendArenaData(section) {
   logFormatLabel.appendChild(logFormatCont);
   section.appendChild(logFormatLabel);
 
-  const latestDateParsed = parse(
-    pd.last_log_timestamp,
-    pd.last_log_format,
-    new Date()
-  );
+  let parsedOutput = "auto-detection";
+  if (pd.settings.log_locale_format) {
+    const testDate = parse(
+      pd.last_log_timestamp,
+      pd.settings.log_locale_format,
+      new Date()
+    );
+    if (isValid(testDate) && !isNaN(testDate.getTime())) {
+      parsedOutput =
+        '<b class="green">' +
+        testDate.toISOString() +
+        "</b><i> (simplified extended ISO_8601 format)</i>";
+    } else {
+      parsedOutput = '<b class="red">Invalid format or timestamp</b>';
+    }
+  }
   section.appendChild(
     createDiv(
       ["settings_note"],
-      `<p><i>Date and time format to use when parsing the Arena log. Incorrect
+      `<p>Parsed output: ${parsedOutput}</p>
+      <p><i>Date and time format to use when parsing the Arena log. Incorrect
       formats can cause issues importing or displaying data. mtgatool tries to
       auto-detect formats, but sometimes manual input is required.</p>
       <p>Leave blank to use default auto-detection, or
       <a class="link parse_link">use ISO_8601 to specify a custom format</a>.</p></i>
       <p>Last log timestamp: <b>${pd.last_log_timestamp}</b></p>
-      <p>Last format used: <b>${pd.last_log_format}</b></p>
-      <p>Parsed output: ${
-        isValid(latestDateParsed) && !isNaN(latestDateParsed.getTime())
-          ? '<b class="green">' +
-            latestDateParsed.toISOString() +
-            "</b><i> (simplified extended ISO_8601 format)</i>"
-          : '<b class="red">Invalid format or timestamp</b>'
-      }</p>`
+      <p>Last format used: <b>${pd.last_log_format}</b></p>`
     )
   );
 


### PR DESCRIPTION
### Motivation
https://discordapp.com/channels/463844727654187020/467737642306371584/624348439571857429
![image](https://user-images.githubusercontent.com/14894693/65286432-6ac9db80-daf4-11e9-9b58-0f71bfd393a6.png)
![image](https://user-images.githubusercontent.com/14894693/65286416-5d145600-daf4-11e9-916e-a81b14044c29.png)

Looks like we broke the settings page live-update display of the log locale format parser. Also we broke the display of the last used log locale format. Also I moved the parsed output next to the UX input field so it would be more clear that it was a live output.

### Demo
![image](https://user-images.githubusercontent.com/14894693/65286503-a5cc0f00-daf4-11e9-80a1-e0ee5076db7d.png)
![image](https://user-images.githubusercontent.com/14894693/65286507-a9f82c80-daf4-11e9-8b54-72aa582c90c2.png)
