### PR TITLE
Simplify if clauses

### DIFF
--- a/src/window_background/arena-log-watcher.js
+++ b/src/window_background/arena-log-watcher.js
@@ -190,13 +190,8 @@ function onLogEntryFound(entry) {
     return;
   } else {
     //console.log("Entry:", entry.label, entry, entry.json());
-    if (globals.firstPass) {
-      updateLoading(entry);
-    }
-    if (
-      (globals.firstPass && !playerData.settings.skip_firstpass) ||
-      !globals.firstPass
-    ) {
+    updateLoading(entry);
+    if (!(globals.firstPass && playerData.settings.skip_firstpass)) {
       try {
         entrySwitch(entry, json);
         if (entry.timestamp) {


### PR DESCRIPTION
Just a small non-functional fix to improve readability.

- `updateLoading` checks for `globals.firstPass`, no need to check an additional time beforehand.
- The if-clause can be rearranged:
<pre>
!globals.firstPass || (globals.firstPass && !playerData.settings.skip_firstpass)
</pre>
Either the first part evaluates to `true`, then the second part is not evaluated at all, or the second part is evaluated because `!globals.firstPass` evaluated to `false`, then `globals.firstPass` must evaluate to `true`:
<pre>
!globals.firstPass || (true && !playerData.settings.skip_firstpass)
</pre>
Now the `true &&` part can be removed, yielding
<pre>!globals.firstPass || !playerData.settings.skip_firstpass</pre>
Move things a bit around and you get:
<pre>!(globals.firstPass && playerData.settings.skip_firstpass)</pre>