### PR TITLE
bugfix practice matches

### DIFF
--- a/window_background/background.js
+++ b/window_background/background.js
@@ -1610,6 +1610,9 @@ function saveMatch(id, matchEndTime) {
   }
   const existingMatch = playerData.match(id) || {};
   const match = completeMatch(existingMatch, currentMatch, matchEndTime);
+  if (!match) {
+    return;
+  }
 
   // console.log("Save match:", match);
   if (!playerData.matches_index.includes(id)) {


### PR DESCRIPTION
### Motivation
We currently skip saving practice matches against Sparky, but some parts of the code fail unexpectedly as a result. This can cause the tool to freeze forever on the loading screen, e.g.:
  1. Start a clean session of Arena, start a practice match, end the match.
  2. Configure mtgatool to enable "Read entire Arena log during launch"
  3. Re-launch mtgatool.
  4. mtgatool with crash after login with "Finishing initial log read..." on screen forever

Here is the console error from the scenario above:
```
background.js:960 TypeError: Cannot read property 'playerDeck' of undefined
    at PlayerData.match (C:\Users\Local Ben\code\MTG-Arena-Tool\dist\win-unpacked\resources\app.asar\shared\player-data.js:428:19)
    at saveMatch (file:///C:/Users/Local%20Ben/code/MTG-Arena-Tool/dist/win-unpacked/resources/app.asar/window_background/background.js:1611:36)
    at onLabelOutLogInfo (C:\Users\Local Ben\code\MTG-Arena-Tool\dist\win-unpacked\resources\app.asar\window_background\labels.js:236:7)
    at onLogEntryFound (file:///C:/Users/Local%20Ben/code/MTG-Arena-Tool/dist/win-unpacked/resources/app.asar/window_background/background.js:722:15)
    at C:\Users\Local Ben\code\MTG-Arena-Tool\dist\win-unpacked\resources\app.asar\window_background\arena-log-watcher.js:59:42
    at Object.append (C:\Users\Local Ben\code\MTG-Arena-Tool\dist\win-unpacked\resources\app.asar\window_background\arena-log-decoder\arena-log-decoder.js:57:11)
    at read (C:\Users\Local Ben\code\MTG-Arena-Tool\dist\win-unpacked\resources\app.asar\window_background\arena-log-watcher.js:59:20)
    at async attempt (C:\Users\Local Ben\code\MTG-Arena-Tool\dist\win-unpacked\resources\app.asar\window_background\arena-log-watcher.js:37:7)
```