### PR TITLE
Overlay Bugfixes

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -19,3 +19,4 @@ coverage
 # production
 build
 dist
+lib

--- a/src/main.js
+++ b/src/main.js
@@ -575,7 +575,12 @@ function createOverlayWindow() {
     }
   });
   overlay.loadURL(`file://${__dirname}/window_overlay_v3/index.html`);
-  //overlay.setIgnoreMouseEvents(true, { forward: true });
+
+  if (process.platform !== "linux") {
+    // https://electronjs.org/docs/api/browser-window#winsetignoremouseeventsignore-options
+    // does not currently support Linux
+    overlay.setIgnoreMouseEvents(true, { forward: true });
+  }
 
   return overlay;
 }

--- a/src/window_overlay_v3/overlay.js
+++ b/src/window_overlay_v3/overlay.js
@@ -1130,7 +1130,7 @@ ready(function() {
       <div class="outer_wrapper elements_wrapper">
         <div class="overlay_deckname"></div>
         <div class="overlay_deckcolors"></div>
-        <div class="overlay_decklist"></div>
+        <div class="overlay_decklist click-on"></div>
         <div class="overlay_clock_container">
             <div class="clock_prev click-on"></div>
             <div class="clock_turn"></div>


### PR DESCRIPTION
### Motivation
This is a bundle of misc bugfixes for the overlays:
 - workaround for #563 by adding a 10-second auto-hide to hover card display
 - bugfix: on windows, fixes an issue with the transparency click-through for the first time overlays appear by calling `overlay.setIgnoreMouseEvents(true, { forward: true });`. This affected matches and drafts. Since this is unsupported in Linux, this PR limits the call to non-linux OS.
  - bugfix: on windows, lets the user scroll the decklist/sideboard
  - refactor: standardizes when the `overlay` window is created in `main` process to eliminate the need for null-checks and certain rare race conditions