### PR TITLE
upgrade date-fns to 2.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "MTG-Arena-Tool",
-  "version": "2.9.3",
+  "version": "2.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1821,9 +1821,9 @@
       }
     },
     "date-fns": {
-      "version": "2.0.0-alpha.27",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.0.0-alpha.27.tgz",
-      "integrity": "sha512-cqfVLS+346P/Mpj2RpDrBv0P4p2zZhWWvfY5fuWrXNR/K38HaAGEkeOwb47hIpQP9Jr/TIxjZ2/sNMQwdXuGMg=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.2.1.tgz",
+      "integrity": "sha512-4V1i5CnTinjBvJpXTq7sDHD4NY6JPcl15112IeSNNLUWQOQ+kIuCvRGOFZMQZNvkadw8F9QTyZxz59rIRU6K+w=="
     },
     "debug": {
       "version": "2.6.9",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "chart.js": "^2.8.0",
     "conf": "^2.2.0",
     "conic-gradient": "^1.0.0",
-    "date-fns": "^2.0.0-alpha.27",
+    "date-fns": "^2.2.1",
     "electron-asar-hot-updater": "0.0.5",
     "electron-debug": "^1.5.0",
     "electron-store": "^3.2.0",

--- a/shared/util.js
+++ b/shared/util.js
@@ -606,7 +606,7 @@ function get_deck_export_txt(deck) {
 //
 exports.timeSince = timeSince;
 function timeSince(_date, options = { includeSeconds: true }) {
-  // https://date-fns.org/v2.0.0-alpha.27/docs/formatDistanceStrict
+  // https://date-fns.org/v2.2.1/docs/formatDistanceStrict
   return formatDistanceStrict(_date, new Date(), options);
 }
 

--- a/window_background/background-util.js
+++ b/window_background/background-util.js
@@ -20,7 +20,7 @@ const playerData = require("../shared/player-data.js");
 // These were tested briefly
 // They are all taken from logs
 // Some format from date-fns could be wrong;
-// https://date-fns.org/v2.0.0-alpha.27/docs/parse
+// https://date-fns.org/v2.2.1/docs/parse
 let dateFormats = [
   "dd.MM.yyyy HH:mm:ss",
   "dd/MM/yyyy HH:mm:ss",

--- a/window_main/settings.js
+++ b/window_main/settings.js
@@ -448,7 +448,7 @@ function appendArenaData(section) {
 
   setTimeout(() => {
     $$(".parse_link")[0].addEventListener("click", () => {
-      shell.openExternal("https://date-fns.org/v2.0.0-alpha.27/docs/parse");
+      shell.openExternal("https://date-fns.org/v2.2.1/docs/parse");
     });
   }, 100);
 }


### PR DESCRIPTION
### Motivation
[Our date utility library date-fns](https://date-fns.org/) released version 2 about a month ago. This PR upgrades our `date-fns` version dependency from 2.0.0-alpha.27 to the latest 2.2.1.

- [prerelease changelog covers from 2.0.0-alpha.27 to 2.0](https://gist.github.com/kossnocorp/a307a464760b405bb78ef5020a4ab136)
 - [changelog covers the rest](https://github.com/date-fns/date-fns/blob/master/CHANGELOG.md)

Nothing in the breaking changes seemed relevant, but you never know.