### PR TITLE
Show winrate interval in explore tab

### DIFF
--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -725,7 +725,6 @@ export function formatRank(rank) {
   return `${rank.rank} ${rank.tier}`;
 }
 
-
-export function roundWinrate(x){
+export function roundWinrate(x) {
   return Math.round(x * 100) / 100;
 }

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -724,3 +724,8 @@ export function formatRank(rank) {
   }
   return `${rank.rank} ${rank.tier}`;
 }
+
+
+export function roundWinrate(x){
+  return Math.round(x * 100) / 100;
+}

--- a/src/window_main/decks.js
+++ b/src/window_main/decks.js
@@ -213,7 +213,10 @@ export function openDecksTab(_filters = {}, scrollTop = 0) {
       if (dwr.total >= 20) {
         // sample Size is large enough to use Wald Interval
         interval = formatPercent(dwr.interval);
-        tooltip = formatWinrateInterval(formatPercent(dwr.winrateLow), formatPercent(dwr.winrateHigh))
+        tooltip = formatWinrateInterval(
+          formatPercent(dwr.winrateLow),
+          formatPercent(dwr.winrateHigh)
+        );
       } else {
         // sample size is too small (garbage results)
         interval = "???";

--- a/src/window_main/decks.js
+++ b/src/window_main/decks.js
@@ -16,6 +16,7 @@ import StatsPanel from "./stats-panel";
 import { openDeck } from "./deck-details";
 import {
   formatPercent,
+  formatWinrateInterval,
   getTagColor,
   getWinrateClass,
   hideLoadingBars,
@@ -212,10 +213,7 @@ export function openDecksTab(_filters = {}, scrollTop = 0) {
       if (dwr.total >= 20) {
         // sample Size is large enough to use Wald Interval
         interval = formatPercent(dwr.interval);
-        tooltip = `${formatPercent(dwr.winrateLow)} to ${formatPercent(
-          dwr.winrateHigh
-        )} with 95% confidence
-(estimated actual winrate bounds, assuming a normal distribution)`;
+        tooltip = formatWinrateInterval(formatPercent(dwr.winrateLow), formatPercent(dwr.winrateHigh))
       } else {
         // sample size is too small (garbage results)
         interval = "???";

--- a/src/window_main/explore.js
+++ b/src/window_main/explore.js
@@ -619,16 +619,23 @@ function deckLoad(_deck, index) {
   });
 
   let deckWinrate = normalApproximationInterval(_deck.mt, _deck.mw);
-  
+
   let colClass = getWinrateClass(deckWinrate.winrate);
   d = createDiv(
     ["list_deck_record"],
-    `${_deck.mw}:${_deck.ml} <span class="${colClass}_bright">(${formatPercent(deckWinrate.winrate)})</span>`
+    `${_deck.mw}:${_deck.ml} <span class="${colClass}_bright">(${formatPercent(
+      deckWinrate.winrate
+    )})</span>`
   );
-  if(_deck.mt >= 20){
+  if (_deck.mt >= 20) {
     // sample Size is large enough to use Wald Interval
-    d.title = formatWinrateInterval(roundWinrate(deckWinrate.winrate - deckWinrate.interval), roundWinrate(deckWinrate.winrate + deckWinrate.interval));
-    d.innerHTML += `<i style="opacity:0.6;"> &plusmn; ${formatPercent(roundWinrate(deckWinrate.interval))}</i>)`;
+    d.title = formatWinrateInterval(
+      roundWinrate(deckWinrate.winrate - deckWinrate.interval),
+      roundWinrate(deckWinrate.winrate + deckWinrate.interval)
+    );
+    d.innerHTML += `<i style="opacity:0.6;"> &plusmn; ${formatPercent(
+      roundWinrate(deckWinrate.interval)
+    )}</i>`;
   }
 
   flr.appendChild(d);

--- a/src/window_main/explore.js
+++ b/src/window_main/explore.js
@@ -17,7 +17,9 @@ import {
   get_rank_index_16,
   removeDuplicates,
   compare_cards,
-  getBoosterCountEstimate
+  getBoosterCountEstimate,
+  roundWinrate,
+  get_deck_missing
 } from "../shared/util";
 import {
   addCheckbox,
@@ -27,9 +29,12 @@ import {
   ipcSend,
   resetMainContainer,
   setLocalState,
-  showLoadingBars
+  showLoadingBars,
+  formatPercent,
+  formatWinrateInterval
 } from "./renderer-util";
 import { openDeck } from "./deck-details";
+import { normalApproximationInterval } from "../shared/stats-fns";
 
 // default values for cached local state
 const defaultData = {
@@ -613,13 +618,18 @@ function deckLoad(_deck, index) {
     flb.appendChild(manaIcon);
   });
 
-  let colClass = getWinrateClass((1 / _deck.mt) * _deck.mw);
+  let deckWinrate = normalApproximationInterval(_deck.mt, _deck.mw);
+  
+  let colClass = getWinrateClass(deckWinrate.winrate);
   d = createDiv(
     ["list_deck_record"],
-    `${_deck.mw}:${_deck.ml} <span class="${colClass}_bright">(${Math.round(
-      (100 / _deck.mt) * _deck.mw
-    )}%)</span>`
+    `${_deck.mw}:${_deck.ml} <span class="${colClass}_bright">(${formatPercent(deckWinrate.winrate)})</span>`
   );
+  if(_deck.mt >= 20){
+    // sample Size is large enough to use Wald Interval
+    d.title = formatWinrateInterval(roundWinrate(deckWinrate.winrate - deckWinrate.interval), roundWinrate(deckWinrate.winrate + deckWinrate.interval));
+    d.innerHTML += `<i style="opacity:0.6;"> &plusmn; ${formatPercent(roundWinrate(deckWinrate.interval))}</i>)`;
+  }
 
   flr.appendChild(d);
 

--- a/src/window_main/renderer-util.js
+++ b/src/window_main/renderer-util.js
@@ -760,7 +760,7 @@ function formatPercent(value, config = { maximumSignificantDigits: 2 }) {
   });
 }
 
-function formatWinrateInterval(lower, upper){
+export function formatWinrateInterval(lower, upper) {
   return `${formatPercent(lower)} to ${formatPercent(upper)} with 95% confidence
 (estimated actual winrate bounds, assuming a normal distribution)`;
 }
@@ -1075,7 +1075,6 @@ export {
   renderLogInput,
   formatPercent,
   formatNumber,
-  formatWinrateInterval,
   getWinrateClass,
   getEventWinLossClass,
   compareWinrates,

--- a/src/window_main/renderer-util.js
+++ b/src/window_main/renderer-util.js
@@ -760,6 +760,11 @@ function formatPercent(value, config = { maximumSignificantDigits: 2 }) {
   });
 }
 
+function formatWinrateInterval(lower, upper){
+  return `${formatPercent(lower)} to ${formatPercent(upper)} with 95% confidence
+(estimated actual winrate bounds, assuming a normal distribution)`;
+}
+
 function formatNumber(value, config = {}) {
   return value.toLocaleString([], {
     style: "decimal",
@@ -1070,6 +1075,7 @@ export {
   renderLogInput,
   formatPercent,
   formatNumber,
+  formatWinrateInterval,
   getWinrateClass,
   getEventWinLossClass,
   compareWinrates,


### PR DESCRIPTION
Decks in the Explore tab often show a high winrate while having been played only a few matches, which makes it difficult to properly assess their performance.

This PR uses the code that was already present for the My Decks tab to display the winrate interval next to the wins : losses ratio, together with the interval boundaries in the tooltip. The part where it says "more matches are needed" is left out, as it is usually not in the capabilities of the one using the Explore tab to play more matches with the deck (s)he's inspecting.