### PR TITLE
Almost-React Overlay

### DIFF
--- a/src/overlay/ActionLog.jsx
+++ b/src/overlay/ActionLog.jsx
@@ -1,0 +1,68 @@
+import React, { useEffect } from "react";
+import format from "date-fns/format";
+
+import db from "../shared/database";
+import { queryElements } from "../shared/dom-fns";
+import { addCardHover } from "../shared/card-hover";
+
+export default function ActionLog(_props) {
+  const { actionLog, index } = _props;
+  const initalTime = actionLog[0] ? new Date(actionLog[0].time) : new Date();
+
+  useEffect(() => {
+    const container = queryElements(
+      `#overlay_${index + 1} .overlay_decklist`
+    )[0];
+
+    const doscroll =
+      Math.round(
+        container.scrollHeight - container.offsetHeight - container.scrollTop
+      ) < 32;
+    if (doscroll) {
+      container.scrollTop = container.scrollHeight;
+    }
+
+    queryElements("log-card").forEach(obj => {
+      const grpId = obj.getAttribute("id");
+      addCardHover(obj, db.card(grpId));
+    });
+    queryElements("log-ability").forEach(obj => {
+      const grpId = obj.getAttribute("id");
+      const abilityText = db.abilities[grpId] || "";
+      obj.title = abilityText;
+    });
+  });
+
+  return (
+    <div key="overlay_decklist" className="overlay_decklist click-on">
+      {actionLog &&
+        actionLog.map((log, index) => {
+          const displayLog = { ...log };
+          displayLog.str = log.str.replace(
+            "<log-card",
+            '<log-card class="click-on"',
+            "gi"
+          );
+          displayLog.str = log.str.replace(
+            "<log-ability",
+            '<log-ability class="click-on"',
+            "gi"
+          );
+          const _date = new Date(log.time);
+          const secondsPast = Math.round((_date - initalTime) / 1000);
+
+          return (
+            <div className={"actionlog log_p" + log.seat} key={"log_" + index}>
+              <div className="actionlog_time" title={format(_date, "HH:mm:ss")}>
+                {secondsPast + "s"}
+              </div>
+              <div
+                className="actionlog_text"
+                dangerouslySetInnerHTML={{ __html: log.str }}
+              />
+            </div>
+          );
+        })}
+    </div>
+  );
+}

--- a/src/overlay/DeckList.tsx
+++ b/src/overlay/DeckList.tsx
@@ -1,0 +1,257 @@
+import React from "react";
+
+import {
+  DRAFT_RANKS,
+  OVERLAY_FULL,
+  OVERLAY_LEFT,
+  OVERLAY_ODDS,
+  OVERLAY_MIXED,
+  OVERLAY_DRAFT
+} from "../shared/constants";
+import db from "../shared/database";
+import {
+  compare_cards as compareCards,
+  get_card_type_sort as getCardTypeSort
+} from "../shared/util";
+import CardTile from "../shared/CardTile";
+import Colors from "../shared/colors";
+import DeckManaCurve from "../shared/DeckManaCurve";
+import DeckTypesStats from "../shared/DeckTypesStats";
+import OwnershipStars from "../shared/OwnershipStars";
+
+import SampleSizePanel from "./SampleSizePanel";
+
+const landsCard = {
+  id: 100,
+  name: "Lands",
+  set: "",
+  artid: 0,
+  type: "Special",
+  cost: [],
+  cmc: 0,
+  rarity: "",
+  cid: 0,
+  frame: [1, 2, 3, 4, 5],
+  artist: "",
+  dfc: "None",
+  collectible: false,
+  craftable: false,
+  images: {
+    art_crop: "../images/type_land.png"
+  },
+  dfcId: 0
+};
+
+function getRank(cardId: string) {
+  const cardObj = db.card(cardId);
+  return (cardObj && cardObj.rank) || 0;
+}
+
+function compareQuantity(a: any, b: any) {
+  return b.quantity - a.quantity;
+}
+
+function compareDraftPicks(a: any, b: any) {
+  const aCard = db.card(a.id);
+  const bCard = db.card(b.id);
+  if (!bCard) {
+    return -1;
+  } else if (!aCard) {
+    return 1;
+  }
+  const aColors = new Colors();
+  if (aCard.cost) {
+    aColors.addFromCost(aCard.cost);
+  }
+  const bColors = new Colors();
+  if (bCard.cost) {
+    bColors.addFromCost(bCard.cost);
+  }
+  const aType = getCardTypeSort(aCard.type);
+  const bType = getCardTypeSort(bCard.type);
+  return (
+    bCard.rank - aCard.rank ||
+    aColors.length - bColors.length ||
+    aCard.cmc - bCard.cmc ||
+    aType - bType ||
+    aCard.name.localeCompare(bCard.name)
+  );
+}
+
+export interface DeckListProps {
+  deck: any;
+  subTitle: string;
+  highlightCardId: string;
+  settings: any;
+  tileStyle: number;
+  cardOdds: any;
+  setOddsCallback: (sampleSize: number) => void;
+}
+
+export default function DeckList(props: DeckListProps): JSX.Element {
+  const { deck, subTitle, settings, tileStyle, highlightCardId, cardOdds, setOddsCallback } = props;
+  if (!deck) return <></>;
+
+  const deckClone = deck.clone();
+
+  let sortFunc: (a: any, b: any) => number = compareCards;
+  if (settings.mode === OVERLAY_ODDS || settings.mode == OVERLAY_MIXED) {
+    sortFunc = compareQuantity;
+  } else if (settings.mode === OVERLAY_DRAFT) {
+    sortFunc = compareDraftPicks;
+  }
+
+  const mainCardTiles: JSX.Element[] = [];
+  const mainCards = deckClone.mainboard;
+  mainCards.removeDuplicates();
+  // group lands
+  if (
+    settings.lands &&
+    [OVERLAY_FULL, OVERLAY_LEFT, OVERLAY_ODDS, OVERLAY_MIXED].includes(
+      settings.mode
+    )
+  ) {
+    let landsNumber = 0;
+    let landsChance = 0;
+    const landsColors = new Colors();
+    mainCards.get().forEach((card: any) => {
+      const cardObj = db.card(card.id);
+      if (cardObj && cardObj.type.includes("Land", 0)) {
+        landsNumber += card.quantity;
+        landsChance += card.chance !== undefined ? card.chance : 0;
+        delete card.chance;
+        card.quantity = 0;
+        if (cardObj.frame) {
+          landsColors.addFromArray(cardObj.frame);
+        }
+      }
+    });
+    const lands = mainCards.add(landsCard, landsNumber, true);
+    if (landsChance > 0) {
+      lands.chance = landsChance;
+    }
+
+    // Set lands frame colors
+    landsCard.frame = landsColors.get();
+  }
+  mainCards.get().sort(sortFunc);
+  mainCards.get().forEach((card: any) => {
+    let quantity = card.quantity;
+    if (settings.mode === OVERLAY_MIXED) {
+      const odds = (card.chance !== undefined ? card.chance : "0") + "%";
+      const q = card.quantity;
+      if (!settings.lands || (settings.lands && odds !== "0%")) {
+        quantity = {
+          quantity: q,
+          odds: odds
+        };
+      }
+    } else if (settings.mode === OVERLAY_ODDS) {
+      quantity = ((card.chance || 0) / 100).toLocaleString([], {
+        style: "percent",
+        maximumSignificantDigits: 2
+      });
+    } else if (settings.mode === OVERLAY_DRAFT) {
+      const rank = getRank(card.id);
+      quantity = DRAFT_RANKS[rank];
+    }
+
+    // This is hackish.. the way we insert our custom elements in the
+    // array of cards is wrong in the first place :()
+    const isCardGroupedLands =
+      card && card.id && card.id.id && card.id.id === 100;
+
+    let fullCard = card;
+    if (card && card.id && !isCardGroupedLands) {
+      fullCard = db.card(card.id);
+    }
+    let dfcCard = null;
+    if (card && card.dfcId) {
+      dfcCard = db.card(card.dfcId);
+    }
+    if (settings.mode === OVERLAY_DRAFT) {
+      mainCardTiles.push(
+        <div
+          className="overlay_card_quantity"
+          key={"maincardtile_owned_" + card.id}
+        >
+          <OwnershipStars card={fullCard} />
+        </div>
+      );
+    }
+    mainCardTiles.push(
+      <CardTile
+        style={tileStyle}
+        card={fullCard}
+        dfcCard={dfcCard}
+        landOdds={cardOdds}
+        key={"maincardtile_" + card.id}
+        indent="a"
+        isSideboard={false}
+        quantity={quantity}
+        showWildcards={false}
+        deck={deck}
+        isHighlighted={card.id === highlightCardId}
+      />
+    );
+  });
+
+  const sideboardCardTiles: JSX.Element[] = [];
+  if (settings.sideboard && deckClone.sideboard.count() > 0) {
+    const sideCards = deckClone.sideboard;
+    sideCards.removeDuplicates();
+    sideCards.get().sort(sortFunc);
+    sideCards.get().forEach((card: any) => {
+      const quantity =
+        settings.mode === OVERLAY_ODDS || settings.mode === OVERLAY_MIXED
+          ? "0%"
+          : card.quantity;
+      let fullCard = card;
+      if (card && card.id) {
+        fullCard = db.card(card.id);
+      }
+      let dfcCard;
+      if (card && card.dfcId) {
+        dfcCard = db.card(card.dfcId);
+      }
+      sideboardCardTiles.push(
+        <CardTile
+          style={tileStyle}
+          card={fullCard}
+          dfcCard={dfcCard}
+          landOdds={cardOdds}
+          key={"sideboardcardtile_" + card.id}
+          indent="a"
+          isSideboard={true}
+          quantity={quantity}
+          showWildcards={false}
+          deck={deck}
+          isHighlighted={false}
+        />
+      );
+    });
+  }
+
+  const arenaDeck = deck.getSave();
+
+  return (
+    <div className="overlay_decklist click-on">
+      <div className="decklist_title">{subTitle}</div>
+      {mainCardTiles}
+      {settings.sideboard && sideboardCardTiles.length && (
+        <div className="card_tile_separator">Sideboard</div>
+      )}
+      {settings.sideboard && sideboardCardTiles}
+      {settings.type_counts && <DeckTypesStats deck={arenaDeck} />}
+      {settings.mana_curve && <DeckManaCurve deck={arenaDeck} />}
+      {settings.draw_odds &&
+        (settings.mode === OVERLAY_ODDS || settings.mode === OVERLAY_MIXED) && (
+          <SampleSizePanel
+            cardOdds={cardOdds}
+            cardsLeft={deck.mainboard.count()}
+            setOddsCallback={setOddsCallback}
+          />
+        )}
+    </div>
+  );
+}

