### PR TITLE
Overlay style

### DIFF
--- a/src/overlay/index.css
+++ b/src/overlay/index.css
@@ -86,6 +86,7 @@ body {
 .overlay_deckname {
     background-color: rgba(0,0,0,0.75);
     padding: 4px 0 0 0;
+    height: 28px;
     text-align: center;
     color: #fae5d2;
 }
@@ -563,6 +564,7 @@ body {
 }
 
 .top_nav_wrapper {
+    z-index: 2 !important;
     flex-direction: row !important;
     height: 32px !important;
     justify-content: flex-end !important;

--- a/src/shared/shared.css
+++ b/src/shared/shared.css
@@ -486,6 +486,7 @@ label {
 
 
 .button {
+    border-radius: 50%;
     -webkit-app-region: no-drag;
     cursor:pointer;
     align-self: center;
@@ -494,18 +495,20 @@ label {
     margin-right: 12px;
     width: 24px;
     height: 24px;
-    opacity: 0.5;
+    opacity: 0.8;
     background-size: contain;
     -webkit-transition: all .33s ease-in-out;
 }
 
 .button:hover {
     opacity: 1;
+    background-color: rgba(231, 202, 142, 0.25);
     -webkit-transform: rotate(-90deg);
 }
 
 .button.minimize:hover {
     opacity: 1;
+    background-color: rgba(231, 202, 142, 0.25);
     -webkit-transform: rotate(0deg);
 }
 
@@ -513,6 +516,12 @@ label {
     opacity: 1;
     -webkit-transform: rotate(0deg);
     left: -8px;
+}
+
+.button.close:hover {
+    opacity: 1;
+    background-color: var(--color-r);
+    -webkit-transform: rotate(-90deg);
 }
 
 .button.settings {


### PR DESCRIPTION
Fixes the buttons in the overlay being hidden by other elements, making them look faded. Also adds an effect to the hovering of the buttons to make it more apparent we can click them; (affects main window controls too)

![image](https://user-images.githubusercontent.com/4711391/68537107-92dbfb00-033d-11ea-94ab-213d388c0e13.png)
