### PR TITLE
Add "Sort By Wildcards" function

### DIFF
--- a/window_main/aggregator.js
+++ b/window_main/aggregator.js
@@ -15,7 +15,11 @@ const {
 } = require("../shared/constants");
 const db = require("../shared/database");
 const pd = require("../shared/player-data");
-const { getReadableEvent, getRecentDeckName } = require("../shared/util");
+const {
+  getReadableEvent,
+  getRecentDeckName,
+  get_deck_missing
+} = require("../shared/util");
 const { normalApproximationInterval } = require("../shared/stats-fns");
 
 // Default filter values
@@ -47,6 +51,9 @@ class Aggregator {
     this.compareDecks = this.compareDecks.bind(this);
     this.compareDecksByWins = this.compareDecksByWins.bind(this);
     this.compareDecksByWinrates = this.compareDecksByWinrates.bind(this);
+    this.compareDecksByWildcardsNeeded = this.compareDecksByWildcardsNeeded.bind(
+      this
+    );
     this.compareEvents = this.compareEvents.bind(this);
     this.updateFilters(filters);
   }
@@ -456,6 +463,33 @@ class Aggregator {
     return (
       bStats.winrate - aStats.winrate ||
       bStats.wins - aStats.wins ||
+      aName.localeCompare(bName)
+    );
+  }
+
+  _sumNumberWildcardsMissing(missingCards) {
+    return Object.values(missingCards).reduce((accum, num) => {
+      if (num) {
+        return accum + num;
+      }
+    });
+  }
+
+  compareDecksByWildcardsNeeded(a, b) {
+    const aMissing = get_deck_missing(a);
+    const bMissing = get_deck_missing(b);
+    const aMissingTotal = this._sumNumberWildcardsMissing(aMissing);
+    const bMissingtotal = this._sumNumberWildcardsMissing(bMissing);
+
+    const aName = getRecentDeckName(a.id);
+    const bName = getRecentDeckName(b.id);
+
+    return (
+      bMissingtotal - aMissingTotal ||
+      bMissing.mythic - aMissing.mythic ||
+      bMissing.rare - aMissing.rare ||
+      bMissing.uncommon - aMissing.uncommon ||
+      bMissing.common - aMissing.common ||
       aName.localeCompare(bName)
     );
   }

--- a/window_main/aggregator.js
+++ b/window_main/aggregator.js
@@ -18,7 +18,8 @@ const pd = require("../shared/player-data");
 const {
   getReadableEvent,
   getRecentDeckName,
-  get_deck_missing
+  get_deck_missing,
+  getBoosterCountEstimate,
 } = require("../shared/util");
 const { normalApproximationInterval } = require("../shared/stats-fns");
 
@@ -51,7 +52,7 @@ class Aggregator {
     this.compareDecks = this.compareDecks.bind(this);
     this.compareDecksByWins = this.compareDecksByWins.bind(this);
     this.compareDecksByWinrates = this.compareDecksByWinrates.bind(this);
-    this.compareDecksByWildcardsNeeded = this.compareDecksByWildcardsNeeded.bind(
+    this.compareDecksByIncompleteness = this.compareDecksByIncompleteness.bind(
       this
     );
     this.compareEvents = this.compareEvents.bind(this);
@@ -467,25 +468,18 @@ class Aggregator {
     );
   }
 
-  _sumNumberWildcardsMissing(missingCards) {
-    return Object.values(missingCards).reduce((accum, num) => {
-      if (num) {
-        return accum + num;
-      }
-    });
-  }
 
-  compareDecksByWildcardsNeeded(a, b) {
+  compareDecksByIncompleteness(a, b) {
     const aMissing = get_deck_missing(a);
     const bMissing = get_deck_missing(b);
-    const aMissingTotal = this._sumNumberWildcardsMissing(aMissing);
-    const bMissingtotal = this._sumNumberWildcardsMissing(bMissing);
+    const aMissingBoosters = getBoosterCountEstimate(aMissing);
+    const bMissingBoosters = getBoosterCountEstimate(bMissing);
 
     const aName = getRecentDeckName(a.id);
     const bName = getRecentDeckName(b.id);
 
     return (
-      bMissingtotal - aMissingTotal ||
+      bMissingBoosters - aMissingBoosters ||
       bMissing.mythic - aMissing.mythic ||
       bMissing.rare - aMissing.rare ||
       bMissing.uncommon - aMissing.uncommon ||

--- a/window_main/aggregator.js
+++ b/window_main/aggregator.js
@@ -19,7 +19,7 @@ const {
   getReadableEvent,
   getRecentDeckName,
   get_deck_missing,
-  getBoosterCountEstimate,
+  getBoosterCountEstimate
 } = require("../shared/util");
 const { normalApproximationInterval } = require("../shared/stats-fns");
 
@@ -467,7 +467,6 @@ class Aggregator {
       aName.localeCompare(bName)
     );
   }
-
 
   compareDecksByIncompleteness(a, b) {
     const aMissing = get_deck_missing(a);

--- a/window_main/decks.js
+++ b/window_main/decks.js
@@ -113,8 +113,8 @@ function openDecksTab(_filters = {}, scrollTop = 0) {
     decks.sort(aggregator.compareDecksByWinrates);
   } else if (filters.sort === "By Wins") {
     decks.sort(aggregator.compareDecksByWins);
-  } else if (filters.sort === "By Wildcards") {
-    decks.sort(aggregator.compareDecksByWildcardsNeeded);
+  } else if (filters.sort === "By Incomplete") {
+    decks.sort(aggregator.compareDecksByIncompleteness);
   } else {
     decks.sort(aggregator.compareDecks);
   }

--- a/window_main/decks.js
+++ b/window_main/decks.js
@@ -113,6 +113,8 @@ function openDecksTab(_filters = {}, scrollTop = 0) {
     decks.sort(aggregator.compareDecksByWinrates);
   } else if (filters.sort === "By Wins") {
     decks.sort(aggregator.compareDecksByWins);
+  } else if (filters.sort === "By Wildcards") {
+    decks.sort(aggregator.compareDecksByWildcardsNeeded);
   } else {
     decks.sort(aggregator.compareDecks);
   }

--- a/window_main/filter-panel.js
+++ b/window_main/filter-panel.js
@@ -357,7 +357,7 @@ class FilterPanel {
       sortDiv.appendChild(sortLabel);
       const sortSelect = createSelect(
         sortDiv,
-        ["By Date", "By Wins", "By Winrate"],
+        ["By Date", "By Wins", "By Winrate", "By Wildcards"],
         this.filters.sort,
         filter => {
           this.filters.sort = filter;

--- a/window_main/filter-panel.js
+++ b/window_main/filter-panel.js
@@ -357,7 +357,7 @@ class FilterPanel {
       sortDiv.appendChild(sortLabel);
       const sortSelect = createSelect(
         sortDiv,
-        ["By Date", "By Wins", "By Winrate", "By Wildcards"],
+        ["By Date", "By Wins", "By Winrate", "By Incomplete"],
         this.filters.sort,
         filter => {
           this.filters.sort = filter;


### PR DESCRIPTION
Add the capability for decks to be sorted by # of wildcards needed. This will first sort by total number needed, then by mythics, then by rares, etc. Open to removing the "total number" as the primary sort if we feel it's more organized that way.

Should resolve #566 
