### PR TITLE
Batch load fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "test:jest": "jest",
     "dist": "npm run babel && build --x64",
     "version": "node -p \"require('./package.json').version\"",
-    "load-logs": "electron \"./scripts/load-logs.js\"",
+    "load-logs": "npm run babel && electron \"./scripts/load-logs.js\"",
     "metadata": "electron \"./scripts/metadata.js\"",
     "babel": "npm run tsc && babel src --extensions \".ts,.tsx,.js,.jsx\" --out-dir lib --copy-files",
     "tsc": "tsc"

--- a/scripts/load-logs.js
+++ b/scripts/load-logs.js
@@ -132,17 +132,20 @@ app.setPath("userData", path.join(appData, appName));
 
 function terminateStall() {
   const timeSinceLastMessage = Date.now() - lastMessageTime;
-  // if thirty seconds have passed then trigger a 
+  // if thirty seconds have passed then trigger a
   // termination using a false initialize event
 
   if (timeSinceLastMessage > 30000) {
-    ipc.send("ipc_switch", {event: 'Timeout - exiting', method: 'initialize'});
+    ipc.send("ipc_switch", {
+      event: "Timeout - exiting",
+      method: "initialize"
+    });
   }
 }
 
 app.on("ready", () => {
   const log_files = require("./batch_load_files.json");
-  
+
   var tsInterval = setInterval(terminateStall, 1000);
 
   nextLog(log_files, _ => {

--- a/scripts/load-logs.js
+++ b/scripts/load-logs.js
@@ -26,7 +26,7 @@ function createBackgroundWindow() {
     frame: false,
     x: 0,
     y: 0,
-    show: false,
+    show: DEBUG,
     width: 640,
     height: 480,
     title: "Background",
@@ -35,7 +35,7 @@ function createBackgroundWindow() {
       nodeIntegration: true
     }
   });
-  win.loadURL(`file://${__dirname}/../window_background/index.html`);
+  win.loadURL(`file://${__dirname}/../lib/window_background/index.html`);
   return win;
 }
 


### PR DESCRIPTION
A fix for working around log files which stall, if there are no messages in 30 seconds then it terminates and moves on.

Now skips past logs which are non-detailed. 

And should now be working with the new babel compilation.