### PR TITLE
Added an Advanced Filter : Owned quantity

### DIFF
--- a/window_main/collection.js
+++ b/window_main/collection.js
@@ -432,18 +432,6 @@ function openCollectionTab() {
 
   addCheckboxSearch(
     cont,
-    '<div class="icon_search_unowned"></div>Show unowned',
-    "query_unown",
-    false
-  );
-  addCheckboxSearch(
-    cont,
-    '<div class="icon_search_incomplete"></div>Incomplete only',
-    "query_incomplete",
-    false
-  );
-  addCheckboxSearch(
-    cont,
     '<div class="icon_search_new"></div>Newly acquired only',
     "query_new",
     false
@@ -500,7 +488,6 @@ function openCollectionTab() {
 
   icd.appendChild(inputCmc);
   cont.appendChild(icd);
-
   let checkboxCmcHigher = addCheckboxSearch(
     cont,
     "Higher than",
@@ -513,6 +500,43 @@ function openCollectionTab() {
     cont,
     "Lower than",
     "query_cmclower",
+    false,
+    true
+  );
+
+  main_but_cont.appendChild(cont);
+  filters.appendChild(main_but_cont);
+  
+  cont = createDiv(["buttons_container"]);
+  icd = createDiv(["input_container_inventory", "auto_width"]);
+
+  label = document.createElement("label");
+  label.style.display = "table";
+  label.innerHTML = "Owned Qty:";
+  icd.appendChild(label);
+
+  let inputQty = document.createElement("input");
+  inputQty.style.maxWidth = "80px";
+  inputQty.id = "query_qty";
+  inputQty.autocomplete = "off";
+  inputQty.type = "number";
+  inputQty.min="0";
+  inputQty.max="4";
+
+  icd.appendChild(inputQty);
+  cont.appendChild(icd);
+   let checkboxQtyHigher = addCheckboxSearch(
+    cont,
+    "Higher than",
+    "query_qtyhigher",
+    false,
+    true
+  );
+  addCheckboxSearch(cont, "Equal to", "query_qtyequal", true);
+  let checkboxQtyLower = addCheckboxSearch(
+    cont,
+    "Lower than",
+    "query_qtylower",
     false,
     true
   );
@@ -607,8 +631,6 @@ function resetFilters() {
 
   document.getElementById("query_name").value = "";
   document.getElementById("query_type").value = "";
-  document.getElementById("query_unown").checked = false;
-  document.getElementById("query_incomplete").checked = false;
   document.getElementById("query_new").checked = false;
   document.getElementById("query_multicolor").checked = false;
   document.getElementById("query_exclude").checked = false;
@@ -932,8 +954,6 @@ function printCards() {
 
   let filterName = document.getElementById("query_name").value.toLowerCase();
   let filterType = document.getElementById("query_type").value.toLowerCase();
-  let filterUnown = document.getElementById("query_unown").checked;
-  let filterIncomplete = document.getElementById("query_incomplete").checked;
   let filterNew = document.getElementById("query_new");
   let filterMulti = document.getElementById("query_multicolor");
   let filterExclude = document.getElementById("query_exclude");
@@ -949,10 +969,15 @@ function printCards() {
   let filterCmcLower = document.getElementById("query_cmclower").checked;
   let filterCmcEqual = document.getElementById("query_cmcequal").checked;
   let filterCmcHigher = document.getElementById("query_cmchigher").checked;
+  
+  let filterQty = document.getElementById("query_qty").value;
+  let filterQtyLower = document.getElementById("query_qtylower").checked;
+  let filterQtyEqual = document.getElementById("query_qtyequal").checked;
+  let filterQtyHigher = document.getElementById("query_qtyhigher").checked;
 
   let totalCards = 0;
   let list;
-  if (filterUnown) {
+  if (filterQty == 0 || filterQtyLower) {
     list = db.cardIds;
   } else {
     list = Object.keys(pd.cards.cards);
@@ -997,13 +1022,6 @@ function printCards() {
       }
     }
 
-    if (filterIncomplete) {
-      const owned = pd.cards.cards[card.id];
-      if (owned >= 4) {
-        continue;
-      }
-    }
-
     if (filterNew.checked && pd.cardsNew[key] === undefined) {
       continue;
     }
@@ -1037,6 +1055,32 @@ function printCards() {
         }
       }
     }
+	
+	if (filterQty > 0) {
+		const owned = pd.cards.cards[card.id];
+      if (filterQtyLower && filterQtyEqual) {
+        if (owned > filterQty) {
+          continue;
+        }
+      } else if (filterQtyHigher && filterQtyEqual) {
+        if (owned < filterQty) {
+          continue;
+        }
+      } else if (filterQtyLower && !filterQtyEqual) {
+        if (owned >= filterQty) {
+          continue;
+        }
+      } else if (filterQtyHigher && !filterQtyEqual) {
+        if (owned <= filterQty) {
+          continue;
+        }
+      } else if (!filterQtyHigher && !filterQtyLower && filterQtyEqual) {
+        if (owned != filterQty) {
+          continue;
+        }
+      }
+    }
+	
 
     if (rarity == "land" && filterAnyRarityChecked && !filterCommon) continue;
     if (rarity == "common" && filterAnyRarityChecked && !filterCommon) continue;

--- a/window_main/collection.js
+++ b/window_main/collection.js
@@ -569,6 +569,18 @@ function openCollectionTab() {
     }
   });
 
+  checkboxQtyLower.addEventListener("change", () => {
+    if (document.getElementById("query_qtylower").checked == true) {
+      document.getElementById("query_qtyhigher").checked = false;
+    }
+  });
+
+  checkboxQtyHigher.addEventListener("change", () => {
+    if (document.getElementById("query_qtyhigher").checked == true) {
+      document.getElementById("query_qtylower").checked = false;
+    }
+  });
+
   printCards();
 }
 
@@ -645,6 +657,10 @@ function resetFilters() {
   document.getElementById("query_cmclower").checked = false;
   document.getElementById("query_cmcequal").checked = true;
   document.getElementById("query_cmchigher").checked = false;
+
+  document.getElementById("query_qtylower").checked = false;
+  document.getElementById("query_qtyequal").checked = true;
+  document.getElementById("query_qtyhigher").checked = false;
 
   printCollectionPage();
 }

--- a/window_main/collection.js
+++ b/window_main/collection.js
@@ -488,6 +488,7 @@ function openCollectionTab() {
 
   icd.appendChild(inputCmc);
   cont.appendChild(icd);
+
   let checkboxCmcHigher = addCheckboxSearch(
     cont,
     "Higher than",
@@ -506,7 +507,7 @@ function openCollectionTab() {
 
   main_but_cont.appendChild(cont);
   filters.appendChild(main_but_cont);
-  
+
   cont = createDiv(["buttons_container"]);
   icd = createDiv(["input_container_inventory", "auto_width"]);
 
@@ -520,12 +521,12 @@ function openCollectionTab() {
   inputQty.id = "query_qty";
   inputQty.autocomplete = "off";
   inputQty.type = "number";
-  inputQty.min="0";
-  inputQty.max="4";
+  inputQty.min = "0";
+  inputQty.max = "4";
 
   icd.appendChild(inputQty);
   cont.appendChild(icd);
-   let checkboxQtyHigher = addCheckboxSearch(
+  let checkboxQtyHigher = addCheckboxSearch(
     cont,
     "Higher than",
     "query_qtyhigher",
@@ -969,7 +970,7 @@ function printCards() {
   let filterCmcLower = document.getElementById("query_cmclower").checked;
   let filterCmcEqual = document.getElementById("query_cmcequal").checked;
   let filterCmcHigher = document.getElementById("query_cmchigher").checked;
-  
+
   let filterQty = document.getElementById("query_qty").value;
   let filterQtyLower = document.getElementById("query_qtylower").checked;
   let filterQtyEqual = document.getElementById("query_qtyequal").checked;
@@ -1055,9 +1056,9 @@ function printCards() {
         }
       }
     }
-	
-	if (filterQty > 0) {
-		const owned = pd.cards.cards[card.id];
+
+    if (filterQty > 0) {
+      const owned = pd.cards.cards[card.id];
       if (filterQtyLower && filterQtyEqual) {
         if (owned > filterQty) {
           continue;
@@ -1080,7 +1081,6 @@ function printCards() {
         }
       }
     }
-	
 
     if (rarity == "land" && filterAnyRarityChecked && !filterCommon) continue;
     if (rarity == "common" && filterAnyRarityChecked && !filterCommon) continue;


### PR DESCRIPTION
Hello Dear Manuel,

The only thing that missed me in your tool was the possibility to filter cards based on the quantity I own. So I did it ! Maybe you will consider it if it looks good for you. 
(i am new to GitHub so sorry if i do something not really well)

Best regards, thank you very much for your work.

> - It works like the CMC filter (I copy-pasted it), you can filter <,> and/or= the owned quantity of the card. It is more precise than the previous filters ("Unowned", "Complete" and "Incomplete"), These ones have been removed.
> - Unowned cards are displayed if filter is null, = 0 or if "Lower than" is checked.
> - Default value is null and "equals to" (like the CMC filter).

![owned quantity](https://user-images.githubusercontent.com/18503007/66708110-c2521480-ed4b-11e9-995f-ab295ff416de.png)
