### PR TITLE
Bugfix Practice and Direct Matches

### DIFF
--- a/src/window_background/labels.js
+++ b/src/window_background/labels.js
@@ -1221,11 +1221,8 @@ export function onLabelEventMatchCreated(entry, json) {
 export function onLabelOutDirectGameChallenge(entry, json) {
   if (!json) return;
   var deck = json.params.deck;
-
-  deck = replaceAll(deck, '"Id"', '"id"');
-  deck = replaceAll(deck, '"Quantity"', '"quantity"');
   deck = JSON.parse(deck);
-  select_deck(deck);
+  select_deck(convert_deck_from_v3(deck));
 
   const httpApi = require("./http-api");
   httpApi.httpTournamentCheck(
@@ -1240,11 +1237,8 @@ export function onLabelOutDirectGameChallenge(entry, json) {
 export function onLabelOutEventAIPractice(entry, json) {
   if (!json) return;
   var deck = json.params.deck;
-
-  deck = replaceAll(deck, '"Id"', '"id"');
-  deck = replaceAll(deck, '"Quantity"', '"quantity"');
   deck = JSON.parse(deck);
-  select_deck(deck);
+  select_deck(convert_deck_from_v3(deck));
 }
 
 function getDraftSet(eventName) {


### PR DESCRIPTION
During one of the recent WotC updates (probably the Brawl launch one), they updated the remaining areas of the log to use the latest deck format. This was reported as "overlays do not work in practice mode" recently.

https://discordapp.com/channels/463844727654187020/467737642306371584/642458619471724605
![image](https://user-images.githubusercontent.com/14894693/68722859-b1bfd480-056b-11ea-8a80-c4b8ffd55082.png)
