### PR TITLE
Consolidate all the share dialog cases

### DIFF
--- a/src/window_main/createShareButton.ts
+++ b/src/window_main/createShareButton.ts
@@ -10,8 +10,16 @@ import { createSelect } from "../shared/createSelect";
 
 const byId = (id: string) => document.querySelector<HTMLInputElement>("input#" + id);
 
-export default function createShareDialog(callback: () => void) {
-    e.stopPropagation();
+export default function createShareButton(classNames: string[], callback: () => void) {
+    let button = createInput(classNames);
+    button.addEventListener("click", (e: MouseEvent) => {
+        e.stopPropagation();
+        createShareDialog(callback);
+      });
+    return button;
+}
+
+function createShareDialog(callback: () => void) {
     const cont = createDiv(["dialog_content"]);
     cont.style.width = "500px";
 

--- a/src/window_main/createShareButton.ts
+++ b/src/window_main/createShareButton.ts
@@ -11,7 +11,7 @@ import { createSelect } from "../shared/createSelect";
 const byId = (id: string) => document.querySelector<HTMLInputElement>("input#" + id);
 
 export default function createShareButton(classNames: string[], callback: () => void) {
-    let button = createInput(classNames);
+    let button = createDiv(classNames);
     button.addEventListener("click", (e: MouseEvent) => {
         e.stopPropagation();
         createShareDialog(callback);

--- a/src/window_main/createShareDialog.ts
+++ b/src/window_main/createShareDialog.ts
@@ -1,0 +1,44 @@
+import {
+    createDiv,
+    createInput,
+} from "../shared/dom-fns";
+import {
+    openDialog,
+    ipcSend,
+} from "./renderer-util";
+import { createSelect } from "../shared/createSelect";
+
+const byId = (id: string) => document.querySelector<HTMLInputElement>("input#" + id);
+
+export default function createShareDialog(callback: () => void) {
+    e.stopPropagation();
+    const cont = createDiv(["dialog_content"]);
+    cont.style.width = "500px";
+
+    cont.append(createDiv(["share_title"], "Link for sharing:"));
+    const icd = createDiv(["share_input_container"]);
+    const linkInput = createInput([], "", {
+    id: "share_input",
+    autocomplete: "off"
+    });
+    linkInput.addEventListener("click", () => linkInput.select());
+    icd.appendChild(linkInput);
+    const but = createDiv(["button_simple"], "Copy");
+    but.addEventListener("click", function() {
+    ipcSend("set_clipboard", byId("share_input")!.value);
+    });
+    icd.appendChild(but);
+    cont.appendChild(icd);
+
+    cont.appendChild(createDiv(["share_subtitle"], "<i>Expires in: </i>"));
+    createSelect(
+    cont,
+    ["One day", "One week", "One month", "Never"],
+    "",
+    callback,
+    "expire_select"
+    );
+
+    openDialog(cont);
+    callback();
+}

--- a/src/window_main/deck-details.js
+++ b/src/window_main/deck-details.js
@@ -3,11 +3,7 @@ import _ from "lodash";
 import { MANA, CARD_RARITIES, EASING_DEFAULT } from "../shared/constants";
 import db from "../shared/database";
 import pd from "../shared/player-data";
-import {
-  createDiv,
-  createSpan,
-  queryElements as $$
-} from "../shared/dom-fns";
+import { createDiv, createSpan, queryElements as $$ } from "../shared/dom-fns";
 import * as deckDrawer from "../shared/deck-drawer";
 import {
   deckManaCurve,
@@ -30,7 +26,7 @@ import {
   showLoadingBars,
   pop
 } from "./renderer-util";
-import createShareDialog from "./createShareDialog";
+import createShareButton from "./createShareButton";
 
 const byId = id => document.getElementById(id);
 // We need to store a sorted list of card types so we create the card counts in the same order.
@@ -289,11 +285,10 @@ export function openDeck(deck = currentOpenDeck, filters = currentFilters) {
   top.appendChild(createDiv(["deck_name"], deck.name));
 
   if (!pd.offline) {
-    const deckShareButton = createDiv(["list_log_share", deck.id + "al"]);
-    deckShareButton.addEventListener("click", e => {
-      e.stopPropagation();
-      createShareDialog(() => deckShareLink(deck));
-    });
+    const deckShareButton = createShareButton(
+      ["list_log_share", deck.id + "al"],
+      () => deckShareLink(deck)
+    );
     top.appendChild(deckShareButton);
   } else {
     const deckCantShare = createDiv(["list_log_cant_share"]);

--- a/src/window_main/deck-details.js
+++ b/src/window_main/deck-details.js
@@ -3,11 +3,9 @@ import _ from "lodash";
 import { MANA, CARD_RARITIES, EASING_DEFAULT } from "../shared/constants";
 import db from "../shared/database";
 import pd from "../shared/player-data";
-import { createSelect } from "../shared/createSelect";
 import {
   createDiv,
   createSpan,
-  createInput,
   queryElements as $$
 } from "../shared/dom-fns";
 import * as deckDrawer from "../shared/deck-drawer";
@@ -27,12 +25,12 @@ import {
   colorPieChart,
   drawDeck,
   drawDeckVisual,
-  openDialog,
   ipcSend,
   makeResizable,
   showLoadingBars,
   pop
 } from "./renderer-util";
+import createShareDialog from "./createShareDialog";
 
 const byId = id => document.getElementById(id);
 // We need to store a sorted list of card types so we create the card counts in the same order.
@@ -294,35 +292,7 @@ export function openDeck(deck = currentOpenDeck, filters = currentFilters) {
     const deckShareButton = createDiv(["list_log_share", deck.id + "al"]);
     deckShareButton.addEventListener("click", e => {
       e.stopPropagation();
-      const cont = createDiv(["dialog_content"]);
-      cont.style.width = "500px";
-
-      cont.append(createDiv(["share_title"], "Link for sharing:"));
-      const icd = createDiv(["share_input_container"]);
-      const linkInput = createInput([], "", {
-        id: "share_input",
-        autocomplete: "off"
-      });
-      linkInput.addEventListener("click", () => linkInput.select());
-      icd.appendChild(linkInput);
-      const but = createDiv(["button_simple"], "Copy");
-      but.addEventListener("click", function() {
-        ipcSend("set_clipboard", byId("share_input").value);
-      });
-      icd.appendChild(but);
-      cont.appendChild(icd);
-
-      cont.appendChild(createDiv(["share_subtitle"], "<i>Expires in: </i>"));
-      createSelect(
-        cont,
-        ["One day", "One week", "One month", "Never"],
-        "",
-        () => deckShareLink(deck),
-        "expire_select"
-      );
-
-      openDialog(cont);
-      deckShareLink(deck);
+      createShareDialog(() => deckShareLink(deck));
     });
     top.appendChild(deckShareButton);
   } else {

--- a/src/window_main/match-details.js
+++ b/src/window_main/match-details.js
@@ -29,7 +29,7 @@ import {
   showLoadingBars,
   toggleVisibility
 } from "./renderer-util";
-import createShareDialog from "./createShareDialog";
+import createShareButton from "./createShareButton";
 
 const byId = id => document.getElementById(id);
 
@@ -81,14 +81,10 @@ function openMatch(id) {
     flc.appendChild(actionLogButton);
 
     if (!pd.offline) {
-      const actionLogShareButton = createDiv([
-        "list_log_share",
-        match.id + "al"
-      ]);
-      actionLogShareButton.addEventListener("click", e => {
-        e.stopPropagation();
-        createShareDialog(() => logShareLink(match.id));
-      });
+      const actionLogShareButton = createShareButton(
+        ["list_log_share", match.id + "al"],
+        () => logShareLink(match.id)
+      );
       flc.appendChild(actionLogShareButton);
     } else {
       const actionLogCantShare = createDiv(["list_log_cant_share"]);

--- a/src/window_main/match-details.js
+++ b/src/window_main/match-details.js
@@ -6,8 +6,7 @@ import _ from "lodash";
 import { MANA, EASING_DEFAULT } from "../shared/constants";
 import db from "../shared/database";
 import pd from "../shared/player-data";
-import { createSelect } from "../shared/createSelect";
-import { createDiv, createInput, queryElements as $$ } from "../shared/dom-fns";
+import { createDiv, queryElements as $$ } from "../shared/dom-fns";
 import * as deckDrawer from "../shared/deck-drawer";
 import {
   get_deck_export,
@@ -26,11 +25,11 @@ import {
   drawCardList,
   drawDeck,
   ipcSend,
-  openDialog,
   openActionLog,
   showLoadingBars,
   toggleVisibility
 } from "./renderer-util";
+import createShareDialog from "./createShareDialog";
 
 const byId = id => document.getElementById(id);
 
@@ -88,35 +87,7 @@ function openMatch(id) {
       ]);
       actionLogShareButton.addEventListener("click", e => {
         e.stopPropagation();
-        const cont = createDiv(["dialog_content"]);
-        cont.style.width = "500px";
-
-        cont.append(createDiv(["share_title"], "Link for sharing:"));
-        const icd = createDiv(["share_input_container"]);
-        const linkInput = createInput([], "", {
-          id: "share_input",
-          autocomplete: "off"
-        });
-        linkInput.addEventListener("click", () => linkInput.select());
-        icd.appendChild(linkInput);
-        const but = createDiv(["button_simple"], "Copy");
-        but.addEventListener("click", function() {
-          ipcSend("set_clipboard", byId("share_input").value);
-        });
-        icd.appendChild(but);
-        cont.appendChild(icd);
-
-        cont.appendChild(createDiv(["share_subtitle"], "<i>Expires in: </i>"));
-        createSelect(
-          cont,
-          ["One day", "One week", "One month", "Never"],
-          "",
-          () => logShareLink(match.id),
-          "expire_select"
-        );
-
-        openDialog(cont);
-        logShareLink(match.id);
+        createShareDialog(() => logShareLink(match.id));
       });
       flc.appendChild(actionLogShareButton);
     } else {

--- a/src/window_main/renderer-util.js
+++ b/src/window_main/renderer-util.js
@@ -26,7 +26,6 @@ import {
   createSpan,
   queryElements as $$
 } from "../shared/dom-fns";
-import { createSelect } from "../shared/createSelect";
 import * as deckDrawer from "../shared/deck-drawer";
 import { cardType } from "../shared/card-types";
 import { addCardHover } from "../shared/card-hover";
@@ -41,6 +40,7 @@ import {
   toMMSS,
   openScryfallCard
 } from "../shared/util";
+import createShareDialog from './createShareDialog';
 
 const DEFAULT_BACKGROUND = "../images/Bedevil-Art.jpg";
 
@@ -667,7 +667,11 @@ function showColorpicker(
   pickerWrapper.style.boxShadow = "none";
 }
 
-function showDatepicker(defaultDate, onChange = () => {}, pickerOptions = {}) {
+function showDatepicker(
+  defaultDate,
+  onChange = date => {},
+  pickerOptions = {}
+) {
   const cont = createDiv(["dialog_content"]);
   cont.style.width = "320px";
   cont.style.heigh = "400px";
@@ -974,35 +978,7 @@ function createReplayShareButton(draft) {
   const replayShareButton = createDiv(["list_draft_share", draft.id + "dr"]);
   replayShareButton.addEventListener("click", e => {
     e.stopPropagation();
-    const cont = createDiv(["dialog_content"]);
-    cont.style.width = "500px";
-
-    cont.append(createDiv(["share_title"], "Link for sharing:"));
-    const icd = createDiv(["share_input_container"]);
-    const linkInput = createInput([], "", {
-      id: "share_input",
-      autocomplete: "off"
-    });
-    linkInput.addEventListener("click", () => linkInput.select());
-    icd.appendChild(linkInput);
-    const but = createDiv(["button_simple"], "Copy");
-    but.addEventListener("click", function() {
-      ipcSend("set_clipboard", byId("share_input").value);
-    });
-    icd.appendChild(but);
-    cont.appendChild(icd);
-
-    cont.appendChild(createDiv(["share_subtitle"], "<i>Expires in: </i>"));
-    createSelect(
-      cont,
-      ["One day", "One week", "One month", "Never"],
-      "",
-      () => draftShareLink(draft.id, draft),
-      "expire_select"
-    );
-
-    openDialog(cont);
-    draftShareLink(draft.id, draft);
+    createShareDialog(() => draftShareLink(draft.id, draft));
   });
   return replayShareButton;
 }

--- a/src/window_main/renderer-util.js
+++ b/src/window_main/renderer-util.js
@@ -40,7 +40,7 @@ import {
   toMMSS,
   openScryfallCard
 } from "../shared/util";
-import createShareDialog from './createShareDialog';
+import createShareButton from "./createShareButton";
 
 const DEFAULT_BACKGROUND = "../images/Bedevil-Art.jpg";
 
@@ -975,11 +975,10 @@ function createReplayDiv(draft) {
 }
 
 function createReplayShareButton(draft) {
-  const replayShareButton = createDiv(["list_draft_share", draft.id + "dr"]);
-  replayShareButton.addEventListener("click", e => {
-    e.stopPropagation();
-    createShareDialog(() => draftShareLink(draft.id, draft));
-  });
+  const replayShareButton = createShareButton(
+    ["list_draft_share", draft.id + "dr"],
+    () => draftShareLink(draft.id, draft)
+  );
   return replayShareButton;
 }
 


### PR DESCRIPTION
We have 3 usages of the share dialog right now, and all 3 look about the same. Literally, the only thing that's different is the callback when clicked. So, abstract it out and we're good to go.

Eventually, once the consumers are more "react aware" we can change it so that this is a component that renders a button, but this is the most expedient right now.