--- a/src/overlay/Overlay.tsx
+++ b/src/overlay/Overlay.tsx
@@ -1,0 +1,228 @@
+import React, { useCallback, useState } from "react";
+
+import {
+  MANA,
+  PACK_SIZES,
+  OVERLAY_FULL,
+  OVERLAY_LEFT,
+  OVERLAY_ODDS,
+  OVERLAY_MIXED,
+  OVERLAY_SEEN,
+  OVERLAY_DRAFT,
+  OVERLAY_LOG,
+  OVERLAY_DRAFT_BREW,
+  OVERLAY_DRAFT_MODES
+} from "../shared/constants";
+import Deck from "../shared/deck";
+
+import Clock from "./Clock";
+import ActionLog from "./ActionLog";
+import DeckList from "./DeckList";
+
+const packSizeMap: { [key: string]: number } = PACK_SIZES;
+const manaColorMap: { [key: number]: string } = MANA;
+
+export interface OverlayProps {
+  actionLog: any;
+  draft: any;
+  draftState: { packN: number; pickN: number };
+  index: number;
+  match: any;
+  playerSeat: number;
+  settings: any;
+  tileStyle: number;
+  turnPriority: number;
+  setOddsCallback: (sampleSize: number) => void;
+  setDraftStateCallback: (state: { packN: number; pickN: number }) => void;
+}
+
+export default function Overlay(props: OverlayProps): JSX.Element {
+  const {
+    actionLog,
+    draft,
+    draftState,
+    index,
+    match,
+    playerSeat,
+    settings,
+    tileStyle,
+    turnPriority,
+    setOddsCallback,
+    setDraftStateCallback
+  } = props;
+
+  let visibleDeck = null;
+  let cardsCount = 0;
+  let mainTitle = "Overlay " + (index + 1);
+  let subTitle = "";
+
+  if (settings.mode === OVERLAY_LOG) {
+    mainTitle = "Action Log";
+    // TODO add subtitle with current turn number
+  }
+
+  const packSize = (draft && packSizeMap[draft.set]) || 14;
+
+  const handleDraftPrev = useCallback((): void => {
+    let { packN, pickN } = draftState;
+    pickN -= 1;
+    if (pickN < 0) {
+      pickN = packSize;
+      packN -= 1;
+    }
+    if (packN < 0) {
+      pickN = draft.pickNumber;
+      packN = draft.packNumber;
+    }
+    setDraftStateCallback({ packN, pickN });
+  }, [draftState, draft]);
+
+  const handleDraftNext = useCallback((): void => {
+    let { packN, pickN } = draftState;
+    pickN += 1;
+    if (pickN > packSize) {
+      pickN = 0;
+      packN += 1;
+    }
+    if (pickN > draft.pickNumber && packN == draft.packNumber) {
+      pickN = 0;
+      packN = 0;
+    }
+    if (
+      packN > draft.packNumber ||
+      (pickN == draft.pickNumber && packN == draft.packNumber)
+    ) {
+      packN = draft.packNumber;
+      pickN = draft.pickNumber;
+    }
+    setDraftStateCallback({ packN, pickN });
+  }, [draftState, draft]);
+
+  const { packN, pickN } = draftState;
+  let pack = [];
+  let pick = "";
+  let isCurrent = false;
+  let pickName = "";
+  if (draft) {
+    isCurrent = packN === draft.packNumber && pickN === draft.pickNumber;
+    pickName = "Pack " + (packN + 1) + " - Pick " + (pickN + 1);
+    if (isCurrent) {
+      pickName += " - Current";
+    }
+    const key = "pack_" + packN + "pick_" + pickN;
+    if (key in draft) {
+      pack = draft[key].pack;
+      pick = draft[key].pick;
+    } else if (isCurrent) {
+      pack = draft.currentPack;
+      pick = "";
+    }
+
+    if (settings.mode === OVERLAY_DRAFT) {
+      visibleDeck = new Deck({ name: pickName }, pack);
+      cardsCount = visibleDeck.mainboard.count();
+      mainTitle = visibleDeck.name;
+      subTitle = "Cards Left: " + cardsCount + " cards";
+    } else if (settings.mode === OVERLAY_DRAFT_BREW) {
+      visibleDeck = new Deck({ name: "All Picks" }, draft.pickedCards);
+      cardsCount = visibleDeck.mainboard.count();
+      mainTitle = visibleDeck.name;
+      subTitle = "Total Picks: " + cardsCount + " cards";
+    }
+  }
+
+  let cleanName = match && match.opponent && match.opponent.name;
+  if (cleanName && cleanName !== "Sparky") {
+    cleanName = cleanName.slice(0, -6);
+  }
+  const oppName = cleanName || "Opponent";
+  let sampleSize = 1;
+  if (match) {
+    const cardOdds = match.playerCardsOdds;
+    sampleSize = cardOdds.sampleSize || 1;
+    switch (settings.mode) {
+      case OVERLAY_FULL:
+        visibleDeck = match.player.deck;
+        cardsCount = visibleDeck.mainboard.count();
+        mainTitle = visibleDeck.name;
+        subTitle = "Full Deck: " + cardsCount + " cards";
+        break;
+      case OVERLAY_LEFT:
+        visibleDeck = match.playerCardsLeft;
+        cardsCount = visibleDeck.mainboard.count();
+        mainTitle = visibleDeck.name;
+        subTitle = "Library: " + cardsCount + " cards";
+        break;
+      case OVERLAY_ODDS:
+      case OVERLAY_MIXED:
+        visibleDeck = match.playerCardsLeft;
+        cardsCount = visibleDeck.mainboard.count();
+        mainTitle = visibleDeck.name;
+        subTitle = `Next Draw: ${sampleSize}/${cardsCount} cards`;
+        break;
+      case OVERLAY_SEEN:
+        visibleDeck = match.oppCards;
+        cardsCount = visibleDeck.mainboard.count();
+        mainTitle = "Played by " + oppName;
+        subTitle = "Total Seen: " + cardsCount + " cards";
+        break;
+    }
+  }
+
+  return (
+    <>
+      {settings.title && (
+        <div className="overlay_deckname">
+          {mainTitle}
+          {settings.mode === OVERLAY_DRAFT && (
+            <div
+              className="overlay_draft_container"
+              style={settings.top && { top: "32px" }}
+            >
+              <div className="draft_prev click-on" onClick={handleDraftPrev} />
+              <div className="draft_title" />
+              <div className="draft_next click-on" onClick={handleDraftNext} />
+            </div>
+          )}
+        </div>
+      )}
+      {settings.mode === OVERLAY_SEEN && match && (
+        <div className="overlay_archetype">{match.oppArchetype}</div>
+      )}
+      {settings.title && visibleDeck && (
+        <div className="overlay_deckcolors">
+          {visibleDeck.colors.get().map((color: number) => (
+            <div
+              className={"mana_s20 mana_" + manaColorMap[color]}
+              key={color}
+            />
+          ))}
+        </div>
+      )}
+      {settings.mode === OVERLAY_LOG && (
+        <ActionLog actionLog={actionLog} index={index} />
+      )}
+      {settings.deck && visibleDeck && (
+        <DeckList
+          deck={visibleDeck}
+          subTitle={subTitle}
+          highlightCardId={pick}
+          settings={settings}
+          tileStyle={tileStyle}
+          cardOdds={match ? match.playerCardsOdds : {}}
+          setOddsCallback={setOddsCallback}
+        />
+      )}
+      {settings.clock && !OVERLAY_DRAFT_MODES.includes(settings.mode) && (
+        <Clock
+          key={"overlay_clock_" + index}
+          matchBeginTime={match ? new Date(match.beginTime) : new Date()}
+          oppName={match ? match.opponent.name : "Opponent"}
+          playerSeat={playerSeat}
+          priorityTimers={match ? match.priorityTimers : []}
+          turnPriority={turnPriority}
+        />
+      )}
+    </>
+  );
+}

