### PR TITLE
Fix mana symbol tyling issues

### DIFF
--- a/shared/shared.css
+++ b/shared/shared.css
@@ -590,11 +590,11 @@ label {
     z-index: 15;
     pointer-events: none;
     background-size: contain;
-    box-shadow: -1px 1px black;
-    border-radius: 100%;
     width: 20px;
     height: 20px;
     margin: 0 2px auto 2px;
+    background-repeat: no-repeat;
+    filter: drop-shadow(-1px 1px black);
 }
 
 .mana_s16 {


### PR DESCRIPTION
Currently, the mana symbols on the deck page (and i'd imagine elsewhere) tile themselves vertically due to a lack of `background-repeat` css style. Additionally, when resized to be smaller than the 20px width, the box shadow no longer aligns with the mana symbol.

This PR fixes both of these issues, by applying a `background-repeat: no-repeat` and a CSS filter for drop shadow, and removes the outdated CSS.