### PR TITLE
size overlay based on the display it's on

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -421,19 +421,18 @@ function updateOverlayVisibility() {
     // display entire overlay window
     clearTimeout(overlayHideTimeout);
     overlayHideTimeout = undefined;
-    overlay.show();
 
-    let displayId = settings.overlay_display
-      ? settings.overlay_display
-      : electron.screen.getPrimaryDisplay().id;
-    let display = electron.screen
-      .getAllDisplays()
-      .filter(d => d.id == displayId)[0];
-    if (display) {
-      overlay.setBounds(display.bounds);
-    } else {
-      overlay.setBounds(electron.screen.getPrimaryDisplay().bounds);
-    }
+    const {
+      bounds,
+      size: { width, height }
+    } =
+      electron.screen
+        .getAllDisplays()
+        .find(d => d.id === settings.overlay_display) ||
+      electron.screen.getPrimaryDisplay();
+    overlay.setBounds(bounds);
+    overlay.setSize(width, height);
+    overlay.show();
   }
 }
 


### PR DESCRIPTION
Overlays are always sized to fit the primary display, which doesn't make sense if the overlay's on a different display.

This fixes that, and delays showing overlays until *after* they're resized.