--- a/src/overlay/SampleSizePanel.tsx
+++ b/src/overlay/SampleSizePanel.tsx
@@ -1,0 +1,70 @@
+import React, { useCallback, useState } from "react";
+
+import { CARD_TYPES } from "../shared/constants";
+
+export interface SampleSizePanelProps {
+  cardOdds: { [key: string]: number };
+  cardsLeft: number;
+  setOddsCallback: (option: number) => void;
+}
+
+export default function SampleSizePanel(
+  props: SampleSizePanelProps
+): JSX.Element {
+  // isLoading is a manual semaphore to only allow one background request in flight at a time
+  const [isLoading, setLoading] = useState(false);
+  const { cardOdds, cardsLeft, setOddsCallback } = props;
+  const sampleSize = cardOdds.sampleSize || 1;
+
+  const handleOddsPrev = useCallback((): void => {
+    if (isLoading) {
+      return; // currently waiting for background
+    }
+    let newSampleSize = sampleSize - 1;
+    if (newSampleSize < 1) {
+      newSampleSize = cardsLeft - 1;
+    }
+    setOddsCallback(newSampleSize);
+    setLoading(true);
+  }, [isLoading, sampleSize, cardsLeft]);
+
+  const handleOddsNext = useCallback((): void => {
+    if (isLoading) {
+      return; // currently waiting for background
+    }
+    const cardsLeft = cardOdds.cardsLeft || 60;
+    let newSampleSize = sampleSize + 1;
+    if (newSampleSize > cardsLeft - 1) {
+      newSampleSize = 1;
+    }
+    setOddsCallback(newSampleSize);
+    setLoading(true);
+  }, [isLoading, sampleSize, cardsLeft]);
+
+  return (
+    <>
+      <div className="overlay_samplesize_container">
+        <div className="odds_prev click-on" onClick={handleOddsPrev} />
+        <div className="odds_number">
+          Sample size: {isLoading ? "..." : sampleSize}
+        </div>
+        <div className="odds_next click-on" onClick={handleOddsNext} />
+      </div>
+      <div className="chance_title" />
+      {CARD_TYPES.map(type => {
+        const abbrev = type.slice(0, 3);
+        const field = "chance" + abbrev;
+        const value = cardOdds[field] ? cardOdds[field] / 100 : 0;
+        const display = value.toLocaleString([], {
+          style: "percent",
+          maximumSignificantDigits: 2
+        });
+        return (
+          <div className="chance_title" key={"chance_title_" + field}>
+            {type}: {isLoading ? "..." : display}
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/src/shared/DeckManaCurve.jsx
+++ b/src/shared/DeckManaCurve.jsx
@@ -1,0 +1,117 @@
+import * as React from "react";
+
+import { MANA_COLORS } from "./constants";
+import db from "./database";
+
+function add(a, b) {
+  return a + b;
+}
+
+function getDeckCurve(deck) {
+  const curve = [];
+  if (!deck.mainDeck) return curve;
+
+  deck.mainDeck.forEach(card => {
+    const cardObj = db.card(card.id);
+    if (!cardObj) return;
+
+    const cmc = cardObj.cmc;
+    if (!curve[cmc]) curve[cmc] = [0, 0, 0, 0, 0, 0];
+
+    if (!cardObj.type.includes("Land")) {
+      cardObj.cost.forEach(c => {
+        if (c.includes("w")) curve[cmc][1] += card.quantity;
+        if (c.includes("u")) curve[cmc][2] += card.quantity;
+        if (c.includes("b")) curve[cmc][3] += card.quantity;
+        if (c.includes("r")) curve[cmc][4] += card.quantity;
+        if (c.includes("g")) curve[cmc][5] += card.quantity;
+      });
+
+      curve[cmc][0] += card.quantity;
+    }
+  });
+  /*
+  // Do not account sideboard?
+  deck.sideboard.forEach(function(card) {
+    var grpid = card.id;
+    var cmc = db.card(grpid).cmc;
+    if (curve[cmc] == undefined)  curve[cmc] = 0;
+    curve[cmc] += card.quantity
+
+    if (db.card(grpid).rarity !== 'land') {
+      curve[cmc] += card.quantity
+    }
+  });
+  */
+  //console.log(curve);
+  return curve;
+}
+
+export default function DeckManaCurve(_props) {
+  const { deck } = _props;
+  const manaCounts = getDeckCurve(deck);
+  const curveMax = Math.max(
+    ...manaCounts
+      .filter(v => {
+        if (v == undefined) return false;
+        return true;
+      })
+      .map(v => v[0] || 0)
+  );
+  // console.log("deckManaCurve", manaCounts, curveMax);
+
+  return (
+    <div className="mana_curve_container">
+      <div className="mana_curve">
+        {manaCounts &&
+          manaCounts.map((cost, i) => {
+            const total = cost[0];
+            const manaTotal = cost.reduce(add, 0) - total;
+
+            return (
+              <div
+                className="mana_curve_column"
+                key={"mana_curve_column_" + i}
+                style={{ height: (total * 100) / curveMax + "%" }}
+              >
+                <div className="mana_curve_number">
+                  {total > 0 ? total : ""}
+                </div>
+                {MANA_COLORS.map((mc, ind) => {
+                  if (ind < 5 && cost[ind + 1] > 0) {
+                    return (
+                      <div
+                        className="mana_curve_column_color"
+                        key={"mana_curve_column_color_" + ind}
+                        style={{
+                          height:
+                            Math.round((cost[ind + 1] / manaTotal) * 100) + "%",
+                          backgroundColor: mc
+                        }}
+                      />
+                    );
+                  }
+                })}
+              </div>
+            );
+          })}
+      </div>
+      <div className="mana_curve_numbers">
+        {manaCounts &&
+          manaCounts.map((cost, i) => {
+            return (
+              <div
+                className="mana_curve_column_number"
+                key={"mana_curve_column_number_" + i}
+              >
+                <div
+                  className={"mana_s16 mana_" + i}
+                  style={{ margin: "auto" }}
+                />
+              </div>
+            );
+          })}
+      </div>
+    </div>
+  );
+}

--- a/src/shared/DeckTypesStats.jsx
+++ b/src/shared/DeckTypesStats.jsx
@@ -1,0 +1,50 @@
+import * as React from "react";
+
+import { CARD_TYPES, CARD_TYPE_CODES } from "./constants";
+import db from "./database";
+
+function getDeckTypesAmount(deck) {
+  const types = { art: 0, cre: 0, enc: 0, ins: 0, lan: 0, pla: 0, sor: 0 };
+  if (!deck.mainDeck) return types;
+
+  deck.mainDeck.forEach(function(card) {
+    // This is hackish.. the way we insert our custom elements in the
+    // array of cards is wrong in the first place :()
+    if (card.id.id && card.id.id == 100) {
+      types.lan += card.quantity;
+      return;
+    }
+    const c = db.card(card.id);
+    if (c) {
+      if (c.type.includes("Land", 0)) types.lan += card.quantity;
+      else if (c.type.includes("Creature", 0)) types.cre += card.quantity;
+      else if (c.type.includes("Artifact", 0)) types.art += card.quantity;
+      else if (c.type.includes("Enchantment", 0)) types.enc += card.quantity;
+      else if (c.type.includes("Instant", 0)) types.ins += card.quantity;
+      else if (c.type.includes("Sorcery", 0)) types.sor += card.quantity;
+      else if (c.type.includes("Planeswalker", 0)) types.pla += card.quantity;
+    }
+  });
+
+  return types;
+}
+
+export default function DeckTypesStats(_props) {
+  const { deck } = _props;
+  const cardTypes = getDeckTypesAmount(deck);
+  return (
+    <div className="types_container">
+      {CARD_TYPE_CODES.map((cardTypeKey, index) => {
+        return (
+          <div className="type_icon_cont" key={"type_icon_cont_" + index}>
+            <div
+              className={"type_icon type_" + cardTypeKey}
+              title={CARD_TYPES[index]}
+            />
+            <span>{cardTypes[cardTypeKey]}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -656,21 +656,22 @@ export const ARENA_MODE_IDLE = 0;
 export const ARENA_MODE_MATCH = 1;
 export const ARENA_MODE_DRAFT = 2;
 
-const DRAFT_RANKS = [];
-DRAFT_RANKS[12] = "A+";
-DRAFT_RANKS[11] = "A";
-DRAFT_RANKS[10] = "A-";
-DRAFT_RANKS[9] = "B+";
-DRAFT_RANKS[8] = "B";
-DRAFT_RANKS[7] = "B-";
-DRAFT_RANKS[6] = "C+";
-DRAFT_RANKS[5] = "C";
-DRAFT_RANKS[4] = "C-";
-DRAFT_RANKS[3] = "D+";
-DRAFT_RANKS[2] = "D";
-DRAFT_RANKS[1] = "D-";
-DRAFT_RANKS[0] = "F";
-export { DRAFT_RANKS };
+export const DRAFT_RANKS = [
+  "F",
+  "D-",
+  "D",
+  "D+",
+  "C-",
+  "C",
+  "C+",
+  "B-",
+  "B",
+  "B+",
+  "A-",
+  "A",
+  "A+"
+];
+
 export const CARD_TYPE_CODES = [
   "cre",
   "lan",

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -1,19 +1,14 @@
 import formatDistanceStrict from "date-fns/formatDistanceStrict";
 import { shell } from "electron";
-import {
-  FORMATS,
-  BLACK,
-  BLUE,
-  GREEN,
-  RED,
-  WHITE,
-  MANA_COLORS,
-  CARD_TYPES,
-  CARD_TYPE_CODES
-} from "./constants";
+import React from "react";
+import ReactDOM from "react-dom";
+
+import { FORMATS, BLACK, BLUE, GREEN, RED, WHITE } from "./constants";
 import db from "./database";
 import pd from "./player-data";
-import { createDiv, createSpan } from "./dom-fns";
+import { createDiv } from "./dom-fns";
+import DeckManaCurve from "./DeckManaCurve";
+import DeckTypesStats from "./DeckTypesStats";
 
 export function getCardArtCrop(cardObj) {
   if (typeof cardObj !== "object") {
@@ -376,72 +371,6 @@ export function getBoosterCountEstimate(neededWildcards) {
   return Math.round(boosterCost);
 }
 
-export function get_deck_types_ammount(deck) {
-  const types = { art: 0, cre: 0, enc: 0, ins: 0, lan: 0, pla: 0, sor: 0 };
-  if (!deck.mainDeck) return types;
-
-  deck.mainDeck.forEach(function(card) {
-    // This is hackish.. the way we insert our custom elements in the
-    // array of cards is wrong in the first place :()
-    if (card.id.id && card.id.id == 100) {
-      types.lan += card.quantity;
-      return;
-    }
-    const c = db.card(card.id);
-    if (c) {
-      if (c.type.includes("Land", 0)) types.lan += card.quantity;
-      else if (c.type.includes("Creature", 0)) types.cre += card.quantity;
-      else if (c.type.includes("Artifact", 0)) types.art += card.quantity;
-      else if (c.type.includes("Enchantment", 0)) types.enc += card.quantity;
-      else if (c.type.includes("Instant", 0)) types.ins += card.quantity;
-      else if (c.type.includes("Sorcery", 0)) types.sor += card.quantity;
-      else if (c.type.includes("Planeswalker", 0)) types.pla += card.quantity;
-    }
-  });
-
-  return types;
-}
-
-export function get_deck_curve(deck) {
-  const curve = [];
-  if (!deck.mainDeck) return curve;
-
-  deck.mainDeck.forEach(card => {
-    const cardObj = db.card(card.id);
-    if (!cardObj) return;
-
-    const cmc = cardObj.cmc;
-    if (!curve[cmc]) curve[cmc] = [0, 0, 0, 0, 0, 0];
-
-    if (!cardObj.type.includes("Land")) {
-      cardObj.cost.forEach(c => {
-        if (c.includes("w")) curve[cmc][1] += card.quantity;
-        if (c.includes("u")) curve[cmc][2] += card.quantity;
-        if (c.includes("b")) curve[cmc][3] += card.quantity;
-        if (c.includes("r")) curve[cmc][4] += card.quantity;
-        if (c.includes("g")) curve[cmc][5] += card.quantity;
-      });
-
-      curve[cmc][0] += card.quantity;
-    }
-  });
-  /*
-  // Do not account sideboard?
-  deck.sideboard.forEach(function(card) {
-    var grpid = card.id;
-    var cmc = db.card(grpid).cmc;
-    if (curve[cmc] == undefined)  curve[cmc] = 0;
-    curve[cmc] += card.quantity
-
-    if (db.card(grpid).rarity !== 'land') {
-      curve[cmc] += card.quantity
-    }
-  });
-  */
-  //console.log(curve);
-  return curve;
-}
-
 export function get_deck_export(deck) {
   let str = "";
   deck.mainDeck = removeDuplicates(deck.mainDeck);
@@ -646,69 +575,15 @@ export function objectClone(originalObject) {
 }
 
 export function deckManaCurve(deck) {
-  const manaCounts = get_deck_curve(deck);
-  const curveMax = Math.max(
-    ...manaCounts
-      .filter(v => {
-        if (v == undefined) return false;
-        return true;
-      })
-      .map(v => v[0] || 0)
-  );
-  // console.log("deckManaCurve", manaCounts, curveMax);
-
-  const container = createDiv(["mana_curve_container"]);
-  const curve = createDiv(["mana_curve"]);
-  const numbers = createDiv(["mana_curve_numbers"]);
-
-  manaCounts.forEach((cost, i) => {
-    const total = cost[0];
-    const manaTotal = cost.reduce(add, 0) - total;
-
-    const curveCol = createDiv(["mana_curve_column"]);
-    curveCol.style.height = (total * 100) / curveMax + "%";
-
-    const curveNum = createDiv(["mana_curve_number"], total > 0 ? total : "");
-    curveCol.appendChild(curveNum);
-
-    MANA_COLORS.forEach((mc, ind) => {
-      if (ind < 5 && cost[ind + 1] > 0) {
-        const col = createDiv(["mana_curve_column_color"]);
-        col.style.height = Math.round((cost[ind + 1] / manaTotal) * 100) + "%";
-        col.style.backgroundColor = mc;
-        curveCol.appendChild(col);
-      }
-    });
-
-    curve.appendChild(curveCol);
-
-    const colNum = createDiv(["mana_curve_column_number"]);
-    const numDiv = createDiv(["mana_s16", "mana_" + i]);
-    numDiv.style.margin = "auto";
-    colNum.appendChild(numDiv);
-    numbers.appendChild(colNum);
-  });
-
-  container.appendChild(curve);
-  container.appendChild(numbers);
-
-  return container;
+  const wrap = createDiv([]);
+  ReactDOM.render(<DeckManaCurve deck={deck} />, wrap);
+  return wrap;
 }
 
 export function deckTypesStats(deck) {
-  const cardTypes = get_deck_types_ammount(deck);
-  const typesContainer = createDiv(["types_container"]);
-  CARD_TYPE_CODES.forEach((cardTypeKey, index) => {
-    const type = createDiv(["type_icon_cont"]);
-    type.appendChild(
-      createDiv(["type_icon", "type_" + cardTypeKey], "", {
-        title: CARD_TYPES[index]
-      })
-    );
-    type.appendChild(createSpan([], cardTypes[cardTypeKey]));
-    typesContainer.appendChild(type);
-  });
-  return typesContainer;
+  const wrap = createDiv([]);
+  ReactDOM.render(<DeckTypesStats deck={deck} />, wrap);
+  return wrap;
 }
 
 // pass in playerData.constructed / limited / historic objects

--- a/src/window_background/forceDeckUpdate.js
+++ b/src/window_background/forceDeckUpdate.js
@@ -48,7 +48,8 @@ const forceDeckUpdate = function(removeUsed = true) {
     typeSor = main.countType("Sorcery");
     typePla = main.countType("Planeswalker");
 
-    let chancesObj = {};
+    const chancesObj = { sampleSize: globals.odds_sample_size };
+
     let landsCount = main.getLandsAmounts();
     chancesObj.landW = chanceType(
       landsCount.w,

--- a/src/window_overlay_v3/overlay.jsx
+++ b/src/window_overlay_v3/overlay.jsx
@@ -1,8 +1,27 @@
 import { ipcRenderer as ipc, webFrame, remote } from "electron";
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import React from "react";
+import ReactDOM from "react-dom";
 import interact from "interactjs";
-import format from "date-fns/format";
+import TransparencyMouseFix from "electron-transparency-mouse-fix";
+import striptags from "striptags";
+
+import pd from "../shared/player-data";
+import Deck from "../shared/deck";
+import { setRenderer } from "../shared/card-hover";
+import { queryElements } from "../shared/dom-fns";
+import {
+  ARENA_MODE_IDLE,
+  ARENA_MODE_MATCH,
+  ARENA_MODE_DRAFT,
+  COLORS_ALL,
+  IPC_BACKGROUND,
+  IPC_OVERLAY,
+  IPC_MAIN,
+  OVERLAY_LOG,
+  OVERLAY_DRAFT_MODES
+} from "../shared/constants";
+
+import Overlay from "../overlay/Overlay";
 
 if (!remote.app.isPackaged) {
   const { openNewGitHubIssue, debugInfo } = require("electron-util");
@@ -23,87 +42,20 @@ if (!remote.app.isPackaged) {
   });
 }
 
-import TransparencyMouseFix from "electron-transparency-mouse-fix";
-let fix = null;
-
-import striptags from "striptags";
-import db from "../shared/database";
-import pd from "../shared/player-data";
-import Deck from "../shared/deck.js";
-import Colors from "../shared/colors";
-import * as deckDrawer from "../shared/deck-drawer";
-import {
-  compare_cards,
-  deckManaCurve,
-  deckTypesStats,
-  get_card_type_sort
-} from "../shared/util";
-import {
-  addCardHover,
-  attachOwnerhipStars,
-  setRenderer
-} from "../shared/card-hover";
-import { queryElements, createDiv } from "../shared/dom-fns";
-import {
-  ARENA_MODE_IDLE,
-  ARENA_MODE_MATCH,
-  ARENA_MODE_DRAFT,
-  COLORS_ALL,
-  DRAFT_RANKS,
-  MANA,
-  PACK_SIZES,
-  IPC_BACKGROUND,
-  IPC_OVERLAY,
-  IPC_MAIN,
-  OVERLAY_FULL,
-  OVERLAY_LEFT,
-  OVERLAY_ODDS,
-  OVERLAY_MIXED,
-  OVERLAY_SEEN,
-  OVERLAY_DRAFT,
-  OVERLAY_LOG,
-  OVERLAY_DRAFT_BREW,
-  OVERLAY_DRAFT_MODES
-} from "../shared/constants.js";
-import Clock from "../overlay/Clock";
+setRenderer(1);
 
 const DEFAULT_BACKGROUND = "../images/Bedevil-Art.jpg";
 
-const byId = id => document.getElementById(id);
-
-let landsCard = {
-  id: 100,
-  name: "Lands",
-  set: "",
-  artid: 0,
-  type: "Special",
-  cost: [],
-  cmc: 0,
-  rarity: "",
-  cid: 0,
-  frame: [1, 2, 3, 4, 5],
-  artist: "",
-  dfc: "None",
-  collectible: false,
-  craftable: false,
-  images: {
-    art_crop: "../images/type_land.png"
-  },
-  dfcId: 0
-};
-
-setRenderer(1);
-
-let playerSeat = 0;
-let oppName = "";
-let turnPriority = 0;
-let oddsSampleSize = 1;
-
 let actionLog = [];
-
-let currentMatch = null;
 let arenaState = ARENA_MODE_IDLE;
 let editMode = false;
+let currentMatch = null;
+let currentDraft;
+let draftState = { packN: 0, pickN: 0 };
+let playerSeat = 0;
+let turnPriority = 0;
+
+const byId = id => document.getElementById(id);
 
 function ipcSend(method, arg, to = IPC_BACKGROUND) {
   ipc.send("ipc_switch", method, IPC_OVERLAY, arg, to);
@@ -123,6 +75,40 @@ ipc.on("set_arena_state", function(event, arg) {
 ipc.on("edit", () => {
   toggleEditMode();
 });
+
+function recreateOverlay(index, _draftState) {
+  const elementsDiv = queryElements(
+    `#overlay_${index + 1} .elements_wrapper`
+  )[0];
+  if (_draftState) {
+    draftState = _draftState;
+  } else if (currentDraft) {
+    draftState = {
+      packN: currentDraft.packNumber,
+      pickN: currentDraft.pickNumber
+    };
+  }
+  const setOddsCallback = sampleSize => {
+    ipcSend("set_odds_samplesize", sampleSize);
+  };
+  const setDraftStateCallback = _draftState => {
+    recreateOverlay(index, _draftState);
+  };
+  const props = {
+    actionLog,
+    draft: currentDraft,
+    draftState,
+    index,
+    match: currentMatch,
+    playerSeat,
+    settings: pd.settings.overlays[index],
+    tileStyle: parseInt(pd.settings.card_tile_style),
+    turnPriority,
+    setOddsCallback,
+    setDraftStateCallback
+  };
+  ReactDOM.render(<Overlay {...props} />, elementsDiv);
+}
 
 function toggleEditMode() {
   editMode = !editMode;
@@ -238,6 +224,10 @@ ipc.on("action_log", function(event, arg) {
   }
   actionLog.sort(compare_logs);
   //console.log(arg.seat, arg.str);
+  pd.settings.overlays.forEach((_overlay, index) => {
+    if (_overlay.mode !== OVERLAY_LOG) return;
+    recreateOverlay(index);
+  });
 });
 
 ipc.on("settings_updated", settingsUpdated);
@@ -248,7 +238,7 @@ function settingsUpdated() {
   // (should be okay since ending edit-mode causes a refresh)
   if (editMode) return;
 
-  console.log(window.innerWidth, window.innerHeight);
+  // console.log(window.innerWidth, window.innerHeight);
   let hoverContainer = byId("overlay_hover");
   if (pd.settings.overlayHover) {
     hoverContainer.style.left = `${pd.settings.overlayHover.x}px`;
@@ -279,42 +269,18 @@ function settingsUpdated() {
 
     change_background(index, pd.settings.back_url);
 
-    let messageDom = `#overlay_${index + 1} .overlay_message`;
-    let deckNameDom = `#overlay_${index + 1} .overlay_deckname`;
-    let deckColorsDom = `#overlay_${index + 1} .overlay_deckcolors`;
-    let deckListDom = `#overlay_${index + 1} .overlay_decklist`;
-    let clockDom = `#overlay_${index + 1} .overlay_clock_container`;
-    let bgImageDom = `#overlay_${index + 1} .overlay_bg_image`;
-    let elementsDom = `#overlay_${index + 1} .elements_wrapper`;
-    let topDom = `#overlay_${index + 1} .top_nav_wrapper`;
-    let mainHoverDom = ".main_hover";
+    const bgImageDom = `#overlay_${index + 1} .overlay_bg_image`;
+    const elementsDom = `#overlay_${index + 1} .elements_wrapper`;
+    const mainHoverDom = ".main_hover";
 
     queryElements(bgImageDom)[0].style.opacity = _overlay.alpha_back.toString();
     queryElements(elementsDom)[0].style.opacity = _overlay.alpha.toString();
 
-    queryElements(topDom)[0].style = "";
-    queryElements(topDom)[0].style.display = _overlay.top ? "" : "none";
-    queryElements(deckNameDom)[0].style = "";
-    queryElements(deckNameDom)[0].style.display = _overlay.title ? "" : "none";
-    queryElements(deckColorsDom)[0].style = "";
-    queryElements(deckColorsDom)[0].style.display = _overlay.title
-      ? ""
-      : "none";
-
-    queryElements(deckListDom)[0].style.display = _overlay.deck ? "" : "none";
     queryElements(mainHoverDom)[0].style.width = pd.cardsSizeHoverCard + "px";
     queryElements(mainHoverDom)[0].style.height =
       pd.cardsSizeHoverCard / 0.71808510638 + "px";
 
-    const showClock =
-      _overlay.clock && !OVERLAY_DRAFT_MODES.includes(_overlay.mode);
-    queryElements(clockDom)[0].style.display = showClock ? "" : "none";
-
-    if (OVERLAY_DRAFT_MODES.includes(_overlay.mode)) {
-      updateDraftView(index);
-    } else {
-      updateMatchView(index);
-    }
+    recreateOverlay(index);
   });
 }
 
@@ -334,7 +300,7 @@ ipc.on("set_draft_cards", (event, draft) => {
   currentDraft = draft;
   pd.settings.overlays.forEach((_overlay, index) => {
     if (!OVERLAY_DRAFT_MODES.includes(_overlay.mode)) return;
-    updateDraftView(index, currentDraft.packNumber, currentDraft.pickNumber);
+    recreateOverlay(index);
   });
 });
 
@@ -347,8 +313,8 @@ ipc.on("set_turn", (event, arg) => {
     pd.settings.sound_priority
   ) {
     //    playBlip();
-    let { Howl, Howler } = require("howler");
-    let sound = new Howl({ src: ["../sounds/blip.mp3"] });
+    const { Howl, Howler } = require("howler");
+    const sound = new Howl({ src: ["../sounds/blip.mp3"] });
     Howler.volume(pd.settings.sound_priority_volume);
     sound.play();
   }
@@ -360,7 +326,7 @@ ipc.on("set_turn", (event, arg) => {
   //turnDecision = _decision;
 
   pd.settings.overlays.forEach((_overlay, index) => {
-    recreateClock(index);
+    recreateOverlay(index);
   });
 });
 
@@ -377,593 +343,9 @@ ipc.on("set_match", (event, arg) => {
 
   pd.settings.overlays.forEach((_overlay, index) => {
     if (OVERLAY_DRAFT_MODES.includes(_overlay.mode)) return;
-    recreateClock(index);
-    updateMatchView(index);
+    recreateOverlay(index);
   });
 });
-
-function updateMatchView(index) {
-  if (!currentMatch) return;
-  let settings = pd.settings.overlays[index];
-
-  let deckNameDom = `#overlay_${index + 1} .overlay_deckname`;
-  let deckColorsDom = `#overlay_${index + 1} .overlay_deckcolors`;
-  let deckListDom = `#overlay_${index + 1} .overlay_decklist`;
-  let archDom = `#overlay_${index + 1} .overlay_archetype`;
-
-  let cleanName =
-    currentMatch && currentMatch.opponent && currentMatch.opponent.name;
-  if (cleanName && cleanName !== "Sparky") {
-    cleanName = cleanName.slice(0, -6);
-  }
-  oppName = cleanName || "Opponent";
-
-  const container = queryElements(deckListDom)[0];
-  const doscroll =
-    Math.round(
-      container.scrollHeight - container.offsetHeight - container.scrollTop
-    ) < 32;
-
-  if (queryElements(archDom)[0]) {
-    queryElements(archDom)[0].remove();
-  }
-
-  queryElements(deckListDom)[0].innerHTML = "";
-  queryElements(deckColorsDom)[0].innerHTML = "";
-  queryElements(deckNameDom)[0].innerHTML = "";
-
-  let deckListDiv;
-  let overlayMode = settings.mode;
-
-  deckListDiv = queryElements(deckListDom)[0];
-  if (overlayMode === OVERLAY_LOG) {
-    // Action Log Mode
-    queryElements(deckNameDom)[0].innerHTML = "Action Log";
-
-    let initalTime = actionLog[0] ? new Date(actionLog[0].time) : new Date();
-    actionLog.forEach(log => {
-      log.str = log.str.replace(
-        "<log-card",
-        '<log-card class="click-on"',
-        "gi"
-      );
-      log.str = log.str.replace(
-        "<log-ability",
-        '<log-ability class="click-on"',
-        "gi"
-      );
-      const _date = new Date(log.time);
-      const secondsPast = Math.round((_date - initalTime) / 1000);
-
-      const box = createDiv(["actionlog", "log_p" + log.seat]);
-      const time = createDiv(["actionlog_time"], secondsPast + "s", {
-        title: format(_date, "HH:mm:ss")
-      });
-      const str = createDiv(["actionlog_text"], log.str);
-
-      box.appendChild(time);
-      box.appendChild(str);
-      deckListDiv.appendChild(box);
-    });
-
-    if (doscroll) {
-      deckListDiv.scrollTop = deckListDiv.scrollHeight;
-    }
-
-    queryElements("log-card").forEach(obj => {
-      const grpId = obj.getAttribute("id");
-      addCardHover(obj, db.card(grpId));
-    });
-
-    queryElements("log-ability").forEach(obj => {
-      const grpId = obj.getAttribute("id");
-      const abilityText = db.abilities[grpId] || "";
-      obj.title = abilityText;
-    });
-
-    return;
-  }
-
-  let deckToDraw = false;
-
-  if (overlayMode === OVERLAY_FULL) {
-    // Full Deck Mode
-    let cardsCount = currentMatch.player.deck.mainboard.count();
-    deckListDiv.appendChild(
-      createDiv(["decklist_title"], "Full Deck: " + cardsCount + " cards")
-    );
-    deckToDraw = currentMatch.player.deck;
-  } else if (overlayMode === OVERLAY_LEFT) {
-    // Library Mode
-    let cardsLeft = currentMatch.playerCardsLeft.mainboard.count();
-    deckListDiv.appendChild(
-      createDiv(["decklist_title"], "Library: " + cardsLeft + " cards")
-    );
-    deckToDraw = currentMatch.playerCardsLeft;
-  } else if (overlayMode === OVERLAY_ODDS || overlayMode === OVERLAY_MIXED) {
-    // Next Draw Odds Mode
-    let cardsLeft = currentMatch.playerCardsLeft.mainboard.count();
-    deckListDiv.appendChild(
-      createDiv(
-        ["decklist_title"],
-        `Next Draw: ${oddsSampleSize}/${cardsLeft} cards`
-      )
-    );
-    deckToDraw = currentMatch.playerCardsLeft;
-  } else if (overlayMode === OVERLAY_SEEN) {
-    // Opponent Cards Mode
-    const deckName = queryElements(deckNameDom)[0];
-    deckName.parentNode.insertBefore(
-      createDiv(["overlay_archetype"]),
-      deckName.nextSibling
-    );
-    deckName.innerHTML = "Played by " + oppName;
-    queryElements(archDom)[0].innerHTML = currentMatch.oppArchetype;
-
-    currentMatch.oppCards.colors
-      .get()
-      .forEach(color =>
-        queryElements(deckColorsDom)[0].appendChild(
-          createDiv(["mana_s20", "mana_" + MANA[color]])
-        )
-      );
-    deckToDraw = currentMatch.oppCards;
-  }
-
-  if (!deckToDraw) return;
-
-  // Deck colors
-  if (
-    [OVERLAY_ODDS, OVERLAY_MIXED, OVERLAY_FULL, OVERLAY_LEFT].includes(
-      overlayMode
-    )
-  ) {
-    queryElements(deckNameDom)[0].innerHTML = deckToDraw.name;
-    deckToDraw.colors
-      .get()
-      .forEach(color =>
-        queryElements(deckColorsDom)[0].appendChild(
-          createDiv(["mana_s20", "mana_" + MANA[color]])
-        )
-      );
-  }
-
-  let sortFunc = compare_cards;
-  if (overlayMode === OVERLAY_ODDS || overlayMode == OVERLAY_MIXED) {
-    sortFunc = compare_quantity;
-  }
-
-  let mainCards = deckToDraw.mainboard;
-  mainCards.removeDuplicates();
-  // group lands
-  if (
-    settings.lands &&
-    [OVERLAY_FULL, OVERLAY_LEFT, OVERLAY_ODDS, OVERLAY_MIXED].includes(
-      overlayMode
-    )
-  ) {
-    let landsNumber = 0;
-    let landsChance = 0;
-    let landsColors = new Colors();
-    mainCards.get().forEach(card => {
-      let cardObj = db.card(card.id);
-      if (cardObj && cardObj.type.includes("Land", 0)) {
-        landsNumber += card.quantity;
-        landsChance += card.chance !== undefined ? card.chance : 0;
-        delete card.chance;
-        card.quantity = 0;
-        if (cardObj.frame) {
-          landsColors.addFromArray(cardObj.frame);
-        }
-      }
-    });
-    let lands = mainCards.add(landsCard, landsNumber, true);
-    if (landsChance > 0) {
-      lands.chance = landsChance;
-    }
-
-    // Set lands frame colors
-    landsCard.frame = landsColors.get();
-  }
-  mainCards.get().sort(sortFunc);
-  mainCards.get().forEach(card => {
-    let tile;
-    if (overlayMode === OVERLAY_MIXED) {
-      let odds = (card.chance !== undefined ? card.chance : "0") + "%";
-      let q = card.quantity;
-
-      if (!settings.lands || (settings.lands && odds !== "0%")) {
-        tile = deckDrawer.cardTile(pd.settings.card_tile_style, card.id, "a", {
-          quantity: q,
-          odds: odds
-        });
-      }
-    } else if (overlayMode === OVERLAY_ODDS) {
-      let quantity = (card.chance !== undefined ? card.chance : "0") + "%";
-      if (!settings.lands || (settings.lands && quantity !== "0%")) {
-        tile = deckDrawer.cardTile(
-          pd.settings.card_tile_style,
-          card.id,
-          "a",
-          quantity
-        );
-      }
-    } else {
-      tile = deckDrawer.cardTile(
-        pd.settings.card_tile_style,
-        card.id,
-        "a",
-        card.quantity
-      );
-    }
-    if (tile) deckListDiv.appendChild(tile);
-
-    // This is hackish.. the way we insert our custom elements in the
-    // array of cards is wrong in the first place :()
-    if (tile && card.id.id && card.id.id == 100) {
-      attachLandOdds(tile, currentMatch.playerCardsOdds);
-    }
-  });
-  if (settings.sideboard && deckToDraw.sideboard.count() > 0) {
-    deckListDiv.appendChild(createDiv(["card_tile_separator"], "Sideboard"));
-
-    const sideCards = deckToDraw.sideboard;
-    sideCards.removeDuplicates();
-    sideCards.get().sort(sortFunc);
-
-    sideCards.get().forEach(function(card) {
-      if (overlayMode === OVERLAY_ODDS || overlayMode === OVERLAY_MIXED) {
-        const tile = deckDrawer.cardTile(
-          pd.settings.card_tile_style,
-          card.id,
-          "a",
-          "0%"
-        );
-        deckListDiv.appendChild(tile);
-      } else {
-        const tile = deckDrawer.cardTile(
-          pd.settings.card_tile_style,
-          card.id,
-          "a",
-          card.quantity
-        );
-        if (tile) deckListDiv.appendChild(tile);
-      }
-    });
-  }
-
-  if (
-    (overlayMode === OVERLAY_ODDS || overlayMode === OVERLAY_MIXED) &&
-    settings.draw_odds
-  ) {
-    drawDeckOdds(index);
-  }
-
-  const deck = deckToDraw.getSave();
-  if (settings.type_counts) {
-    deckListDiv.appendChild(deckTypesStats(deck));
-  }
-  if (settings.mana_curve) {
-    deckListDiv.appendChild(deckManaCurve(deck));
-  }
-}
-
-function attachLandOdds(tile, odds) {
-  let landsDiv = createDiv(["lands_div"]);
-
-  let createManaChanceDiv = function(odds, color) {
-    let cont = createDiv(["mana_cont"], odds + "%");
-    let div = createDiv(["mana_s16", "flex_end", "mana_" + color]);
-    cont.appendChild(div);
-    landsDiv.appendChild(cont);
-  };
-
-  if (odds.landW) createManaChanceDiv(odds.landW, "w");
-  if (odds.landU) createManaChanceDiv(odds.landU, "u");
-  if (odds.landB) createManaChanceDiv(odds.landB, "b");
-  if (odds.landR) createManaChanceDiv(odds.landR, "r");
-  if (odds.landG) createManaChanceDiv(odds.landG, "g");
-
-  tile.addEventListener("mouseover", () => {
-    if (queryElements(".lands_div").length == 0) {
-      queryElements(".overlay_hover_container")[0].appendChild(landsDiv);
-    }
-  });
-
-  tile.addEventListener("mouseleave", () => {
-    queryElements(".lands_div").forEach(div => {
-      if (div) {
-        queryElements(".overlay_hover_container")[0].removeChild(div);
-      }
-    });
-  });
-}
-
-function drawDeckOdds(index) {
-  let deckListDom = `#overlay_${index + 1} .overlay_decklist`;
-  let deckListDiv = queryElements(deckListDom)[0];
-
-  const navCont = createDiv(["overlay_samplesize_container"]);
-
-  let oddsPrev = createDiv(["odds_prev", "click-on"]);
-  let oddsNext = createDiv(["odds_next", "click-on"]);
-
-  navCont.appendChild(oddsPrev);
-  navCont.appendChild(
-    createDiv(["odds_number"], "Sample size: " + oddsSampleSize)
-  );
-  navCont.appendChild(oddsNext);
-
-  deckListDiv.appendChild(navCont);
-
-  deckListDiv.appendChild(createDiv(["chance_title"])); // Add some space
-
-  let cardOdds = currentMatch.playerCardsOdds;
-
-  deckListDiv.appendChild(
-    createDiv(
-      ["chance_title"],
-      "Creature: " +
-        (cardOdds.chanceCre != undefined ? cardOdds.chanceCre : "0") +
-        "%"
-    )
-  );
-  deckListDiv.appendChild(
-    createDiv(
-      ["chance_title"],
-      "Instant: " +
-        (cardOdds.chanceIns != undefined ? cardOdds.chanceIns : "0") +
-        "%"
-    )
-  );
-  deckListDiv.appendChild(
-    createDiv(
-      ["chance_title"],
-      "Sorcery: " +
-        (cardOdds.chanceSor != undefined ? cardOdds.chanceSor : "0") +
-        "%"
-    )
-  );
-  deckListDiv.appendChild(
-    createDiv(
-      ["chance_title"],
-      "Artifact: " +
-        (cardOdds.chanceArt != undefined ? cardOdds.chanceArt : "0") +
-        "%"
-    )
-  );
-  deckListDiv.appendChild(
-    createDiv(
-      ["chance_title"],
-      "Enchantment: " +
-        (cardOdds.chanceEnc != undefined ? cardOdds.chanceEnc : "0") +
-        "%"
-    )
-  );
-  deckListDiv.appendChild(
-    createDiv(
-      ["chance_title"],
-      "Planeswalker: " +
-        (cardOdds.chancePla != undefined ? cardOdds.chancePla : "0") +
-        "%"
-    )
-  );
-  deckListDiv.appendChild(
-    createDiv(
-      ["chance_title"],
-      "Land: " +
-        (cardOdds.chanceLan != undefined ? cardOdds.chanceLan : "0") +
-        "%"
-    )
-  );
-
-  let oddNextDom = `#overlay_${index + 1} .odds_next`;
-  let oddPrevDom = `#overlay_${index + 1} .odds_prev`;
-  //
-  queryElements(oddPrevDom)[0].addEventListener("click", function() {
-    let cardsLeft = currentMatch.playerCardsLeft.mainboard.count();
-    oddsSampleSize -= 1;
-    if (oddsSampleSize < 1) {
-      oddsSampleSize = cardsLeft - 1;
-    }
-    ipcSend("set_odds_samplesize", oddsSampleSize);
-  });
-  //
-  queryElements(oddNextDom)[0].addEventListener("click", function() {
-    let cardsLeft = currentMatch.playerCardsLeft.mainboard.count();
-    oddsSampleSize += 1;
-    if (oddsSampleSize > cardsLeft - 1) {
-      oddsSampleSize = 1;
-    }
-    ipcSend("set_odds_samplesize", oddsSampleSize);
-  });
-}
-
-var currentDraft;
-let packN;
-let pickN;
-
-function updateDraftView(index, _packN = -1, _pickN = -1) {
-  if (!currentDraft) return;
-  const settings = pd.settings.overlays[index];
-  if (_packN === -1 || _pickN === -1) {
-    packN = currentDraft.packNumber;
-    pickN = currentDraft.pickNumber;
-  } else {
-    packN = _packN;
-    pickN = _pickN;
-  }
-  const key = "pack_" + packN + "pick_" + pickN;
-
-  let deckNameDom = `#overlay_${index + 1} .overlay_deckname`;
-  let deckColorsDom = `#overlay_${index + 1} .overlay_deckcolors`;
-  let deckListDom = `#overlay_${index + 1} .overlay_decklist`;
-
-  queryElements(deckListDom)[0].innerHTML = "";
-  queryElements(deckColorsDom)[0].innerHTML = "";
-
-  let overlayMode = settings.mode;
-  if (overlayMode === OVERLAY_DRAFT) {
-    const titleDiv = queryElements(deckNameDom)[0];
-    titleDiv.style.display = "";
-    let title = "Pack " + (packN + 1) + " - Pick " + (pickN + 1);
-    if (
-      packN === currentDraft.packNumber &&
-      pickN === currentDraft.pickNumber
-    ) {
-      title += " - Current";
-    }
-    titleDiv.innerHTML = title;
-
-    const controlCont = createDiv(["overlay_draft_container"]);
-    if (settings.top) controlCont.style.top = "32px";
-
-    const draftPrev = createDiv(["draft_prev", "click-on"]);
-    draftPrev.addEventListener("click", function() {
-      pickN -= 1;
-      let packSize = (currentDraft && PACK_SIZES[currentDraft.set]) || 14;
-
-      if (pickN < 0) {
-        pickN = packSize;
-        packN -= 1;
-      }
-      if (packN < 0) {
-        pickN = currentDraft.pickNumber;
-        packN = currentDraft.packNumber;
-      }
-
-      updateDraftView(index, packN, pickN);
-    });
-    controlCont.appendChild(draftPrev);
-
-    controlCont.appendChild(createDiv(["draft_title"]));
-
-    const draftNext = createDiv(["draft_next", "click-on"]);
-    draftNext.addEventListener("click", function() {
-      pickN += 1;
-      let packSize = (currentDraft && PACK_SIZES[currentDraft.set]) || 14;
-
-      if (pickN > packSize) {
-        pickN = 0;
-        packN += 1;
-      }
-
-      if (pickN > currentDraft.pickNumber && packN == currentDraft.packNumber) {
-        pickN = 0;
-        packN = 0;
-      }
-
-      if (
-        packN > currentDraft.packNumber ||
-        (pickN == currentDraft.pickNumber && packN == currentDraft.packNumber)
-      ) {
-        updateDraftView(index);
-      } else {
-        updateDraftView(index, packN, pickN);
-      }
-    });
-    controlCont.appendChild(draftNext);
-
-    titleDiv.appendChild(controlCont);
-
-    let draftPack = currentDraft[key];
-    let pick = "";
-    if (!draftPack) {
-      draftPack = currentDraft.currentPack || [];
-    } else {
-      pick = draftPack.pick;
-      draftPack = draftPack.pack;
-    }
-
-    const colors = get_ids_colors(draftPack);
-    colors.forEach(function(color) {
-      queryElements(deckColorsDom)[0].appendChild(
-        createDiv(["mana_s20", "mana_" + MANA[color]])
-      );
-    });
-
-    draftPack.sort(compareDraftPicks);
-
-    const deckListDiv = queryElements(deckListDom)[0];
-    deckListDiv.style.display = "";
-
-    draftPack.forEach(grpId => {
-      const card = db.card(grpId) || { id: grpId, rank: 0 };
-      const rank = card.rank;
-
-      const cont = createDiv(["overlay_card_quantity"]);
-      attachOwnerhipStars(card, cont);
-      deckListDiv.appendChild(cont);
-
-      const tile = deckDrawer.cardTile(
-        pd.settings.card_tile_style,
-        grpId,
-        "a",
-        DRAFT_RANKS[rank]
-      );
-      deckListDiv.appendChild(tile);
-      if (grpId == pick) {
-        tile.style.backgroundColor = "rgba(250, 229, 210, 0.66)";
-      }
-    });
-  } else if (overlayMode === OVERLAY_DRAFT_BREW) {
-    const deckListDiv = queryElements(deckListDom)[0];
-    const deckToDraw = new Deck(
-      { name: "All Picks" },
-      currentDraft.pickedCards
-    );
-
-    queryElements(deckNameDom)[0].innerHTML = deckToDraw.name;
-    deckToDraw.colors
-      .get()
-      .forEach(color =>
-        queryElements(deckColorsDom)[0].appendChild(
-          createDiv(["mana_s20", "mana_" + MANA[color]])
-        )
-      );
-    const mainCards = deckToDraw.mainboard;
-    mainCards.removeDuplicates();
-    mainCards.get().sort(compare_cards);
-    mainCards.get().forEach(card => {
-      const tile = deckDrawer.cardTile(
-        pd.settings.card_tile_style,
-        card.id,
-        "a",
-        card.quantity
-      );
-      if (tile) deckListDiv.appendChild(tile);
-    });
-
-    const deck = deckToDraw.getSave();
-    if (settings.type_counts) {
-      deckListDiv.appendChild(deckTypesStats(deck));
-    }
-    if (settings.mana_curve) {
-      deckListDiv.appendChild(deckManaCurve(deck));
-    }
-  }
-}
-
-function recreateClock(index) {
-  const clockDiv = queryElements(
-    `#overlay_${index + 1} .overlay_clock_container`
-  )[0];
-  if (!clockDiv) return;
-
-  const props = {
-    key: "overlay_clock_" + index,
-    matchBeginTime: currentMatch
-      ? new Date(currentMatch.beginTime)
-      : new Date(),
-    oppName: currentMatch ? currentMatch.opponent.name : "Opponent",
-    playerSeat: playerSeat,
-    priorityTimers: currentMatch
-      ? currentMatch.priorityTimers
-      : [Date.now(), 0, 0],
-    turnPriority: turnPriority
-  };
-  ReactDOM.render(<Clock {...props} />, clockDiv);
-}
 
 function change_background(index, arg = "default") {
   if (!arg) return;
@@ -1022,15 +404,10 @@ ready(function() {
   queryElements(".overlay_container").forEach(node => {
     node.innerHTML = `
       <div class="outer_wrapper">
-          <div class="overlay_wrapper overlay_bg_image" >
+          <div class="overlay_wrapper overlay_bg_image">
           </div>
       </div>
       <div class="outer_wrapper elements_wrapper">
-        <div class="overlay_deckname"></div>
-        <div class="overlay_deckcolors"></div>
-        <div class="overlay_decklist click-on"></div>
-        <div class="overlay_clock_container"></div>
-        <div class="overlay_message click-on"></div>
       </div>
       <div class="outer_wrapper top_nav_wrapper">
         <div class="flex_item overlay_icon click-on"></div>
@@ -1038,98 +415,40 @@ ready(function() {
         <div class="button close click-on" style="margin-right: 4px;"></div>
       </div>`;
   });
-  pd.settings.overlays.forEach((_overlay, index) => recreateClock(index));
+  pd.settings.overlays.forEach((_overlay, index) => recreateOverlay(index));
   // Force a dom refresh
   queryElements(".overlay_container")[0].style.display = "none";
   queryElements(".overlay_container")[0].style.display = "";
 
   setTimeout(() => {
     pd.settings.overlays.forEach((_overlay, index) => {
-      const iconDom = `#overlay_${index + 1} .overlay_icon`;
-      const settingsDom = `#overlay_${index + 1} .settings`;
-      const closeDom = `#overlay_${index + 1} .close`;
-      const deckListDom = `#overlay_${index + 1} .overlay_decklist`;
-
-      const deckListDiv = queryElements(deckListDom)[0];
-      deckListDiv.addEventListener("mouseover", function() {
-        let index = this.offsetParent.offsetParent.attributes["0"].value.slice(
-          -1
-        );
-        let mainHoverDom = ".main_hover";
-        let settings = pd.settings.overlays[index - 1];
-
-        if (settings.cards_overlay) {
-          queryElements(mainHoverDom)[0].style.display = "";
-        } else {
-          queryElements(mainHoverDom)[0].style.display = "none";
-        }
-      });
-
-      const iconDiv = queryElements(iconDom)[0];
+      const iconSelector = `#overlay_${index + 1} .overlay_icon`;
+      const iconDiv = queryElements(iconSelector)[0];
       iconDiv.style.backgroundColor = `var(--color-${COLORS_ALL[index]})`;
       iconDiv.addEventListener("click", toggleEditMode);
 
-      queryElements(settingsDom)[0].addEventListener("click", function() {
+      const settingsSelector = `#overlay_${index + 1} .settings`;
+      queryElements(settingsSelector)[0].addEventListener("click", function() {
         ipcSend("renderer_show");
         ipcSend("force_open_overlay_settings", index, IPC_MAIN);
       });
-      queryElements(closeDom)[0].addEventListener("click", function() {
+
+      const closeSelector = `#overlay_${index + 1} .close`;
+      queryElements(closeSelector)[0].addEventListener("click", function() {
         close(-1, index);
       });
     });
   }, 500);
   setTimeout(() => {
-    fix = new TransparencyMouseFix({
+    new TransparencyMouseFix({
       log: false,
       fixPointerEvents: "auto"
     });
   }, 1000);
 });
 
-function get_ids_colors(list) {
-  var colors = [];
-  list.forEach(function(grpid) {
-    var cdb = db.card(grpid);
-    if (cdb) {
-      //var card_name = cdb.name;
-      var card_cost = cdb.cost;
-      card_cost.forEach(function(c) {
-        if (c.indexOf("w") !== -1 && !colors.includes(1)) colors.push(1);
-        if (c.indexOf("u") !== -1 && !colors.includes(2)) colors.push(2);
-        if (c.indexOf("b") !== -1 && !colors.includes(3)) colors.push(3);
-        if (c.indexOf("r") !== -1 && !colors.includes(4)) colors.push(4);
-        if (c.indexOf("g") !== -1 && !colors.includes(5)) colors.push(5);
-      });
-    }
-  });
-
-  return colors;
-}
-
-function compare_quantity(a, b) {
-  return b.quantity - a.quantity;
-}
-
 function compare_logs(a, b) {
   if (a.time < b.time) return -1;
   if (a.time > b.time) return 1;
   return 0;
-}
-
-function compareDraftPicks(a, b) {
-  const aCard = db.card(a);
-  const bCard = db.card(b);
-  const aColors = new Colors();
-  aColors.addFromCost(aCard.cost);
-  const bColors = new Colors();
-  bColors.addFromCost(bCard.cost);
-  const aType = get_card_type_sort(aCard.type);
-  const bType = get_card_type_sort(bCard.type);
-  return (
-    bCard.rank - aCard.rank ||
-    aColors.length - bColors.length ||
-    aCard.cmc - bCard.cmc ||
-    aType - bType ||
-    aCard.name.localeCompare(bCard.name)
-  );
 }


### PR DESCRIPTION
### Motivation
This PR converts the bulk of the display code in the overlay process into React function components. It attempts to leave the code functionally identical, but there may be one or two places where it unintentionally fixes bugs. This is a port of the WIP draft #687.

#### Shared Code
  - `util.deckManaCurve` ==> converted into `DeckManaCurve`, now uses new React component
  - `util.deckTypesStats` ==> converted into `DeckTypesStats`, now uses new React component
  - `constants.DRAFT_RANKS` refactored to allows TS to infer its type (redundant with part of #684)

#### Other Non-Overlay Changes
  - `background/forceDeckUpdate` now includes the `sampleSize` in the response payload. This ensures that the overlay has the sample-size that matches the request when processing (instead of manually tracking it as state that could get out of sync in race conditions).

#### Overlay React VS legacy boundary
This PR focuses on the elements_wrapper part of each overlay, which is where most of display widgets are:
```
      <div class="outer_wrapper">
          <div class="overlay_wrapper overlay_bg_image">
          </div>
      </div>
      <div class="outer_wrapper elements_wrapper">
        <!-- now under React control -->
      </div>
      <div class="outer_wrapper top_nav_wrapper">
        <div class="flex_item overlay_icon click-on"></div>
        <div class="button settings click-on" style="margin: 0;"></div>
        <div class="button close click-on" style="margin-right: 4px;"></div>
      </div>
```
This deliberately "leaves behind" the majority of the state management, "window" management, and IPC control in the original `window_overlay_v3/overlay.jsx` for now.

The other remaining obvious legacy dependency is the hover code, which can probably be refactored after this lands to clean up a lot of the unnecessary plumbing.