### PR TITLE
Bugfix Decks Page Date Sort

### DIFF
--- a/src/window_main/aggregator.js
+++ b/src/window_main/aggregator.js
@@ -436,9 +436,9 @@ class Aggregator {
     if (aValid && bValid && !isEqual(aDate, bDate)) {
       return compareDesc(aDate, bDate);
     } else if (aValid) {
-      return 1;
-    } else if (bValid) {
       return -1;
+    } else if (bValid) {
+      return 1;
     }
 
     const aName = getRecentDeckName(a.id);
@@ -515,9 +515,9 @@ class Aggregator {
     if (aValid && bValid && !isEqual(aDate, bDate)) {
       return compareDesc(aDate, bDate);
     } else if (aValid) {
-      return 1;
-    } else if (bValid) {
       return -1;
+    } else if (bValid) {
+      return 1;
     }
 
     const aName = getReadableEvent(a);

--- a/src/window_main/aggregator.js
+++ b/src/window_main/aggregator.js
@@ -40,7 +40,7 @@ const ALL_EVENT_TRACKS = "All Event Tracks";
 // Archetype constants
 const NO_ARCH = "No Archetype";
 
-const dateMaxValid = (a, b) => {
+export const dateMaxValid = (a, b) => {
   const aValid = isValid(a);
   const bValid = isValid(b);
   return (
@@ -431,11 +431,16 @@ class Aggregator {
       this.deckLastPlayed[b.id],
       new Date(b.lastUpdated)
     );
-    const aValid = isValid(a);
-    const bValid = isValid(b);
+    const aValid = isValid(aDate);
+    const bValid = isValid(bDate);
     if (aValid && bValid && !isEqual(aDate, bDate)) {
       return compareDesc(aDate, bDate);
+    } else if (aValid) {
+      return 1;
+    } else if (bValid) {
+      return -1;
     }
+
     const aName = getRecentDeckName(a.id);
     const bName = getRecentDeckName(b.id);
     return aName.localeCompare(bName);
@@ -505,11 +510,16 @@ class Aggregator {
   compareEvents(a, b) {
     const aDate = this.eventLastPlayed[a];
     const bDate = this.eventLastPlayed[b];
-    const aValid = isValid(a);
-    const bValid = isValid(b);
+    const aValid = isValid(aDate);
+    const bValid = isValid(bDate);
     if (aValid && bValid && !isEqual(aDate, bDate)) {
       return compareDesc(aDate, bDate);
+    } else if (aValid) {
+      return 1;
+    } else if (bValid) {
+      return -1;
     }
+
     const aName = getReadableEvent(a);
     const bName = getReadableEvent(b);
     return aName.localeCompare(bName);

--- a/src/window_main/decks.js
+++ b/src/window_main/decks.js
@@ -9,7 +9,7 @@ import {
   getBoosterCountEstimate,
   getReadableFormat
 } from "../shared/util";
-import Aggregator from "./aggregator";
+import Aggregator, { dateMaxValid } from "./aggregator";
 import FilterPanel from "./filter-panel";
 import ListItem from "./list-item";
 import StatsPanel from "./stats-panel";
@@ -21,6 +21,7 @@ import {
   getWinrateClass,
   hideLoadingBars,
   ipcSend,
+  localTimeSince,
   makeResizable,
   resetMainContainer,
   setLocalState,
@@ -143,20 +144,21 @@ export function openDecksTab(_filters = {}, scrollTop = 0) {
         openDeckCallback(id, filters)
       );
     }
-    listItem.center.classList.add("deck_tags_container");
     listItem.divideLeft();
+    listItem.divideCenter();
     listItem.divideRight();
 
-    createTag(listItem.center, deck.id, null, false);
+    listItem.centerTop.classList.add("deck_tags_container");
+    createTag(listItem.centerTop, deck.id, null, false);
     if (deck.format) {
       const fText = getReadableFormat(deck.format);
-      const t = createTag(listItem.center, deck.id, fText, false);
+      const t = createTag(listItem.centerTop, deck.id, fText, false);
       t.style.fontStyle = "italic";
     }
     if (deck.tags) {
       deck.tags.forEach(tag => {
         if (tag !== getReadableFormat(deck.format)) {
-          createTag(listItem.center, deck.id, tag);
+          createTag(listItem.centerTop, deck.id, tag);
         }
       });
     }
@@ -205,6 +207,18 @@ export function openDecksTab(_filters = {}, scrollTop = 0) {
       const m = createDiv(["mana_s20", "mana_" + MANA[color]]);
       listItem.leftBottom.appendChild(m);
     });
+
+    const lastUpdated = new Date(deck.lastUpdated);
+    const lastPlayed = new Date(aggregator.deckLastPlayed[deck.id]);
+    const lastTouch = dateMaxValid(lastUpdated, lastPlayed);
+    const deckLastTouchedDiv = createDiv(
+      ["list_deck_winrate"],
+      `<i style="opacity:0.6">updated/played:</i> ${localTimeSince(lastTouch)}`
+    );
+    deckLastTouchedDiv.style.marginLeft = "18px";
+    deckLastTouchedDiv.style.marginRight = "auto";
+    deckLastTouchedDiv.style.lineHeight = "18px";
+    listItem.centerBottom.appendChild(deckLastTouchedDiv);
 
     const dwr = aggregator.deckStats[deck.id];
     if (dwr && dwr.total > 0) {


### PR DESCRIPTION
### Motivation
Our `aggregator` code does not correctly handle sorting and filtering of invalid dates. This had particularly negative effects on the Decks page with the "All Time" filter in particular.

https://discordapp.com/channels/463844727654187020/506793351786266624/640002609033248789
![image](https://user-images.githubusercontent.com/14894693/68066634-70702f00-fcf8-11e9-860e-2a3dbabbc944.png)

Special thanks to @ZerOwl#7430 as well for helping us identify this and making sure we got it fixed.

### Demo
![image](https://user-images.githubusercontent.com/14894693/68066619-2ab36680-fcf8-11e9-9a61-ee6d76d55cfd.png)
