### PR TITLE
Reactify top nav

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "MTG-Arena-Tool",
-  "version": "2.12.8",
+  "version": "2.12.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1690,6 +1690,11 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@sphinxxxx/color-conversion/-/color-conversion-2.2.1.tgz",
       "integrity": "sha512-5+ofCE09lF6C7DPSVyvQ2Nf0oaue3Cl+SosT45DYy5nhgUXsOq3TetArC1q8mVfAOjhG0WReQPPFBdc4xXVNkg=="
+    },
+    "@types/animejs": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/animejs/-/animejs-3.1.0.tgz",
+      "integrity": "sha512-OOOQ11ylW8GeFY85yM3HrprR5wZl1R1KsxrxNLMpE9l24zs+4yXAu4WsDESWcCAf5+PxvPNsLV9W/PB3J+XGMQ=="
     },
     "@types/babel__core": {
       "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "tsc": "tsc"
   },
   "dependencies": {
+    "@types/animejs": "^3.1.0",
     "animejs": "^3.0.1",
     "async": "^2.6.1",
     "chart.js": "^2.8.0",

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -734,6 +734,7 @@ export const DEFAULT_TILE = 67003;
 export const CARD_TILE_ARENA = 0;
 export const CARD_TILE_FLAT = 1;
 export const EASING_DEFAULT = "cubicBezier(0.570, 0.165, 0.210, 0.990)";
+
 export const MAIN_LOGIN = -2;
 export const MAIN_HOME = -1;
 export const MAIN_DECKS = 0;
@@ -744,6 +745,8 @@ export const MAIN_ECONOMY = 4;
 export const MAIN_COLLECTION = 5;
 export const MAIN_SETTINGS = 6;
 export const MAIN_UPDATE = 9;
+export const MAIN_CONSTRUCTED = 10;
+export const MAIN_LIMITED = 11;
 
 export const SHORTCUT_NAMES = {
   shortcut_overlay_1: "Toggle Overlay 1",

--- a/src/shared/player-data.js
+++ b/src/shared/player-data.js
@@ -270,6 +270,7 @@ class PlayerData {
     this.decks = undefined;
     this.name = undefined;
     this.arenaId = undefined;
+    this.offline = false;
     this.draft = this.draft.bind(this);
     this.event = this.event.bind(this);
     this.match = this.match.bind(this);

--- a/src/shared/player-data.js
+++ b/src/shared/player-data.js
@@ -273,6 +273,7 @@ class PlayerData {
     this.offline = false;
     this.patreon = false;
     this.patreon_tier = -1;
+    this.settings = undefined;
     this.draft = this.draft.bind(this);
     this.event = this.event.bind(this);
     this.match = this.match.bind(this);

--- a/src/shared/player-data.js
+++ b/src/shared/player-data.js
@@ -25,7 +25,7 @@ const playerDataDefault = {
   arenaVersion: "",
   offline: false,
   patreon: false,
-  patreon_tier: 0,
+  patreon_tier: -1,
   last_log_timestamp: null,
   last_log_format: ""
 };
@@ -271,6 +271,8 @@ class PlayerData {
     this.name = undefined;
     this.arenaId = undefined;
     this.offline = false;
+    this.patreon = false;
+    this.patreon_tier = -1;
     this.draft = this.draft.bind(this);
     this.event = this.event.bind(this);
     this.match = this.match.bind(this);

--- a/src/window_main/DateFilter.tsx
+++ b/src/window_main/DateFilter.tsx
@@ -9,29 +9,29 @@ export interface DateFilterProps extends ReactSelectProps {
 }
 
 export default function DateFilter(props: DateFilterProps) {
-    const [ showArchived, setShowArchived ] = React.useState(props.showArchivedValue);
-    
-    const onClickArchiveCheckbox = React.useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
-      const newValue = event.currentTarget.checked;
-      if (newValue != showArchived) {
-        setShowArchived(newValue);
-        props.onArchiveClick && props.onArchiveClick(newValue);
-      }
-    }, [props.onArchiveClick, showArchived]);
-    
-    const { prefixId, options, current, callback, showArchivedFilter } = props;
-    return (
-      <div className={"dateCont"}>
-        <div className={"select_container filter_panel_select_margin " + prefixId + "_query_date"}>
-            <ReactSelect options={options} current={current} callback={callback} />
-        </div>
-        {showArchivedFilter && (
-          <label className={"archive_label check_container hover_label"}>
-            {"archived"}
-            <input type={"checkbox"} id={prefixId + "_query_archived"} checked={showArchived} onChange={onClickArchiveCheckbox}></input>
-            <span className={"checkmark"} />
-          </label>
-        )}
+  const [ showArchived, setShowArchived ] = React.useState(props.showArchivedValue);
+  
+  const onClickArchiveCheckbox = React.useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = event.currentTarget.checked;
+    if (newValue != showArchived) {
+      setShowArchived(newValue);
+      props.onArchiveClick && props.onArchiveClick(newValue);
+    }
+  }, [props.onArchiveClick, showArchived]);
+  
+  const { prefixId, options, current, callback, showArchivedFilter } = props;
+  return (
+    <div className={"dateCont"}>
+      <div className={"select_container filter_panel_select_margin " + prefixId + "_query_date"}>
+          <ReactSelect options={options} current={current} callback={callback} />
       </div>
-    )
+      {showArchivedFilter && (
+        <label className={"archive_label check_container hover_label"}>
+          {"archived"}
+          <input type={"checkbox"} id={prefixId + "_query_archived"} checked={showArchived} onChange={onClickArchiveCheckbox}></input>
+          <span className={"checkmark"} />
+        </label>
+      )}
+    </div>
+  )
 }

--- a/src/window_main/TagOption.tsx
+++ b/src/window_main/TagOption.tsx
@@ -1,34 +1,36 @@
-import Aggregator from './aggregator';
-import React from 'react';
-import { getTagColor } from './renderer-util';
+import Aggregator from "./aggregator";
+import React from "react";
+import { getTagColor } from "./renderer-util";
 import { getReadableFormat } from "../shared/util";
 
 export interface TagOptionProps {
-    tag: string;
-    showCount?: boolean;
-    archCounts?: { [key: string]: number }
+  tag: string;
+  showCount?: boolean;
+  archCounts?: { [key: string]: number };
 }
 
 export default function TagOption(props: TagOptionProps) {
-    const { tag, showCount, archCounts } = props;
-    if (tag === Aggregator.DEFAULT_TAG) return tag;
-    if (tag === Aggregator.DEFAULT_ARCH) return tag;
-    const color = getTagColor(tag);
-    const margins = "margin: 5px; margin-right: 30px;";
-    const style: React.CSSProperties = {
-        whiteSpace: 'nowrap',
-        backgroundColor: color,
-        color: 'black',
-        paddingRight: '12px',
-        margin: '5px',
-        marginRight: '30px',
-    }
-    let tagString = getReadableFormat(tag);
-    if (showCount && archCounts && tag in archCounts) {
-        tagString += ` (${archCounts[tag]})`;
-    }
-    if (tag === Aggregator.NO_ARCH) return tagString;
-    return (
-        <div className={"deck_tag"} style={style}>{tagString}</div>
-    );
+  const { tag, showCount, archCounts } = props;
+  if (tag === Aggregator.DEFAULT_TAG) return tag;
+  if (tag === Aggregator.DEFAULT_ARCH) return tag;
+  const color = getTagColor(tag);
+  const margins = "margin: 5px; margin-right: 30px;";
+  const style: React.CSSProperties = {
+    whiteSpace: "nowrap",
+    backgroundColor: color,
+    color: "black",
+    paddingRight: "12px",
+    margin: "5px",
+    marginRight: "30px"
+  };
+  let tagString = getReadableFormat(tag);
+  if (showCount && archCounts && tag in archCounts) {
+    tagString += ` (${archCounts[tag]})`;
+  }
+  if (tag === Aggregator.NO_ARCH) return tagString;
+  return (
+    <div className={"deck_tag"} style={style}>
+      {tagString}
+    </div>
+  );
 }

--- a/src/window_main/index.css
+++ b/src/window_main/index.css
@@ -305,6 +305,33 @@ relative-time, local-time {
     cursor: default;
 }
 
+.top_constructed_rank {
+    background: url(../images/ranks_constructed_48.png);
+}
+
+.top_limited_rank {
+    background: url(../images/ranks_limited_48.png);
+}
+
+.top_constructed_rank, .top_limited_rank {
+    /* Align leaderboard indicator to center and add text border*/
+    display: flex;
+    margin: auto;
+    align-items: center;
+    justify-content: center;
+    -webkit-app-region: no-drag;
+    align-self: center;
+    width: 48px;
+    height: 48px;
+    background-position: 0px 0px;
+    text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;
+}
+
+.top_userdata_container {
+    display: flex;
+    margin-left: auto;
+}
+
 .it10, .it11 {
     width: 60px;
 }

--- a/src/window_main/index.css
+++ b/src/window_main/index.css
@@ -376,7 +376,7 @@ relative-time, local-time {
 }
 
 .top_nav_icon {
-    opacity: 0;
+    opacity: 1;
     position: absolute;
     left: calc(50% - 16px);
     top: 16px;

--- a/src/window_main/index.css
+++ b/src/window_main/index.css
@@ -305,14 +305,21 @@ relative-time, local-time {
     cursor: default;
 }
 
+.it7, .it8 {
+    width: 60px;
+}
 
 .icon_7 {
     -webkit-app-region: no-drag;
     align-self: center;
     width: 48px;
     height: 48px;
-    background: url(../images/ranks_constructed_48.png);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;
     background-position: 0px 0px;
+    background: url(../images/ranks_constructed_48.png);
 }
 
 .icon_8 {
@@ -320,16 +327,12 @@ relative-time, local-time {
     align-self: center;
     width: 48px;
     height: 48px;
-    background: url(../images/ranks_limited_48.png);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;
     background-position: 0px 0px;
-}
-
-.top_constructed_rank, .top_limited_rank {
-  /* Align leaderboard indicator to center and add text border*/
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;
+    background: url(../images/ranks_limited_48.png);
 }
 
 .top_patreon {

--- a/src/window_main/index.css
+++ b/src/window_main/index.css
@@ -306,7 +306,7 @@ relative-time, local-time {
 }
 
 
-.top_constructed_rank {
+.icon_7 {
     -webkit-app-region: no-drag;
     align-self: center;
     width: 48px;
@@ -315,7 +315,7 @@ relative-time, local-time {
     background-position: 0px 0px;
 }
 
-.top_limited_rank {
+.icon_8 {
     -webkit-app-region: no-drag;
     align-self: center;
     width: 48px;
@@ -373,7 +373,6 @@ relative-time, local-time {
 }
 
 .top_nav_icon {
-    display: none;
     opacity: 0;
     position: absolute;
     left: calc(50% - 16px);
@@ -459,7 +458,7 @@ span.top_nav_item_text {
     display: inline-grid;
 }
 
-.it7, .it8 {
+.icon_7, .icon_8 {
     opacity: 1;
 }
 
@@ -468,7 +467,7 @@ span.top_nav_item_text {
     opacity: 1;
 }
 
-.ith_icon {
+.icon_h {
     width: 32px;
     height: 32px;
     opacity: 1;

--- a/src/window_main/index.css
+++ b/src/window_main/index.css
@@ -305,7 +305,7 @@ relative-time, local-time {
     cursor: default;
 }
 
-.it7, .it8 {
+.it10, .it11 {
     width: 60px;
 }
 
@@ -391,30 +391,26 @@ relative-time, local-time {
 }
 
 .icon_0 {
-    background: url(../images/tab_tourneys.png);
-}
-
-.icon_1 {
     background: url(../images/tab_my_decks.png);
 }
 
-.icon_2 {
+.icon_1 {
     background: url(../images/tab_history.png);
 }
 
-.icon_3 {
+.icon_2 {
     background: url(../images/tab_events.png);
 }
 
-.icon_4 {
+.icon_3 {
     background: url(../images/tab_explore.png);
 }
 
-.icon_5 {
+.icon_4 {
     background: url(../images/tab_economy.png);
 }
 
-.icon_6 {
+.icon_5 {
     background: url(../images/tab_collection.png);
 }
 
@@ -434,6 +430,11 @@ span.top_nav_item_text {
     overflow: hidden;
     display: inline-block;
     -webkit-transition: all .5s ease-in-out;
+}
+
+.top_nav_item_no_label {
+    max-width: 60px !important;
+    min-width: 60px !important;
 }
 
 .top_nav_item {
@@ -470,11 +471,10 @@ span.top_nav_item_text {
     opacity: 1;
 }
 
-.icon_h {
+.icon_-1 {
     width: 32px;
     height: 32px;
     opacity: 1;
-    margin: 16px auto;
     background-repeat: no-repeat;
     background-image: url(../images/tab_home.png);
 }

--- a/src/window_main/index.html
+++ b/src/window_main/index.html
@@ -32,13 +32,21 @@
                     <div class="button close"></div>
                 </div>
             </div>
-            <div class="top_nav hidden">
+            <div class="top_nav_container">
                 <div class="top_nav_icons">
                     <div class="top_nav_separator"></div>
-                    <div class="top_nav_item ith" title="Home" style="width: 60px;"><div class="ith_icon"></div></div>
-                    <div class="top_nav_item it0"><span class="top_nav_item_text">MY DECKS</span><div class="top_nav_icon icon_1" title="My Decks"></div></div>
-                    <div class="top_nav_item it1"><span class="top_nav_item_text">HISTORY</span><div class="top_nav_icon icon_2" title="History"></div></div>
-                    <div class="top_nav_item it2"><span class="top_nav_item_text">EVENTS</span><div class="top_nav_icon icon_3" title="Events"></div></div>
+                    <div class="top_nav_item ith" title="Home" style="width: 60px;"><div class="ith_icon"></div>
+                    </div>
+                    <div class="top_nav_item it0"><span class="top_nav_item_text">MY DECKS</span><div class="top_nav_icon icon_1" title="My Decks"></div>
+                    </div>
+                    <div class="top_nav_item it1">
+                        <span class="top_nav_item_text">HISTORY</span>
+                        <div class="top_nav_icon icon_2" title="History"></div>
+                    </div>
+                    <div class="top_nav_item it2">
+                        <span class="top_nav_item_text">EVENTS</span>
+                        <div class="top_nav_icon icon_3" title="Events"></div>
+                    </div>
                     <div class="top_nav_item it3"><span class="top_nav_item_text">EXPLORE</span><div class="top_nav_icon icon_4" title="Explore"></div></div>
                     <div class="top_nav_item it4"><span class="top_nav_item_text">ECONOMY</span><div class="top_nav_icon icon_5" title="Economy"></div></div>
                     <div class="top_nav_item it5"><span class="top_nav_item_text">COLLECTION</span><div class="top_nav_icon icon_6" title="Collection"></div></div>

--- a/src/window_main/index.html
+++ b/src/window_main/index.html
@@ -33,37 +33,7 @@
                 </div>
             </div>
             <div class="top_nav_container">
-                <div class="top_nav_icons">
-                    <div class="top_nav_separator"></div>
-                    <div class="top_nav_item ith" title="Home" style="width: 60px;"><div class="ith_icon"></div>
-                    </div>
-                    <div class="top_nav_item it0"><span class="top_nav_item_text">MY DECKS</span><div class="top_nav_icon icon_1" title="My Decks"></div>
-                    </div>
-                    <div class="top_nav_item it1">
-                        <span class="top_nav_item_text">HISTORY</span>
-                        <div class="top_nav_icon icon_2" title="History"></div>
-                    </div>
-                    <div class="top_nav_item it2">
-                        <span class="top_nav_item_text">EVENTS</span>
-                        <div class="top_nav_icon icon_3" title="Events"></div>
-                    </div>
-                    <div class="top_nav_item it3"><span class="top_nav_item_text">EXPLORE</span><div class="top_nav_icon icon_4" title="Explore"></div></div>
-                    <div class="top_nav_item it4"><span class="top_nav_item_text">ECONOMY</span><div class="top_nav_icon icon_5" title="Economy"></div></div>
-                    <div class="top_nav_item it5"><span class="top_nav_item_text">COLLECTION</span><div class="top_nav_icon icon_6" title="Collection"></div></div>
-                </div>
-                <div class="top_nav_info">
-                    <div class="flex_item" style="margin-left: auto;">
-                        <div class="top_nav_item it7">
-                            <div class="top_constructed_rank"></div>
-                        </div>
-                        <div class="top_nav_item it8">
-                            <div class="top_limited_rank"></div>
-                        </div>
-                        <div class="top_patreon"></div>
-                        <div class="top_username" title="Arena username"></div>
-                        <div class="top_username_id" title="Arena user ID"></div>
-                    </div>
-                </div>
+                <!-- Now featuring; React! -->
             </div>
 
             <div class="loading_bar_main main_loading" style="display: none"><div class="loading_color loading_w"></div><div class="loading_color loading_u"></div><div class="loading_color loading_b"></div><div class="loading_color loading_r"></div><div class="loading_color loading_g"></div></div>

--- a/src/window_main/renderer-util.js
+++ b/src/window_main/renderer-util.js
@@ -1,6 +1,6 @@
 import fs from "fs";
 import path from "path";
-import { app, ipcRenderer as ipc, remote } from "electron";
+import { app, ipcRenderer as ipc, remote, shell } from "electron";
 const { dialog } = remote;
 import _ from "lodash";
 import anime from "animejs";
@@ -42,6 +42,7 @@ import {
 } from "../shared/util";
 import ReactDOM from "react-dom";
 import createShareButton from "./createShareButton";
+import { openSettingsTab } from "./settings";
 
 const DEFAULT_BACKGROUND = "../images/Bedevil-Art.jpg";
 
@@ -1033,6 +1034,37 @@ function draftShareLink(id, draft) {
   ipcSend("request_draft_link", { expire, id, draftData });
 }
 
+function showOfflineSplash() {
+  hideLoadingBars();
+  byId("ux_0").innerHTML = `
+  <div class="message_center_offline" style="display: flex; position: fixed;">
+    <div class="message_unlink"></div>
+    <div class="message_big red">Oops, you are offline!</div>
+    <div class="message_sub_16 white">To access online features:</div>
+    <div class="message_sub_16 white">If you are logged in, you may need to <a class="privacy_link">enable online sharing</a> and restart.</div>
+    <div class="message_sub_16 white">If you are in offline mode, you can <a class="launch_login_link">login to your account</a>.</div>
+    <div class="message_sub_16 white">If you need an account, you can <a class="signup_link">sign up here</a>.</div>
+  </div>`;
+  $$(".privacy_link")[0].addEventListener("click", function() {
+    force_open_settings(SETTINGS_PRIVACY);
+  });
+  $$(".launch_login_link")[0].addEventListener("click", function() {
+    const clearAppSettings = {
+      remember_me: false,
+      auto_login: false,
+      launch_to_tray: false
+    };
+    ipcSend("save_app_settings", clearAppSettings);
+    remote.app.relaunch();
+    remote.app.exit(0);
+  });
+  $$(".signup_link")[0].addEventListener("click", function() {
+    shell.openExternal("https://mtgatool.com/signup/");
+  });
+}
+
+
+
 export {
   actionLogDir,
   ipcSend,
@@ -1064,5 +1096,6 @@ export {
   compareWinrates,
   compareColorWinrates,
   localTimeSince,
-  attachMatchData
+  attachMatchData,
+  showOfflineSplash
 };

--- a/src/window_main/renderer-util.js
+++ b/src/window_main/renderer-util.js
@@ -13,7 +13,8 @@ import {
   MANA_COLORS,
   IPC_MAIN,
   IPC_BACKGROUND,
-  EASING_DEFAULT
+  EASING_DEFAULT,
+  SETTINGS_PRIVACY
 } from "../shared/constants";
 import db from "../shared/database";
 import pd from "../shared/player-data";
@@ -42,7 +43,7 @@ import {
 } from "../shared/util";
 import ReactDOM from "react-dom";
 import createShareButton from "./createShareButton";
-import { openSettingsTab } from "./settings";
+import { force_open_settings } from "./tabControl";
 
 const DEFAULT_BACKGROUND = "../images/Bedevil-Art.jpg";
 
@@ -1062,8 +1063,6 @@ function showOfflineSplash() {
     shell.openExternal("https://mtgatool.com/signup/");
   });
 }
-
-
 
 export {
   actionLogDir,

--- a/src/window_main/renderer.js
+++ b/src/window_main/renderer.js
@@ -41,7 +41,7 @@ import { createDiv, queryElements as $$ } from "../shared/dom-fns";
 import {
   compare_cards,
   get_deck_colors,
-  removeDuplicates,
+  removeDuplicates
 } from "../shared/util";
 
 import {

--- a/src/window_main/renderer.js
+++ b/src/window_main/renderer.js
@@ -143,11 +143,11 @@ function showLogin() {
 function updateTopBar() {
   const topNavDiv = $$(".top_nav_container")[0];
   createTopNav(topNavDiv);
-  /*
+
   if (pd.offline || !pd.settings.send_data) {
     $$(".unlink")[0].style.display = "block";
   }
-
+  /*
   if (pd.name) {
     $$(".top_username")[0].innerHTML = pd.name.slice(0, -6);
     $$(".top_username_id")[0].innerHTML = pd.name.slice(-6);
@@ -413,8 +413,6 @@ ipc.on("no_log", function(event, arg) {
 ipc.on("offline", function() {
   showOfflineSplash();
 });
-
-
 
 //
 ipc.on("log_read", function() {

--- a/src/window_main/renderer.js
+++ b/src/window_main/renderer.js
@@ -73,6 +73,8 @@ import { openCollectionTab } from "./collection";
 import { openSettingsTab, setCurrentOverlaySettings } from "./settings";
 import { showWhatsNew } from "./whats-new";
 
+import createTopNav from "./topNav";
+
 const byId = id => document.getElementById(id);
 let sidebarActive = MAIN_LOGIN;
 let loggedIn = false;
@@ -163,6 +165,9 @@ function updateNavIcons() {
 }
 
 function updateTopBar() {
+  const topNavDiv = $$(".top_nav_container")[0];
+  createTopNav(topNavDiv);
+/*
   updateNavIcons();
 
   if (pd.offline || !pd.settings.send_data) {
@@ -213,6 +218,7 @@ function updateTopBar() {
   } else {
     patreonIcon.style.display = "none";
   }
+  */
 }
 
 //

--- a/src/window_main/renderer.js
+++ b/src/window_main/renderer.js
@@ -140,33 +140,10 @@ function showLogin() {
   byId("signin_user").focus();
 }
 
-//
-function updateNavIcons() {
-  if ($$(".top_nav_icons")[0].offsetWidth < 530) {
-    if (!top_compact) {
-      $$("span.top_nav_item_text").forEach(el => (el.style.opacity = 0));
-      $$(".top_nav_icon").forEach(el => (el.style.display = "block"));
-      $$(".top_nav_icon").forEach(el => (el.style.opacity = 1));
-      top_compact = true;
-    }
-  } else {
-    if (top_compact) {
-      $$("span.top_nav_item_text").forEach(el => (el.style.opacity = 1));
-      $$(".top_nav_icon").forEach(el => (el.style.opacity = 0));
-      window.setTimeout(() => {
-        $$(".top_nav_icon").forEach(el => (el.style.display = "none"));
-      }, 500);
-      top_compact = false;
-    }
-  }
-}
-
 function updateTopBar() {
   const topNavDiv = $$(".top_nav_container")[0];
   createTopNav(topNavDiv);
   /*
-  updateNavIcons();
-
   if (pd.offline || !pd.settings.send_data) {
     $$(".unlink")[0].style.display = "block";
   }
@@ -453,14 +430,11 @@ ipc.on("popup", function(event, arg, time) {
 });
 
 
-
-//
-let top_compact = false;
 let resizeTimer;
 window.addEventListener("resize", () => {
   hideLoadingBars();
   clearTimeout(resizeTimer);
-  resizeTimer = setTimeout(updateNavIcons, 100);
+  resizeTimer = setTimeout(updateTopBar, 100);
 });
 
 function ready(fn) {

--- a/src/window_main/renderer.js
+++ b/src/window_main/renderer.js
@@ -64,8 +64,8 @@ import { showWhatsNew } from "./whats-new";
 import { showOfflineSplash } from "./renderer-util";
 import { setExploreDecks } from "./explore";
 
-import { openTab } from "./tabControl";
-import createTopNav from "./topNav";
+import { openTab, forceOpenAbout, forceOpenSettings } from "./tabControl";
+import { updateTopBar } from "./topNav";
 
 const byId = id => document.getElementById(id);
 let loggedIn = false;
@@ -132,15 +132,6 @@ function showLogin() {
 
   $$(".button_simple_disabled")[0].classList.add("button_simple");
   byId("signin_user").focus();
-}
-
-function updateTopBar() {
-  const topNavDiv = $$(".top_nav_container")[0];
-  createTopNav(topNavDiv);
-
-  if (pd.offline || !pd.settings.send_data) {
-    $$(".unlink")[0].style.display = "block";
-  }
 }
 
 //
@@ -249,7 +240,7 @@ ipc.on("show_notification", function(event, arg) {
 
   if (arg === "Update available" || arg === "Update downloaded") {
     const handler = () => {
-      force_open_about();
+      forceOpenAbout();
       notification.removeEventListener("click", handler);
     };
     notification.addEventListener("click", handler);
@@ -265,18 +256,18 @@ ipc.on("hide_notification", function() {
 
 //
 ipc.on("force_open_settings", function() {
-  force_open_settings();
+  forceOpenSettings();
 });
 
 //
 ipc.on("force_open_overlay_settings", function(event, arg) {
   setCurrentOverlaySettings(arg);
-  force_open_settings(SETTINGS_OVERLAY);
+  forceOpenSettings(SETTINGS_OVERLAY);
 });
 
 //
 ipc.on("force_open_about", function() {
-  force_open_about();
+  forceOpenAbout();
 });
 
 //
@@ -411,7 +402,7 @@ ready(function() {
   $$(".version_number")[0].innerHTML = `v${remote.app.getVersion()}`;
 
   $$(".version_number")[0].addEventListener("click", function() {
-    force_open_settings(SETTINGS_ABOUT);
+    forceOpenSettings(SETTINGS_ABOUT);
   });
 
   $$(".signup_link")[0].addEventListener("click", function() {
@@ -457,31 +448,12 @@ ready(function() {
 
   //
   $$(".settings")[0].addEventListener("click", function() {
-    force_open_settings();
+    forceOpenSettings();
   });
 });
 
-function force_open_settings(section = -1) {
-  anime({
-    targets: ".moving_ux",
-    left: 0,
-    easing: EASING_DEFAULT,
-    duration: 350
-  });
-  openSettingsTab(section, 0);
-  updateTopBar();
-}
 
-function force_open_about() {
-  anime({
-    targets: ".moving_ux",
-    left: 0,
-    easing: EASING_DEFAULT,
-    duration: 350
-  });
-  openSettingsTab(SETTINGS_ABOUT, 0);
-  updateTopBar();
-}
+
 
 //
 ipc.on("set_draft_link", function(event, arg) {

--- a/src/window_main/renderer.js
+++ b/src/window_main/renderer.js
@@ -63,16 +63,13 @@ import {
 import Aggregator from "./aggregator";
 import { openHomeTab, requestHome } from "./home";
 import { tournamentOpen } from "./tournaments";
-import { openDecksTab } from "./decks";
 import { openDeck } from "./deck-details";
-import { openHistoryTab } from "./history";
-import { openEventsTab } from "./events";
-import { openEconomyTab } from "./economy";
-import { openExploreTab, setExploreDecks } from "./explore";
-import { openCollectionTab } from "./collection";
 import { openSettingsTab, setCurrentOverlaySettings } from "./settings";
 import { showWhatsNew } from "./whats-new";
+import { showOfflineSplash } from "./renderer-util";
+import { setExploreDecks } from "./explore";
 
+import { openTab } from "./tabControl";
 import createTopNav from "./topNav";
 
 const byId = id => document.getElementById(id);
@@ -167,7 +164,7 @@ function updateNavIcons() {
 function updateTopBar() {
   const topNavDiv = $$(".top_nav_container")[0];
   createTopNav(topNavDiv);
-/*
+  /*
   updateNavIcons();
 
   if (pd.offline || !pd.settings.send_data) {
@@ -394,63 +391,6 @@ function rememberMe() {
   };
   ipcSend("save_app_settings", rSettings);
 }
-
-//
-function openTab(tab, filters = {}, dataIndex = 0, scrollTop = 0) {
-  showLoadingBars();
-  $$(".top_nav_item").forEach(el => el.classList.remove("item_selected"));
-  let tabClass = "it" + tab;
-  resetMainContainer();
-  switch (tab) {
-    case 0:
-      openDecksTab(filters, scrollTop);
-      break;
-    case 1:
-      openHistoryTab(filters, dataIndex, scrollTop);
-      break;
-    case 2:
-      openEventsTab(filters, dataIndex, scrollTop);
-      break;
-    case 3:
-      if (pd.offline) {
-        showOfflineSplash();
-      } else {
-        openExploreTab();
-      }
-      break;
-    case 4:
-      openEconomyTab(dataIndex, scrollTop);
-      break;
-    case 5:
-      openCollectionTab();
-      break;
-    case 6:
-      tabClass = "ith";
-      openSettingsTab(-1, scrollTop);
-      break;
-    case -1:
-      tabClass = "ith";
-      if (pd.offline) {
-        showOfflineSplash();
-      } else {
-        if (getLocalState().discordTag === null) {
-          openHomeTab(null, true);
-        } else {
-          requestHome();
-        }
-      }
-      break;
-    case -2:
-    default:
-      // $$(".message_center")[0].style.display = "initial";
-      hideLoadingBars();
-      $$(".init_loading")[0].style.display = "block";
-      break;
-  }
-  if ($$("." + tabClass)[0])
-    $$("." + tabClass)[0].classList.add("item_selected");
-}
-
 //
 ipc.on("initialize", function() {
   showLoadingBars();
@@ -497,35 +437,7 @@ ipc.on("offline", function() {
   showOfflineSplash();
 });
 
-//
-function showOfflineSplash() {
-  hideLoadingBars();
-  byId("ux_0").innerHTML = `
-  <div class="message_center_offline" style="display: flex; position: fixed;">
-    <div class="message_unlink"></div>
-    <div class="message_big red">Oops, you are offline!</div>
-    <div class="message_sub_16 white">To access online features:</div>
-    <div class="message_sub_16 white">If you are logged in, you may need to <a class="privacy_link">enable online sharing</a> and restart.</div>
-    <div class="message_sub_16 white">If you are in offline mode, you can <a class="launch_login_link">login to your account</a>.</div>
-    <div class="message_sub_16 white">If you need an account, you can <a class="signup_link">sign up here</a>.</div>
-  </div>`;
-  $$(".privacy_link")[0].addEventListener("click", function() {
-    force_open_settings(SETTINGS_PRIVACY);
-  });
-  $$(".launch_login_link")[0].addEventListener("click", function() {
-    const clearAppSettings = {
-      remember_me: false,
-      auto_login: false,
-      launch_to_tray: false
-    };
-    ipcSend("save_app_settings", clearAppSettings);
-    remote.app.relaunch();
-    remote.app.exit(0);
-  });
-  $$(".signup_link")[0].addEventListener("click", function() {
-    shell.openExternal("https://mtgatool.com/signup/");
-  });
-}
+
 
 //
 ipc.on("log_read", function() {
@@ -540,31 +452,7 @@ ipc.on("popup", function(event, arg, time) {
   pop(arg, time);
 });
 
-//
-function force_open_settings(section = -1) {
-  sidebarActive = MAIN_SETTINGS;
-  anime({
-    targets: ".moving_ux",
-    left: 0,
-    easing: EASING_DEFAULT,
-    duration: 350
-  });
-  $$(".top_nav_item").forEach(el => el.classList.remove("item_selected"));
-  openSettingsTab(section, 0);
-}
 
-//
-function force_open_about() {
-  sidebarActive = MAIN_UPDATE;
-  anime({
-    targets: ".moving_ux",
-    left: 0,
-    easing: EASING_DEFAULT,
-    duration: 350
-  });
-  $$(".top_nav_item").forEach(el => el.classList.remove("item_selected"));
-  openSettingsTab(SETTINGS_ABOUT, 0);
-}
 
 //
 let top_compact = false;
@@ -719,6 +607,31 @@ ready(function() {
     });
   });
 });
+
+
+function force_open_settings(section = -1) {
+  sidebarActive = MAIN_SETTINGS;
+  anime({
+    targets: ".moving_ux",
+    left: 0,
+    easing: EASING_DEFAULT,
+    duration: 350
+  });
+  $$(".top_nav_item").forEach(el => el.classList.remove("item_selected"));
+  openSettingsTab(section, 0);
+}
+
+function force_open_about() {
+  sidebarActive = MAIN_UPDATE;
+  anime({
+    targets: ".moving_ux",
+    left: 0,
+    easing: EASING_DEFAULT,
+    duration: 350
+  });
+  $$(".top_nav_item").forEach(el => el.classList.remove("item_selected"));
+  openSettingsTab(SETTINGS_ABOUT, 0);
+}
 
 //
 //ipc.on("show_loading", () => showLoadingBars());

--- a/src/window_main/renderer.js
+++ b/src/window_main/renderer.js
@@ -452,9 +452,6 @@ ready(function() {
   });
 });
 
-
-
-
 //
 ipc.on("set_draft_link", function(event, arg) {
   hideLoadingBars();

--- a/src/window_main/renderer.js
+++ b/src/window_main/renderer.js
@@ -429,12 +429,9 @@ ipc.on("popup", function(event, arg, time) {
   pop(arg, time);
 });
 
-
-let resizeTimer;
 window.addEventListener("resize", () => {
   hideLoadingBars();
-  clearTimeout(resizeTimer);
-  resizeTimer = setTimeout(updateTopBar, 100);
+  updateTopBar();
 });
 
 function ready(fn) {

--- a/src/window_main/tabControl.ts
+++ b/src/window_main/tabControl.ts
@@ -1,0 +1,83 @@
+import {
+    MAIN_HOME ,
+    MAIN_DECKS,
+    MAIN_HISTORY,
+    MAIN_EVENTS,
+    MAIN_EXPLORE,
+    MAIN_ECONOMY,
+    MAIN_COLLECTION,
+    MAIN_SETTINGS
+} from "../shared/constants";
+import { queryElements as $$ } from "../shared/dom-fns";
+import pd from "../shared/player-data";
+
+import {
+  getLocalState,
+  hideLoadingBars,
+  resetMainContainer,
+  showLoadingBars
+} from "./renderer-util";
+
+import { openDecksTab } from "./decks";
+import { openHistoryTab } from "./history";
+import { openEventsTab } from "./events";
+import { openEconomyTab } from "./economy";
+import { openExploreTab } from "./explore";
+import { openCollectionTab } from "./collection";
+import { showOfflineSplash } from "./renderer-util";
+import { openSettingsTab } from "./settings";
+import { openHomeTab, requestHome } from "./home";
+
+//
+export function openTab(tab:number, filters = {}, dataIndex = 0, scrollTop = 0) {
+    showLoadingBars();
+    $$(".top_nav_item").forEach(el => el.classList.remove("item_selected"));
+    let tabClass = "it" + tab;
+    resetMainContainer();
+    switch (tab) {
+      case MAIN_DECKS:
+        openDecksTab(filters, scrollTop);
+        break;
+      case MAIN_HISTORY:
+        openHistoryTab(filters, dataIndex, scrollTop);
+        break;
+      case MAIN_EVENTS:
+        openEventsTab(filters, dataIndex, scrollTop);
+        break;
+      case MAIN_EXPLORE:
+        if (pd.offline) {
+          showOfflineSplash();
+        } else {
+          openExploreTab();
+        }
+        break;
+      case MAIN_ECONOMY:
+        openEconomyTab(dataIndex, scrollTop);
+        break;
+      case MAIN_COLLECTION:
+        openCollectionTab();
+        break;
+      case MAIN_SETTINGS:
+        tabClass = "ith";
+        openSettingsTab(-1, scrollTop);
+        break;
+      case MAIN_HOME:
+        tabClass = "ith";
+        if (pd.offline) {
+          showOfflineSplash();
+        } else {
+          if (getLocalState().discordTag === null) {
+            openHomeTab(null, true);
+          } else {
+            requestHome();
+          }
+        }
+        break;
+      default:
+        hideLoadingBars();
+        $$(".init_loading")[0].style.display = "block";
+        break;
+    }
+    if ($$("." + tabClass)[0])
+      $$("." + tabClass)[0].classList.add("item_selected");
+  }

--- a/src/window_main/tabControl.ts
+++ b/src/window_main/tabControl.ts
@@ -1,16 +1,16 @@
 import {
-    EASING_DEFAULT,
-    DATE_SEASON,
-    MAIN_HOME ,
-    MAIN_DECKS,
-    MAIN_HISTORY,
-    MAIN_EVENTS,
-    MAIN_EXPLORE,
-    MAIN_ECONOMY,
-    MAIN_COLLECTION,
-    MAIN_SETTINGS,
-    MAIN_CONSTRUCTED,
-    MAIN_LIMITED
+  EASING_DEFAULT,
+  DATE_SEASON,
+  MAIN_HOME ,
+  MAIN_DECKS,
+  MAIN_HISTORY,
+  MAIN_EVENTS,
+  MAIN_EXPLORE,
+  MAIN_ECONOMY,
+  MAIN_COLLECTION,
+  MAIN_SETTINGS,
+  MAIN_CONSTRUCTED,
+  MAIN_LIMITED
 } from "../shared/constants";
 
 import { queryElements as $$ } from "../shared/dom-fns";
@@ -41,8 +41,6 @@ import { openHomeTab, requestHome } from "./home";
 //
 export function openTab(tab:number, filters = {}, dataIndex = 0, scrollTop = 0) {
   showLoadingBars();
-  //$$(".top_nav_item").forEach(el => el.classList.remove("item_selected"));
-  let tabClass = "it" + tab;
   resetMainContainer();
   switch (tab) {
     case MAIN_DECKS:
@@ -68,11 +66,9 @@ export function openTab(tab:number, filters = {}, dataIndex = 0, scrollTop = 0) 
       openCollectionTab();
       break;
     case MAIN_SETTINGS:
-      tabClass = "ith";
       openSettingsTab(-1, scrollTop);
       break;
     case MAIN_HOME:
-      tabClass = "ith";
       if (pd.offline) {
         showOfflineSplash();
       } else {
@@ -85,59 +81,49 @@ export function openTab(tab:number, filters = {}, dataIndex = 0, scrollTop = 0) 
       break;
     default:
       hideLoadingBars();
-      $$(".init_loading")[0].style.display = "block";
+      //$$(".init_loading")[0].style.display = "block";
       break;
   }
-  if ($$("." + tabClass)[0])
-    $$("." + tabClass)[0].classList.add("item_selected");
 }
 
-export function clickNav(id:number) {
+export function clickNav(id:number, selected:boolean) {
   changeBackground("default");
   document.body.style.cursor = "auto";
-  //if (!selected)
-      anime({
-          targets: ".moving_ux",
-          left: 0,
-          easing: EASING_DEFAULT,
-          duration: 350
-      });
+  anime({
+    targets: ".moving_ux",
+    left: 0,
+    easing: EASING_DEFAULT,
+    duration: 350
+  });
+  if (!selected) {
+    let filters = { date: pd.settings.last_date_filter, eventId: "All Events", rankedMode: false };
+    let sidebarActive = id;
 
-      let filters = { date: pd.settings.last_date_filter, eventId: "", rankedMode: false };
-      const sidebarActive = id;
+    if (id == MAIN_CONSTRUCTED) {
+      sidebarActive = MAIN_HISTORY;
+      filters = {
+        ...Aggregator.getDefaultFilters(),
+        date: DATE_SEASON,
+        eventId: Aggregator.RANKED_CONST,
+        rankedMode: true
+      };
+    }
+    if (id == MAIN_LIMITED) {
+      sidebarActive = MAIN_HISTORY;
+      filters = {
+        ...Aggregator.getDefaultFilters(),
+        date: DATE_SEASON,
+        eventId: Aggregator.RANKED_DRAFT,
+        rankedMode: true
+      };
+    }
 
-      if (id == MAIN_CONSTRUCTED) {
-          filters = {
-              ...Aggregator.getDefaultFilters(),
-              date: DATE_SEASON,
-              eventId: Aggregator.RANKED_CONST,
-              rankedMode: true
-          };
-      }
-      if (id == MAIN_LIMITED) {
-          filters = {
-              ...Aggregator.getDefaultFilters(),
-              date: DATE_SEASON,
-              eventId: Aggregator.RANKED_DRAFT,
-              rankedMode: true
-          };
-      }
-
-      setLocalState({ lastDataIndex: 0, lastScrollTop: 0 });
-      openTab(sidebarActive, filters);
-      ipcSend("save_user_settings", {
-          last_open_tab: sidebarActive,
-          last_date_filter: filters.date,
-          skip_refresh: true
-      });
-  /*
-  } else {
-    anime({
-      targets: ".moving_ux",
-      left: 0,
-      easing: EASING_DEFAULT,
-      duration: 350
+    setLocalState({ lastDataIndex: 0, lastScrollTop: 0 });
+    openTab(sidebarActive, filters);
+    ipcSend("save_user_settings", {
+      last_open_tab: sidebarActive,
+      last_date_filter: filters.date,
+      skip_refresh: true
     });
   }
-  */
 }

--- a/src/window_main/tabControl.ts
+++ b/src/window_main/tabControl.ts
@@ -10,10 +10,11 @@ import {
   MAIN_COLLECTION,
   MAIN_SETTINGS,
   MAIN_CONSTRUCTED,
-  MAIN_LIMITED
+  MAIN_LIMITED,
+  SETTINGS_ABOUT
 } from "../shared/constants";
 
-import { queryElements as $$ } from "../shared/dom-fns";
+import { updateTopBar } from "./topNav";
 import pd from "../shared/player-data";
 import Aggregator from "./aggregator";
 import anime from "animejs";
@@ -86,7 +87,7 @@ export function openTab(tab:number, filters = {}, dataIndex = 0, scrollTop = 0) 
   }
 }
 
-export function clickNav(id:number, selected:boolean) {
+export function clickNav(id:number) {
   changeBackground("default");
   document.body.style.cursor = "auto";
   anime({
@@ -95,35 +96,65 @@ export function clickNav(id:number, selected:boolean) {
     easing: EASING_DEFAULT,
     duration: 350
   });
-  if (!selected) {
-    let filters = { date: pd.settings.last_date_filter, eventId: "All Events", rankedMode: false };
-    let sidebarActive = id;
+  let filters = { date: pd.settings.last_date_filter, eventId: "All Events", rankedMode: false };
+  let sidebarActive = id;
 
-    if (id == MAIN_CONSTRUCTED) {
-      sidebarActive = MAIN_HISTORY;
-      filters = {
-        ...Aggregator.getDefaultFilters(),
-        date: DATE_SEASON,
-        eventId: Aggregator.RANKED_CONST,
-        rankedMode: true
-      };
-    }
-    if (id == MAIN_LIMITED) {
-      sidebarActive = MAIN_HISTORY;
-      filters = {
-        ...Aggregator.getDefaultFilters(),
-        date: DATE_SEASON,
-        eventId: Aggregator.RANKED_DRAFT,
-        rankedMode: true
-      };
-    }
-
-    setLocalState({ lastDataIndex: 0, lastScrollTop: 0 });
-    openTab(sidebarActive, filters);
-    ipcSend("save_user_settings", {
-      last_open_tab: sidebarActive,
-      last_date_filter: filters.date,
-      skip_refresh: true
-    });
+  if (id === MAIN_CONSTRUCTED) {
+    sidebarActive = MAIN_HISTORY;
+    filters = {
+      ...Aggregator.getDefaultFilters(),
+      date: DATE_SEASON,
+      eventId: Aggregator.RANKED_CONST,
+      rankedMode: true
+    };
   }
+  if (id === MAIN_LIMITED) {
+    sidebarActive = MAIN_HISTORY;
+    filters = {
+      ...Aggregator.getDefaultFilters(),
+      date: DATE_SEASON,
+      eventId: Aggregator.RANKED_DRAFT,
+      rankedMode: true
+    };
+  }
+
+  setLocalState({ lastDataIndex: 0, lastScrollTop: 0 });
+  openTab(sidebarActive, filters);
+  ipcSend("save_user_settings", {
+    last_open_tab: sidebarActive,
+    last_date_filter: filters.date,
+    skip_refresh: true
+  });
+}
+
+export function forceOpenAbout() {
+  anime({
+    targets: ".moving_ux",
+    left: 0,
+    easing: EASING_DEFAULT,
+    duration: 350
+  });
+
+  ipcSend("save_user_settings", {
+    last_open_tab: MAIN_SETTINGS
+  });
+
+  openSettingsTab(SETTINGS_ABOUT, 0);
+  updateTopBar();
+}
+
+export function forceOpenSettings(section = -1) {
+  anime({
+    targets: ".moving_ux",
+    left: 0,
+    easing: EASING_DEFAULT,
+    duration: 350
+  });
+
+  ipcSend("save_user_settings", {
+    last_open_tab: MAIN_SETTINGS
+  });
+
+  openSettingsTab(section, 0);
+  updateTopBar();
 }

--- a/src/window_main/tabControl.ts
+++ b/src/window_main/tabControl.ts
@@ -1,4 +1,6 @@
 import {
+    EASING_DEFAULT,
+    DATE_SEASON,
     MAIN_HOME ,
     MAIN_DECKS,
     MAIN_HISTORY,
@@ -6,13 +8,21 @@ import {
     MAIN_EXPLORE,
     MAIN_ECONOMY,
     MAIN_COLLECTION,
-    MAIN_SETTINGS
+    MAIN_SETTINGS,
+    MAIN_CONSTRUCTED,
+    MAIN_LIMITED
 } from "../shared/constants";
+
 import { queryElements as $$ } from "../shared/dom-fns";
 import pd from "../shared/player-data";
+import Aggregator from "./aggregator";
+import anime from "animejs";
 
 import {
+  changeBackground,
+  ipcSend,
   getLocalState,
+  setLocalState,
   hideLoadingBars,
   resetMainContainer,
   showLoadingBars
@@ -30,54 +40,104 @@ import { openHomeTab, requestHome } from "./home";
 
 //
 export function openTab(tab:number, filters = {}, dataIndex = 0, scrollTop = 0) {
-    showLoadingBars();
-    $$(".top_nav_item").forEach(el => el.classList.remove("item_selected"));
-    let tabClass = "it" + tab;
-    resetMainContainer();
-    switch (tab) {
-      case MAIN_DECKS:
-        openDecksTab(filters, scrollTop);
-        break;
-      case MAIN_HISTORY:
-        openHistoryTab(filters, dataIndex, scrollTop);
-        break;
-      case MAIN_EVENTS:
-        openEventsTab(filters, dataIndex, scrollTop);
-        break;
-      case MAIN_EXPLORE:
-        if (pd.offline) {
-          showOfflineSplash();
+  showLoadingBars();
+  //$$(".top_nav_item").forEach(el => el.classList.remove("item_selected"));
+  let tabClass = "it" + tab;
+  resetMainContainer();
+  switch (tab) {
+    case MAIN_DECKS:
+      openDecksTab(filters, scrollTop);
+      break;
+    case MAIN_HISTORY:
+      openHistoryTab(filters, dataIndex, scrollTop);
+      break;
+    case MAIN_EVENTS:
+      openEventsTab(filters, dataIndex, scrollTop);
+      break;
+    case MAIN_EXPLORE:
+      if (pd.offline) {
+        showOfflineSplash();
+      } else {
+        openExploreTab();
+      }
+      break;
+    case MAIN_ECONOMY:
+      openEconomyTab(dataIndex, scrollTop);
+      break;
+    case MAIN_COLLECTION:
+      openCollectionTab();
+      break;
+    case MAIN_SETTINGS:
+      tabClass = "ith";
+      openSettingsTab(-1, scrollTop);
+      break;
+    case MAIN_HOME:
+      tabClass = "ith";
+      if (pd.offline) {
+        showOfflineSplash();
+      } else {
+        if (getLocalState().discordTag === null) {
+          openHomeTab(null, true);
         } else {
-          openExploreTab();
+          requestHome();
         }
-        break;
-      case MAIN_ECONOMY:
-        openEconomyTab(dataIndex, scrollTop);
-        break;
-      case MAIN_COLLECTION:
-        openCollectionTab();
-        break;
-      case MAIN_SETTINGS:
-        tabClass = "ith";
-        openSettingsTab(-1, scrollTop);
-        break;
-      case MAIN_HOME:
-        tabClass = "ith";
-        if (pd.offline) {
-          showOfflineSplash();
-        } else {
-          if (getLocalState().discordTag === null) {
-            openHomeTab(null, true);
-          } else {
-            requestHome();
-          }
-        }
-        break;
-      default:
-        hideLoadingBars();
-        $$(".init_loading")[0].style.display = "block";
-        break;
-    }
-    if ($$("." + tabClass)[0])
-      $$("." + tabClass)[0].classList.add("item_selected");
+      }
+      break;
+    default:
+      hideLoadingBars();
+      $$(".init_loading")[0].style.display = "block";
+      break;
   }
+  if ($$("." + tabClass)[0])
+    $$("." + tabClass)[0].classList.add("item_selected");
+}
+
+export function clickNav(id:number) {
+  changeBackground("default");
+  document.body.style.cursor = "auto";
+  //if (!selected)
+      anime({
+          targets: ".moving_ux",
+          left: 0,
+          easing: EASING_DEFAULT,
+          duration: 350
+      });
+
+      let filters = { date: pd.settings.last_date_filter, eventId: "", rankedMode: false };
+      const sidebarActive = id;
+
+      if (id == MAIN_CONSTRUCTED) {
+          filters = {
+              ...Aggregator.getDefaultFilters(),
+              date: DATE_SEASON,
+              eventId: Aggregator.RANKED_CONST,
+              rankedMode: true
+          };
+      }
+      if (id == MAIN_LIMITED) {
+          filters = {
+              ...Aggregator.getDefaultFilters(),
+              date: DATE_SEASON,
+              eventId: Aggregator.RANKED_DRAFT,
+              rankedMode: true
+          };
+      }
+
+      setLocalState({ lastDataIndex: 0, lastScrollTop: 0 });
+      openTab(sidebarActive, filters);
+      ipcSend("save_user_settings", {
+          last_open_tab: sidebarActive,
+          last_date_filter: filters.date,
+          skip_refresh: true
+      });
+  /*
+  } else {
+    anime({
+      targets: ".moving_ux",
+      left: 0,
+      easing: EASING_DEFAULT,
+      duration: 350
+    });
+  }
+  */
+}

--- a/src/window_main/topNav.tsx
+++ b/src/window_main/topNav.tsx
@@ -2,11 +2,16 @@ import _ from "lodash";
 import React, { useEffect } from "react";
 import ReactDOM from 'react-dom';
 import { queryElements as $$ } from "../shared/dom-fns";
-import { openTab } from "./tabControl";
+import { openTab, clickNav } from "./tabControl";
 import pd from "../shared/player-data";
 
 import {
-    MAIN_HOME ,
+    get_rank_index,
+    formatRank
+} from "../shared/util";
+
+import {
+    MAIN_HOME,
     MAIN_DECKS,
     MAIN_HISTORY,
     MAIN_EVENTS,
@@ -18,30 +23,63 @@ import {
 } from "../shared/constants";
 
 interface topNavItemProps {
+    currentTab: number,
     compact: boolean,
     id: number,
     title: string
 }
 
 function TopNavItem(props:topNavItemProps) {
-    const {compact, id, title} = props;
+    const {currentTab, compact, id, title} = props;
+
+    const selected = currentTab == id;
 
     const clickTab = React.useCallback((tabId: number) => (event: React.MouseEvent<HTMLDivElement>) => {
         if (!event.currentTarget.classList.contains("item_selected")) {
             $$(".top_nav_item").forEach(el => el.classList.remove("item_selected"));
             event.currentTarget.classList.add("item_selected");
+            clickNav(tabId);
             openTab(tabId);
         }
     }, [props.id]);
 
     return compact ? (
-        <div className={"top_nav_item_no_label top_nav_item it" + id} onClick={clickTab(id)}>
+        <div className={(selected ? "item_selected" : "") + " top_nav_item_no_label top_nav_item it" + id} onClick={clickTab(id)}>
             <div className={"top_nav_icon icon_" + id} title={_.camelCase(title)}></div>
         </div>
     ) : (
-        <div className={"top_nav_item it" + id + (title == "" ? " top_nav_item_no_label" : "")} onClick={clickTab(id)}>
+        <div className={(selected ? "item_selected" : "") + " top_nav_item it" + id + (title == "" ? " top_nav_item_no_label" : "")} onClick={clickTab(id)}>
             {title !== "" ? (<span className={"top_nav_item_text"}>{title}</span>) : 
             (<div className={"top_nav_icon icon_" + id} title={_.camelCase(title)}></div>)}
+        </div>
+    );
+}
+
+interface topRankProps {
+    currentTab: number,
+    id: number,
+    rank: any,
+    rankClass: string
+}
+
+function TopRankIcon(props:topRankProps) {
+    const {currentTab, id, rank, rankClass} = props;
+    
+    const selected = currentTab == id;
+
+    const clickTab = React.useCallback(() => (event: React.MouseEvent<HTMLDivElement>) => {
+        clickNav(id);
+    }, [props.id]);
+    
+
+   const propTitle = formatRank(rank);
+   const rankStyle = {
+       backgroundPosition: get_rank_index(rank.rank, rank.tier) * -48 + "px 0px"
+   };
+
+    return (
+        <div className={(selected ? "item_selected" : "") + " top_nav_item"} onClick={clickTab()}>
+            <div style={rankStyle} title={propTitle} className={rankClass}></div>
         </div>
     );
 }
@@ -71,16 +109,23 @@ function PatreonBadge(props: patreonProps) {
 
 function TopNav() {
     const [compact, setCompact] = React.useState(false);
-    const homeTab = {compact: compact, id: MAIN_HOME, title:""};
-    const myDecksTab = {compact: compact, id: MAIN_DECKS, title:"MY DECKS"};
-    const historyTab = {compact: compact, id: MAIN_HISTORY, title:"HISTORY"};
-    const eventsTab = {compact: compact, id: MAIN_EVENTS, title:"EVENTS"};
-    const exploreTab = {compact: compact, id: MAIN_EXPLORE, title:"EXPLORE"};
-    const economyTab = {compact: compact, id: MAIN_ECONOMY, title:"ECONOMY"};
-    const collectionTab = {compact: compact, id: MAIN_COLLECTION, title:"COLLECTION"};
+    const currentTab = pd.settings.last_open_tab;
 
-    const contructedNav = {compact: compact, id: MAIN_CONSTRUCTED, title:""};
-    const limitedNav = {compact: compact, id: MAIN_LIMITED, title:""};
+    const defaultTab = {
+        compact: compact,
+        currentTab: currentTab
+    }
+
+    const homeTab = {...defaultTab, id: MAIN_HOME, title:""};
+    const myDecksTab = {...defaultTab, id: MAIN_DECKS, title:"MY DECKS"};
+    const historyTab = {...defaultTab, id: MAIN_HISTORY, title:"HISTORY"};
+    const eventsTab = {...defaultTab, id: MAIN_EVENTS, title:"EVENTS"};
+    const exploreTab = {...defaultTab, id: MAIN_EXPLORE, title:"EXPLORE"};
+    const economyTab = {...defaultTab, id: MAIN_ECONOMY, title:"ECONOMY"};
+    const collectionTab = {...defaultTab, id: MAIN_COLLECTION, title:"COLLECTION"};
+
+    const contructedNav = {currentTab: currentTab, id: MAIN_CONSTRUCTED,rank: pd.rank.constructed, rankClass: "top_constructed_rank"};
+    const limitedNav = {currentTab: currentTab, id: MAIN_LIMITED,rank: pd.rank.limited, rankClass: "top_limited_rank"};
 
     React.useEffect(() => {
         if ($$(".top_nav_icons")[0].offsetWidth < 530) {
@@ -101,8 +146,8 @@ function TopNav() {
     let userNumerical = pd.name.slice(-6);
 
     return (
-        <div className={"top_nav"}>
-            <div className={"top_nav_icons"}>
+        <div className="top_nav">
+            <div className="top_nav_icons">
                 <TopNavItem {...homeTab}/>
                 <TopNavItem {...myDecksTab}/>
                 <TopNavItem {...historyTab}/>
@@ -111,12 +156,14 @@ function TopNav() {
                 <TopNavItem {...economyTab}/>
                 <TopNavItem {...collectionTab}/>
             </div>
-            <div className={"top_nav_info"}>
-                <TopNavItem {...contructedNav}/>
-                <TopNavItem {...limitedNav}/>
-                { pd.patreon ? <PatreonBadge {...patreon} /> : null }
-                <div className={"top_username"} title={"Arena username"}>{userName}</div>
-                <div className={"top_username_id"} title={"Arena user ID"}>{userNumerical}</div>
+            <div className="top_nav_info">
+                <div className="top_userdata_container">
+                    <TopRankIcon {...contructedNav}/>
+                    <TopRankIcon {...limitedNav}/>
+                    { pd.patreon ? <PatreonBadge {...patreon} /> : null }
+                    <div className="top_username" title={"Arena username"}>{userName}</div>
+                    <div className="top_username_id" title={"Arena user ID"}>{userNumerical}</div>
+                </div>
             </div>
         </div>
     );

--- a/src/window_main/topNav.tsx
+++ b/src/window_main/topNav.tsx
@@ -118,6 +118,7 @@ function PatreonBadge(props: patreonProps) {
 function TopNav() {
   const [compact, setCompact] = React.useState(false);
   const [currentTab, setCurrentTab] = React.useState(pd.settings.last_open_tab);
+  const topNavIconsRef:any = React.useRef(null);
 
   const defaultTab = {
     compact: compact,
@@ -150,7 +151,7 @@ function TopNav() {
   };
 
   React.useEffect(() => {
-    if ($$(".top_nav_icons")[0].offsetWidth < 530) {
+    if (topNavIconsRef.current.offsetWidth < 530) {
       if (!compact) {
         setCompact(true);
       }
@@ -169,7 +170,7 @@ function TopNav() {
 
   return (
     <div className="top_nav">
-      <div className="top_nav_icons">
+      <div ref={topNavIconsRef} className="top_nav_icons">
         <TopNavItem {...homeTab}/>
         <TopNavItem {...myDecksTab}/>
         <TopNavItem {...historyTab}/>

--- a/src/window_main/topNav.tsx
+++ b/src/window_main/topNav.tsx
@@ -39,8 +39,8 @@ function TopNavItem(props:topNavItemProps) {
         </div>
     ) : (
         <div className={"top_nav_item it" + id + (title == "" ? " top_nav_item_no_label" : "")} onClick={clickTab(id)}>
-            {title !== "" ? (<span className={"top_nav_item_text"}>{title}</span>) : false}
-            <div className={"top_nav_icon icon_" + id} title={_.camelCase(title)}></div>
+            {title !== "" ? (<span className={"top_nav_item_text"}>{title}</span>) : 
+            (<div className={"top_nav_icon icon_" + id} title={_.camelCase(title)}></div>)}
         </div>
     );
 }

--- a/src/window_main/topNav.tsx
+++ b/src/window_main/topNav.tsx
@@ -1,0 +1,63 @@
+import _ from "lodash";
+import mountReactComponent from "./mountReactComponent";
+import { createDiv } from "../shared/dom-fns";
+import React from "react";
+import ReactDOM from 'react-dom';
+
+interface topNavItemProps {
+    id: string,
+    title: string
+}
+
+function TopNavItem(props:topNavItemProps) {
+    const {id, title} = props;
+    return (
+        <div className={"top_nav_item it" + id}>
+            {title !== "" ? (<span className={"top_nav_item_text"}>{title}</span>) : false}
+            <div className={"top_nav_icon icon_" + id} title={_.camelCase(title)}></div>
+        </div>
+    );
+}
+
+function TopNav() {
+    const homeTab = {id: "h", title:""};
+    const myDecksTab = {id: "0", title:"MY DECKS"};
+    const historyTab = {id: "1", title:"HISTORY"};
+    const eventsTab = {id: "2", title:"EVENTS"};
+    const exploreTab = {id: "3", title:"EXPLORE"};
+    const economyTab = {id: "4", title:"ECONOMY"};
+    const collectionTab = {id: "5", title:"COLLECTION"};
+
+    const contructedNav = {id: "7", title:""};
+    const limitedNav = {id: "8", title:""};
+
+    return (
+        <div className={"top_nav"}>
+            <div className={"top_nav_icons"}>
+                <TopNavItem {...homeTab}/>
+                <TopNavItem {...myDecksTab}/>
+                <TopNavItem {...historyTab}/>
+                <TopNavItem {...eventsTab}/>
+                <TopNavItem {...exploreTab}/>
+                <TopNavItem {...economyTab}/>
+                <TopNavItem {...collectionTab}/>
+            </div>
+            <div className={"top_nav_info"}>
+                <TopNavItem {...contructedNav}/>
+                <TopNavItem {...limitedNav}/>
+                <div className={"top_patreon"}></div>
+                <div className={"top_username"} title={"Arena username"}></div>
+                <div className={"top_username_id"} title={"Arena user ID"}></div>
+            </div>
+        </div>
+    );
+}
+
+export default function createTopNav(parent: Element): boolean {
+    ReactDOM.render(
+        <TopNav />,
+        parent
+    );
+
+    return true;
+}

--- a/src/window_main/topNav.tsx
+++ b/src/window_main/topNav.tsx
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import React from "react";
+import React, { useEffect } from "react";
 import ReactDOM from 'react-dom';
 import { queryElements as $$ } from "../shared/dom-fns";
 import { openTab } from "./tabControl";
@@ -17,12 +17,13 @@ import {
 } from "../shared/constants";
 
 interface topNavItemProps {
+    compact: boolean,
     id: number,
     title: string
 }
 
 function TopNavItem(props:topNavItemProps) {
-    const {id, title} = props;
+    const {compact, id, title} = props;
 
     const clickTab = React.useCallback((tabId: number) => (event: React.MouseEvent<HTMLDivElement>) => {
         if (!event.currentTarget.classList.contains("item_selected")) {
@@ -32,8 +33,12 @@ function TopNavItem(props:topNavItemProps) {
         }
     }, [props.id]);
 
-    return (
-        <div className={"top_nav_item it" + id} onClick={clickTab(id)}>
+    return compact ? (
+        <div className={"top_nav_item_no_label top_nav_item it" + id} onClick={clickTab(id)}>
+            <div className={"top_nav_icon icon_" + id} title={_.camelCase(title)}></div>
+        </div>
+    ) : (
+        <div className={"top_nav_item it" + id + (title == "" ? " top_nav_item_no_label" : "")} onClick={clickTab(id)}>
             {title !== "" ? (<span className={"top_nav_item_text"}>{title}</span>) : false}
             <div className={"top_nav_icon icon_" + id} title={_.camelCase(title)}></div>
         </div>
@@ -41,16 +46,27 @@ function TopNavItem(props:topNavItemProps) {
 }
 
 function TopNav() {
-    const homeTab = {id: MAIN_HOME, title:""};
-    const myDecksTab = {id: MAIN_DECKS, title:"MY DECKS"};
-    const historyTab = {id: MAIN_HISTORY, title:"HISTORY"};
-    const eventsTab = {id: MAIN_EVENTS, title:"EVENTS"};
-    const exploreTab = {id: MAIN_EXPLORE, title:"EXPLORE"};
-    const economyTab = {id: MAIN_ECONOMY, title:"ECONOMY"};
-    const collectionTab = {id: MAIN_COLLECTION, title:"COLLECTION"};
+    const [compact, setCompact] = React.useState(false);
+    const homeTab = {compact: compact, id: MAIN_HOME, title:""};
+    const myDecksTab = {compact: compact, id: MAIN_DECKS, title:"MY DECKS"};
+    const historyTab = {compact: compact, id: MAIN_HISTORY, title:"HISTORY"};
+    const eventsTab = {compact: compact, id: MAIN_EVENTS, title:"EVENTS"};
+    const exploreTab = {compact: compact, id: MAIN_EXPLORE, title:"EXPLORE"};
+    const economyTab = {compact: compact, id: MAIN_ECONOMY, title:"ECONOMY"};
+    const collectionTab = {compact: compact, id: MAIN_COLLECTION, title:"COLLECTION"};
 
-    const contructedNav = {id: MAIN_CONSTRUCTED, title:""};
-    const limitedNav = {id: MAIN_LIMITED, title:""};
+    const contructedNav = {compact: compact, id: MAIN_CONSTRUCTED, title:""};
+    const limitedNav = {compact: compact, id: MAIN_LIMITED, title:""};
+
+    React.useEffect(() => {
+        if ($$(".top_nav_icons")[0].offsetWidth < 530) {
+            if (!compact) {
+                setCompact(true);
+            }
+        } else if (compact) {
+            setCompact(false);
+        }
+    });
 
     return (
         <div className={"top_nav"}>

--- a/src/window_main/topNav.tsx
+++ b/src/window_main/topNav.tsx
@@ -22,7 +22,7 @@ import {
   MAIN_LIMITED
 } from "../shared/constants";
 
-interface topNavItemProps {
+interface TopNavItemProps {
   currentTab: number,
   compact: boolean,
   id: number,
@@ -30,7 +30,7 @@ interface topNavItemProps {
   title: string
 }
 
-function TopNavItem(props:topNavItemProps) {
+function TopNavItem(props:TopNavItemProps) {
   const {currentTab, compact, id, callback, title} = props;
 
   const selected = currentTab === id;
@@ -120,14 +120,11 @@ function PatreonBadge(props: patreonProps) {
 function TopNav() {
   const [compact, setCompact] = React.useState(false);
   const [currentTab, setCurrentTab] = React.useState(pd.settings.last_open_tab);
-  const setCurrentTabCallback = (id:number) => {
-    setCurrentTab(id);
-  };
 
   const defaultTab = {
     compact: compact,
     currentTab: currentTab,
-    callback: setCurrentTabCallback
+    callback: setCurrentTab
   }
 
   const homeTab = {...defaultTab, id: MAIN_HOME, title:""};
@@ -139,7 +136,7 @@ function TopNav() {
   const collectionTab = {...defaultTab, id: MAIN_COLLECTION, title:"COLLECTION"};
   
   const contructedNav = {
-    callback: setCurrentTabCallback,
+    callback: setCurrentTab,
     currentTab: currentTab,
     id: MAIN_CONSTRUCTED,
     rank: pd.rank ? pd.rank.constructed : null,
@@ -147,7 +144,7 @@ function TopNav() {
   };
 
   const limitedNav = {
-    callback: setCurrentTabCallback,
+    callback: setCurrentTab,
     currentTab: currentTab,
     id: MAIN_LIMITED,
     rank: pd.rank ? pd.rank.limited : null,

--- a/src/window_main/topNav.tsx
+++ b/src/window_main/topNav.tsx
@@ -11,195 +11,195 @@ import {
 } from "../shared/util";
 
 import {
-    MAIN_HOME,
-    MAIN_DECKS,
-    MAIN_HISTORY,
-    MAIN_EVENTS,
-    MAIN_EXPLORE,
-    MAIN_ECONOMY,
-    MAIN_COLLECTION,
-    MAIN_CONSTRUCTED,
-    MAIN_LIMITED
+  MAIN_HOME,
+  MAIN_DECKS,
+  MAIN_HISTORY,
+  MAIN_EVENTS,
+  MAIN_EXPLORE,
+  MAIN_ECONOMY,
+  MAIN_COLLECTION,
+  MAIN_CONSTRUCTED,
+  MAIN_LIMITED
 } from "../shared/constants";
 
 interface topNavItemProps {
-    currentTab: number,
-    compact: boolean,
-    id: number,
-    callback: (id:number) => void,
-    title: string
+  currentTab: number,
+  compact: boolean,
+  id: number,
+  callback: (id:number) => void,
+  title: string
 }
 
 function TopNavItem(props:topNavItemProps) {
-    const {currentTab, compact, id, callback, title} = props;
+  const {currentTab, compact, id, callback, title} = props;
 
-    const selected = currentTab === id;
+  const selected = currentTab === id;
 
-    const clickTab = React.useCallback((tabId: number) => (event: React.MouseEvent<HTMLDivElement>) => {
-        clickNav(tabId, selected);
-        callback(tabId);
-    }, [props.id, props.callback]);
+  const clickTab = React.useCallback((tabId: number) => (event: React.MouseEvent<HTMLDivElement>) => {
+    clickNav(tabId, selected);
+    callback(tabId);
+  }, [props.id, props.callback]);
 
-    return compact ? (
-        <div className={(selected ? "item_selected" : "") + " top_nav_item_no_label top_nav_item it" + id} onClick={clickTab(id)}>
-            <div className={"top_nav_icon icon_" + id} title={_.camelCase(title)}></div>
-        </div>
-    ) : (
-        <div className={(selected ? "item_selected" : "") + " top_nav_item it" + id + (title == "" ? " top_nav_item_no_label" : "")} onClick={clickTab(id)}>
-            {title !== "" ? (<span className={"top_nav_item_text"}>{title}</span>) : 
-            (<div className={"top_nav_icon icon_" + id} title={_.camelCase(title)}></div>)}
-        </div>
-    );
+  return compact ? (
+    <div className={(selected ? "item_selected" : "") + " top_nav_item_no_label top_nav_item it" + id} onClick={clickTab(id)}>
+      <div className={"top_nav_icon icon_" + id} title={_.camelCase(title)}></div>
+    </div>
+  ) : (
+    <div className={(selected ? "item_selected" : "") + " top_nav_item it" + id + (title == "" ? " top_nav_item_no_label" : "")} onClick={clickTab(id)}>
+      {title !== "" ? (<span className={"top_nav_item_text"}>{title}</span>) : 
+      (<div className={"top_nav_icon icon_" + id} title={_.camelCase(title)}></div>)}
+    </div>
+  );
 }
 
 interface topRankProps {
-    currentTab: number,
-    id: number,
-    rank: any | null,
-    callback: (id:number) => void,
-    rankClass: string
+  currentTab: number,
+  id: number,
+  rank: any | null,
+  callback: (id:number) => void,
+  rankClass: string
 }
 
 function TopRankIcon(props:topRankProps) {
-    const {currentTab, id, rank, callback, rankClass} = props;
-    
-    const selected = currentTab === id;
+  const {currentTab, id, rank, callback, rankClass} = props;
+  
+  const selected = currentTab === id;
 
-    const clickTab = React.useCallback((tabId) => (event: React.MouseEvent<HTMLDivElement>) => {
-        clickNav(tabId, selected);
-        callback(tabId);
-    }, [props.id, props.callback]);
+  const clickTab = React.useCallback((tabId) => (event: React.MouseEvent<HTMLDivElement>) => {
+    clickNav(tabId, selected);
+    callback(tabId);
+  }, [props.id, props.callback]);
 
-    if (rank == null) {
-        // No rank badge, default to beginner and remove interactions
-        const rankStyle = {
-            backgroundPosition: "0px 0px"
-        };
-        return (
-            <div className="top_nav_item">
-                <div style={rankStyle} className={rankClass}></div>
-            </div>
-        );
-    }
-
-    const propTitle = formatRank(rank);
+  if (rank == null) {
+    // No rank badge, default to beginner and remove interactions
     const rankStyle = {
-        backgroundPosition: get_rank_index(rank.rank, rank.tier) * -48 + "px 0px"
+        backgroundPosition: "0px 0px"
     };
-
     return (
-        <div className={(selected ? "item_selected" : "") + " top_nav_item"} onClick={clickTab(id)}>
-            <div style={rankStyle} title={propTitle} className={rankClass}></div>
-        </div>
+      <div className="top_nav_item">
+        <div style={rankStyle} className={rankClass}></div>
+      </div>
     );
+  }
+
+  const propTitle = formatRank(rank);
+  const rankStyle = {
+    backgroundPosition: get_rank_index(rank.rank, rank.tier) * -48 + "px 0px"
+  };
+
+  return (
+    <div className={(selected ? "item_selected" : "") + " top_nav_item"} onClick={clickTab(id)}>
+      <div style={rankStyle} title={propTitle} className={rankClass}></div>
+    </div>
+  );
 }
 
 interface patreonProps {
-    patreon: boolean,
-    patreonTier: number
+  patreon: boolean,
+  patreonTier: number
 }
 
 function PatreonBadge(props: patreonProps) {
-    const { patreonTier } = props;
+  const { patreonTier } = props;
 
-    let title = "Patreon Basic Tier";
-    if (patreonTier === 1) title = "Patreon Standard Tier";
-    if (patreonTier === 2) title = "Patreon Modern Tier";
-    if (patreonTier === 3) title = "Patreon Legacy Tier";
-    if (patreonTier === 4) title = "Patreon Vintage Tier";
+  let title = "Patreon Basic Tier";
+  if (patreonTier === 1) title = "Patreon Standard Tier";
+  if (patreonTier === 2) title = "Patreon Modern Tier";
+  if (patreonTier === 3) title = "Patreon Legacy Tier";
+  if (patreonTier === 4) title = "Patreon Vintage Tier";
 
-    const style = {
-        backgroundPosition: (-40 * patreonTier) + "px 0px"
-    };
+  const style = {
+    backgroundPosition: (-40 * patreonTier) + "px 0px"
+  };
 
-    return (
-        <div title={title} style={style} className="top_patreon" ></div>
-    );
+  return (
+    <div title={title} style={style} className="top_patreon" ></div>
+  );
 }
 
 function TopNav() {
-    const [compact, setCompact] = React.useState(false);
-    const [currentTab, setCurrentTab] = React.useState(pd.settings.last_open_tab);
-    const setCurrentTabCallback = (id:number) => {
-        setCurrentTab(id);
-    };
+  const [compact, setCompact] = React.useState(false);
+  const [currentTab, setCurrentTab] = React.useState(pd.settings.last_open_tab);
+  const setCurrentTabCallback = (id:number) => {
+    setCurrentTab(id);
+  };
 
-    const defaultTab = {
-        compact: compact,
-        currentTab: currentTab,
-        callback: setCurrentTabCallback
+  const defaultTab = {
+    compact: compact,
+    currentTab: currentTab,
+    callback: setCurrentTabCallback
+  }
+
+  const homeTab = {...defaultTab, id: MAIN_HOME, title:""};
+  const myDecksTab = {...defaultTab, id: MAIN_DECKS, title:"MY DECKS"};
+  const historyTab = {...defaultTab, id: MAIN_HISTORY, title:"HISTORY"};
+  const eventsTab = {...defaultTab, id: MAIN_EVENTS, title:"EVENTS"};
+  const exploreTab = {...defaultTab, id: MAIN_EXPLORE, title:"EXPLORE"};
+  const economyTab = {...defaultTab, id: MAIN_ECONOMY, title:"ECONOMY"};
+  const collectionTab = {...defaultTab, id: MAIN_COLLECTION, title:"COLLECTION"};
+  
+  const contructedNav = {
+    callback: setCurrentTabCallback,
+    currentTab: currentTab,
+    id: MAIN_CONSTRUCTED,
+    rank: pd.rank ? pd.rank.constructed : null,
+    rankClass: "top_constructed_rank"
+  };
+
+  const limitedNav = {
+    callback: setCurrentTabCallback,
+    currentTab: currentTab,
+    id: MAIN_LIMITED,
+    rank: pd.rank ? pd.rank.limited : null,
+    rankClass: "top_limited_rank"
+  };
+
+  React.useEffect(() => {
+    if ($$(".top_nav_icons")[0].offsetWidth < 530) {
+      if (!compact) {
+        setCompact(true);
+      }
+    } else if (compact) {
+      setCompact(false);
     }
+  });
 
-    const homeTab = {...defaultTab, id: MAIN_HOME, title:""};
-    const myDecksTab = {...defaultTab, id: MAIN_DECKS, title:"MY DECKS"};
-    const historyTab = {...defaultTab, id: MAIN_HISTORY, title:"HISTORY"};
-    const eventsTab = {...defaultTab, id: MAIN_EVENTS, title:"EVENTS"};
-    const exploreTab = {...defaultTab, id: MAIN_EXPLORE, title:"EXPLORE"};
-    const economyTab = {...defaultTab, id: MAIN_ECONOMY, title:"ECONOMY"};
-    const collectionTab = {...defaultTab, id: MAIN_COLLECTION, title:"COLLECTION"};
-    
-    const contructedNav = {
-        callback: setCurrentTabCallback,
-        currentTab: currentTab,
-        id: MAIN_CONSTRUCTED,
-        rank: pd.rank ? pd.rank.constructed : null,
-        rankClass: "top_constructed_rank"
-    };
+  const patreon = {
+    patreon: pd.patreon,
+    patreonTier: pd.patreon_tier
+  };
 
-    const limitedNav = {
-        callback: setCurrentTabCallback,
-        currentTab: currentTab,
-        id: MAIN_LIMITED,
-        rank: pd.rank ? pd.rank.limited : null,
-        rankClass: "top_limited_rank"
-    };
+  let userName = pd.name.slice(0, -6);
+  let userNumerical = pd.name.slice(-6);
 
-    React.useEffect(() => {
-        if ($$(".top_nav_icons")[0].offsetWidth < 530) {
-            if (!compact) {
-                setCompact(true);
-            }
-        } else if (compact) {
-            setCompact(false);
-        }
-    });
-
-    const patreon = {
-        patreon: pd.patreon,
-        patreonTier: pd.patreon_tier
-    };
-
-    let userName = pd.name.slice(0, -6);
-    let userNumerical = pd.name.slice(-6);
-
-    return (
-        <div className="top_nav">
-            <div className="top_nav_icons">
-                <TopNavItem {...homeTab}/>
-                <TopNavItem {...myDecksTab}/>
-                <TopNavItem {...historyTab}/>
-                <TopNavItem {...eventsTab}/>
-                <TopNavItem {...exploreTab}/>
-                <TopNavItem {...economyTab}/>
-                <TopNavItem {...collectionTab}/>
-            </div>
-            <div className="top_nav_info">
-                <div className="top_userdata_container">
-                    <TopRankIcon {...contructedNav}/>
-                    <TopRankIcon {...limitedNav}/>
-                    { pd.patreon ? <PatreonBadge {...patreon} /> : null }
-                    <div className="top_username" title={"Arena username"}>{userName}</div>
-                    <div className="top_username_id" title={"Arena user ID"}>{userNumerical}</div>
-                </div>
-            </div>
+  return (
+    <div className="top_nav">
+      <div className="top_nav_icons">
+        <TopNavItem {...homeTab}/>
+        <TopNavItem {...myDecksTab}/>
+        <TopNavItem {...historyTab}/>
+        <TopNavItem {...eventsTab}/>
+        <TopNavItem {...exploreTab}/>
+        <TopNavItem {...economyTab}/>
+        <TopNavItem {...collectionTab}/>
+      </div>
+      <div className="top_nav_info">
+        <div className="top_userdata_container">
+          <TopRankIcon {...contructedNav}/>
+          <TopRankIcon {...limitedNav}/>
+          { pd.patreon ? <PatreonBadge {...patreon} /> : null }
+          <div className="top_username" title={"Arena username"}>{userName}</div>
+          <div className="top_username_id" title={"Arena user ID"}>{userNumerical}</div>
         </div>
-    );
+      </div>
+  </div>
+  );
 }
 
 export default function createTopNav(parent: Element): boolean {
-    ReactDOM.render(
-        <TopNav />,
-        parent
-    );
-    return true;
+  ReactDOM.render(
+    <TopNav />,
+    parent
+  );
+  return true;
 }

--- a/src/window_main/topNav.tsx
+++ b/src/window_main/topNav.tsx
@@ -1,18 +1,39 @@
 import _ from "lodash";
-import mountReactComponent from "./mountReactComponent";
-import { createDiv } from "../shared/dom-fns";
 import React from "react";
 import ReactDOM from 'react-dom';
+import { queryElements as $$ } from "../shared/dom-fns";
+import { openTab } from "./tabControl";
+
+import {
+    MAIN_HOME ,
+    MAIN_DECKS,
+    MAIN_HISTORY,
+    MAIN_EVENTS,
+    MAIN_EXPLORE,
+    MAIN_ECONOMY,
+    MAIN_COLLECTION,
+    MAIN_CONSTRUCTED,
+    MAIN_LIMITED
+} from "../shared/constants";
 
 interface topNavItemProps {
-    id: string,
+    id: number,
     title: string
 }
 
 function TopNavItem(props:topNavItemProps) {
     const {id, title} = props;
+
+    const clickTab = React.useCallback((tabId: number) => (event: React.MouseEvent<HTMLDivElement>) => {
+        if (!event.currentTarget.classList.contains("item_selected")) {
+            $$(".top_nav_item").forEach(el => el.classList.remove("item_selected"));
+            event.currentTarget.classList.add("item_selected");
+            openTab(tabId);
+        }
+    }, [props.id]);
+
     return (
-        <div className={"top_nav_item it" + id}>
+        <div className={"top_nav_item it" + id} onClick={clickTab(id)}>
             {title !== "" ? (<span className={"top_nav_item_text"}>{title}</span>) : false}
             <div className={"top_nav_icon icon_" + id} title={_.camelCase(title)}></div>
         </div>
@@ -20,16 +41,16 @@ function TopNavItem(props:topNavItemProps) {
 }
 
 function TopNav() {
-    const homeTab = {id: "h", title:""};
-    const myDecksTab = {id: "0", title:"MY DECKS"};
-    const historyTab = {id: "1", title:"HISTORY"};
-    const eventsTab = {id: "2", title:"EVENTS"};
-    const exploreTab = {id: "3", title:"EXPLORE"};
-    const economyTab = {id: "4", title:"ECONOMY"};
-    const collectionTab = {id: "5", title:"COLLECTION"};
+    const homeTab = {id: MAIN_HOME, title:""};
+    const myDecksTab = {id: MAIN_DECKS, title:"MY DECKS"};
+    const historyTab = {id: MAIN_HISTORY, title:"HISTORY"};
+    const eventsTab = {id: MAIN_EVENTS, title:"EVENTS"};
+    const exploreTab = {id: MAIN_EXPLORE, title:"EXPLORE"};
+    const economyTab = {id: MAIN_ECONOMY, title:"ECONOMY"};
+    const collectionTab = {id: MAIN_COLLECTION, title:"COLLECTION"};
 
-    const contructedNav = {id: "7", title:""};
-    const limitedNav = {id: "8", title:""};
+    const contructedNav = {id: MAIN_CONSTRUCTED, title:""};
+    const limitedNav = {id: MAIN_LIMITED, title:""};
 
     return (
         <div className={"top_nav"}>
@@ -58,6 +79,5 @@ export default function createTopNav(parent: Element): boolean {
         <TopNav />,
         parent
     );
-
     return true;
 }

--- a/src/window_main/topNav.tsx
+++ b/src/window_main/topNav.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from "react";
 import ReactDOM from 'react-dom';
 import { queryElements as $$ } from "../shared/dom-fns";
 import { openTab } from "./tabControl";
+import pd from "../shared/player-data";
 
 import {
     MAIN_HOME ,
@@ -45,6 +46,29 @@ function TopNavItem(props:topNavItemProps) {
     );
 }
 
+interface patreonProps {
+    patreon: boolean,
+    patreonTier: number
+}
+
+function PatreonBadge(props: patreonProps) {
+    const { patreonTier } = props;
+
+    let title = "Patreon Basic Tier";
+    if (patreonTier === 1) title = "Patreon Standard Tier";
+    if (patreonTier === 2) title = "Patreon Modern Tier";
+    if (patreonTier === 3) title = "Patreon Legacy Tier";
+    if (patreonTier === 4) title = "Patreon Vintage Tier";
+
+    const style = {
+        backgroundPosition: (-40 * patreonTier) + "px 0px"
+    };
+
+    return (
+        <div title={title} style={style} className="top_patreon" ></div>
+    );
+}
+
 function TopNav() {
     const [compact, setCompact] = React.useState(false);
     const homeTab = {compact: compact, id: MAIN_HOME, title:""};
@@ -68,6 +92,14 @@ function TopNav() {
         }
     });
 
+    const patreon = {
+        patreon: pd.patreon,
+        patreonTier: pd.patreon_tier
+    };
+
+    let userName = pd.name.slice(0, -6);
+    let userNumerical = pd.name.slice(-6);
+
     return (
         <div className={"top_nav"}>
             <div className={"top_nav_icons"}>
@@ -82,9 +114,9 @@ function TopNav() {
             <div className={"top_nav_info"}>
                 <TopNavItem {...contructedNav}/>
                 <TopNavItem {...limitedNav}/>
-                <div className={"top_patreon"}></div>
-                <div className={"top_username"} title={"Arena username"}></div>
-                <div className={"top_username_id"} title={"Arena user ID"}></div>
+                { pd.patreon ? <PatreonBadge {...patreon} /> : null }
+                <div className={"top_username"} title={"Arena username"}>{userName}</div>
+                <div className={"top_username_id"} title={"Arena user ID"}>{userNumerical}</div>
             </div>
         </div>
     );

--- a/src/window_main/topNav.tsx
+++ b/src/window_main/topNav.tsx
@@ -26,22 +26,19 @@ interface topNavItemProps {
     currentTab: number,
     compact: boolean,
     id: number,
+    callback: (id:number) => void,
     title: string
 }
 
 function TopNavItem(props:topNavItemProps) {
-    const {currentTab, compact, id, title} = props;
+    const {currentTab, compact, id, callback, title} = props;
 
-    const selected = currentTab == id;
+    const selected = currentTab === id;
 
     const clickTab = React.useCallback((tabId: number) => (event: React.MouseEvent<HTMLDivElement>) => {
-        if (!event.currentTarget.classList.contains("item_selected")) {
-            $$(".top_nav_item").forEach(el => el.classList.remove("item_selected"));
-            event.currentTarget.classList.add("item_selected");
-            clickNav(tabId);
-            openTab(tabId);
-        }
-    }, [props.id]);
+        clickNav(tabId, selected);
+        callback(tabId);
+    }, [props.id, props.callback]);
 
     return compact ? (
         <div className={(selected ? "item_selected" : "") + " top_nav_item_no_label top_nav_item it" + id} onClick={clickTab(id)}>
@@ -59,18 +56,19 @@ interface topRankProps {
     currentTab: number,
     id: number,
     rank: any,
+    callback: (id:number) => void,
     rankClass: string
 }
 
 function TopRankIcon(props:topRankProps) {
-    const {currentTab, id, rank, rankClass} = props;
+    const {currentTab, id, rank, callback, rankClass} = props;
     
-    const selected = currentTab == id;
+    const selected = currentTab === id;
 
-    const clickTab = React.useCallback(() => (event: React.MouseEvent<HTMLDivElement>) => {
-        clickNav(id);
-    }, [props.id]);
-    
+    const clickTab = React.useCallback((tabId) => (event: React.MouseEvent<HTMLDivElement>) => {
+        clickNav(tabId, selected);
+        callback(tabId);
+    }, [props.id, props.callback]);
 
    const propTitle = formatRank(rank);
    const rankStyle = {
@@ -78,7 +76,7 @@ function TopRankIcon(props:topRankProps) {
    };
 
     return (
-        <div className={(selected ? "item_selected" : "") + " top_nav_item"} onClick={clickTab()}>
+        <div className={(selected ? "item_selected" : "") + " top_nav_item"} onClick={clickTab(id)}>
             <div style={rankStyle} title={propTitle} className={rankClass}></div>
         </div>
     );
@@ -109,11 +107,15 @@ function PatreonBadge(props: patreonProps) {
 
 function TopNav() {
     const [compact, setCompact] = React.useState(false);
-    const currentTab = pd.settings.last_open_tab;
+    const [currentTab, setCurrentTab] = React.useState(pd.settings.last_open_tab);
+    const setCurrentTabCallback = (id:number) => {
+        setCurrentTab(id);
+    };
 
     const defaultTab = {
         compact: compact,
-        currentTab: currentTab
+        currentTab: currentTab,
+        callback: setCurrentTabCallback
     }
 
     const homeTab = {...defaultTab, id: MAIN_HOME, title:""};
@@ -124,8 +126,8 @@ function TopNav() {
     const economyTab = {...defaultTab, id: MAIN_ECONOMY, title:"ECONOMY"};
     const collectionTab = {...defaultTab, id: MAIN_COLLECTION, title:"COLLECTION"};
 
-    const contructedNav = {currentTab: currentTab, id: MAIN_CONSTRUCTED,rank: pd.rank.constructed, rankClass: "top_constructed_rank"};
-    const limitedNav = {currentTab: currentTab, id: MAIN_LIMITED,rank: pd.rank.limited, rankClass: "top_limited_rank"};
+    const contructedNav = {callback: setCurrentTabCallback, currentTab: currentTab, id: MAIN_CONSTRUCTED,rank: pd.rank.constructed, rankClass: "top_constructed_rank"};
+    const limitedNav = {callback: setCurrentTabCallback, currentTab: currentTab, id: MAIN_LIMITED,rank: pd.rank.limited, rankClass: "top_limited_rank"};
 
     React.useEffect(() => {
         if ($$(".top_nav_icons")[0].offsetWidth < 530) {

--- a/src/window_main/topNav.tsx
+++ b/src/window_main/topNav.tsx
@@ -33,19 +33,17 @@ interface TopNavItemProps {
 function TopNavItem(props:TopNavItemProps) {
   const {currentTab, compact, id, callback, title} = props;
 
-  const selected = currentTab === id;
-
   const clickTab = React.useCallback((tabId: number) => (event: React.MouseEvent<HTMLDivElement>) => {
-    clickNav(tabId, selected);
+    clickNav(tabId);
     callback(tabId);
   }, [props.id, props.callback]);
 
   return compact ? (
-    <div className={(selected ? "item_selected" : "") + " top_nav_item_no_label top_nav_item it" + id} onClick={clickTab(id)}>
+    <div className={(currentTab === id ? "item_selected" : "") + " top_nav_item_no_label top_nav_item it" + id} onClick={clickTab(id)}>
       <div className={"top_nav_icon icon_" + id} title={_.camelCase(title)}></div>
     </div>
   ) : (
-    <div className={(selected ? "item_selected" : "") + " top_nav_item it" + id + (title == "" ? " top_nav_item_no_label" : "")} onClick={clickTab(id)}>
+    <div className={(currentTab === id ? "item_selected" : "") + " top_nav_item it" + id + (title == "" ? " top_nav_item_no_label" : "")} onClick={clickTab(id)}>
       {title !== "" ? (<span className={"top_nav_item_text"}>{title}</span>) : 
       (<div className={"top_nav_icon icon_" + id} title={_.camelCase(title)}></div>)}
     </div>
@@ -66,7 +64,7 @@ function TopRankIcon(props:topRankProps) {
   const selected = currentTab === id;
 
   const clickTab = React.useCallback((tabId) => (event: React.MouseEvent<HTMLDivElement>) => {
-    clickNav(tabId, selected);
+    clickNav(tabId);
     callback(tabId);
   }, [props.id, props.callback]);
 
@@ -199,4 +197,13 @@ export default function createTopNav(parent: Element): boolean {
     parent
   );
   return true;
+}
+
+export function updateTopBar() {
+  const topNavDiv = $$(".top_nav_container")[0];
+  createTopNav(topNavDiv);
+
+  if (pd.offline || !pd.settings.send_data) {
+    $$(".unlink")[0].style.display = "block";
+  }
 }

--- a/src/window_main/topNav.tsx
+++ b/src/window_main/topNav.tsx
@@ -55,7 +55,7 @@ function TopNavItem(props:topNavItemProps) {
 interface topRankProps {
     currentTab: number,
     id: number,
-    rank: any,
+    rank: any | null,
     callback: (id:number) => void,
     rankClass: string
 }
@@ -70,10 +70,22 @@ function TopRankIcon(props:topRankProps) {
         callback(tabId);
     }, [props.id, props.callback]);
 
-   const propTitle = formatRank(rank);
-   const rankStyle = {
-       backgroundPosition: get_rank_index(rank.rank, rank.tier) * -48 + "px 0px"
-   };
+    if (rank == null) {
+        // No rank badge, default to beginner and remove interactions
+        const rankStyle = {
+            backgroundPosition: "0px 0px"
+        };
+        return (
+            <div className="top_nav_item">
+                <div style={rankStyle} className={rankClass}></div>
+            </div>
+        );
+    }
+
+    const propTitle = formatRank(rank);
+    const rankStyle = {
+        backgroundPosition: get_rank_index(rank.rank, rank.tier) * -48 + "px 0px"
+    };
 
     return (
         <div className={(selected ? "item_selected" : "") + " top_nav_item"} onClick={clickTab(id)}>
@@ -125,9 +137,22 @@ function TopNav() {
     const exploreTab = {...defaultTab, id: MAIN_EXPLORE, title:"EXPLORE"};
     const economyTab = {...defaultTab, id: MAIN_ECONOMY, title:"ECONOMY"};
     const collectionTab = {...defaultTab, id: MAIN_COLLECTION, title:"COLLECTION"};
+    
+    const contructedNav = {
+        callback: setCurrentTabCallback,
+        currentTab: currentTab,
+        id: MAIN_CONSTRUCTED,
+        rank: pd.rank ? pd.rank.constructed : null,
+        rankClass: "top_constructed_rank"
+    };
 
-    const contructedNav = {callback: setCurrentTabCallback, currentTab: currentTab, id: MAIN_CONSTRUCTED,rank: pd.rank.constructed, rankClass: "top_constructed_rank"};
-    const limitedNav = {callback: setCurrentTabCallback, currentTab: currentTab, id: MAIN_LIMITED,rank: pd.rank.limited, rankClass: "top_limited_rank"};
+    const limitedNav = {
+        callback: setCurrentTabCallback,
+        currentTab: currentTab,
+        id: MAIN_LIMITED,
+        rank: pd.rank ? pd.rank.limited : null,
+        rankClass: "top_limited_rank"
+    };
 
     React.useEffect(() => {
         if ($$(".top_nav_icons")[0].offsetWidth < 530) {


### PR DESCRIPTION
This PR streamlines the inner workings of the top navigation bar, simplifies the process of opening things like tabs or settings and creates a set of React components to replace the HTML5 mess we had going on there.

Extra goodies;
- Accidentally fixed some of the mess `renderer.js` was.
- Fixed some issues arising when moving trough tabs.
- Isolated display of top navigation from its control.

First run at tsx, reviewers beware! 