### PR TITLE
Discoverable Edit Mode

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -44,6 +44,7 @@ let mainLoaded = false;
 let backLoaded = false;
 let overlayLoaded = false;
 let arenaState = ARENA_MODE_IDLE;
+let isEditMode = false;
 
 const singleLock = app.requestSingleInstanceLock();
 
@@ -225,6 +226,12 @@ function startApp() {
           // set progress to >1 for indeterminate time
           mainWindow.setProgressBar(arg.progress);
         }
+        break;
+
+      case "edit":
+        isEditMode = !isEditMode;
+        updateOverlayVisibility();
+        overlay.webContents.send("edit");
         break;
 
       case "renderer_window_minimize":
@@ -447,7 +454,8 @@ function getOverlayVisible(settings) {
     (OVERLAY_DRAFT_MODES.includes(settings.mode) &&
       arenaState === ARENA_MODE_DRAFT) ||
     (!OVERLAY_DRAFT_MODES.includes(settings.mode) &&
-      arenaState === ARENA_MODE_MATCH);
+      arenaState === ARENA_MODE_MATCH) ||
+    (isEditMode && arenaState === ARENA_MODE_IDLE);
 
   return settings.show && (currentModeApplies || settings.show_always);
 }
@@ -618,7 +626,7 @@ function createMainWindow() {
       }
     },
     {
-      label: "Edit Mode",
+      label: "Edit Overlay Positions",
       click: () => {
         overlay.webContents.send("edit");
       }

--- a/src/main.js
+++ b/src/main.js
@@ -228,10 +228,8 @@ function startApp() {
         }
         break;
 
-      case "edit":
-        isEditMode = !isEditMode;
-        updateOverlayVisibility();
-        overlay.webContents.send("edit");
+      case "toggle_edit_mode":
+        toggleEditMode();
         break;
 
       case "renderer_window_minimize":
@@ -374,6 +372,12 @@ function setArenaState(state) {
   updateOverlayVisibility();
 }
 
+function toggleEditMode() {
+  isEditMode = !isEditMode;
+  overlay.webContents.send("set_edit_mode", isEditMode);
+  updateOverlayVisibility();
+}
+
 function setSettings(_settings) {
   try {
     settings = JSON.parse(_settings);
@@ -393,7 +397,7 @@ function setSettings(_settings) {
       openOverlayDevTools
     );
     globalShortcut.register(settings.shortcut_editmode, () => {
-      overlay.webContents.send("edit");
+      toggleEditMode();
     });
     settings.overlays.forEach((_settings, index) => {
       let short = "shortcut_overlay_" + (index + 1);
@@ -438,8 +442,8 @@ function updateOverlayVisibility() {
         .getAllDisplays()
         .find(d => d.id == settings.overlay_display) ||
       electron.screen.getPrimaryDisplay();
-    overlay.show();
     overlay.setBounds(bounds);
+    overlay.show();
   }
 }
 
@@ -628,7 +632,7 @@ function createMainWindow() {
     {
       label: "Edit Overlay Positions",
       click: () => {
-        overlay.webContents.send("edit");
+        toggleEditMode();
       }
     },
     {

--- a/src/main.js
+++ b/src/main.js
@@ -44,7 +44,7 @@ let mainLoaded = false;
 let backLoaded = false;
 let overlayLoaded = false;
 let arenaState = ARENA_MODE_IDLE;
-let isEditMode = false;
+let editMode = false;
 
 const singleLock = app.requestSingleInstanceLock();
 
@@ -373,8 +373,8 @@ function setArenaState(state) {
 }
 
 function toggleEditMode() {
-  isEditMode = !isEditMode;
-  overlay.webContents.send("set_edit_mode", isEditMode);
+  editMode = !editMode;
+  overlay.webContents.send("set_edit_mode", editMode);
   updateOverlayVisibility();
 }
 
@@ -451,15 +451,25 @@ function isEntireOverlayVisible() {
   return overlay.isVisible();
 }
 
+/**
+ * Computes whether an Overlay windowlet should be visible based on the
+ * specified current overlay settings and Arena state. For example, given
+ * overlay settings for a draft-mode overlay, it will return true iff Arena
+ * is currently in a draft or idle.
+ *
+ * @param OverlaySettingsData settings
+ */
 function getOverlayVisible(settings) {
   if (!settings) return false;
 
+  // Note: ensure this logic matches the logic in OverlayWindowlet
+  // TODO: extract a common utility?
   const currentModeApplies =
     (OVERLAY_DRAFT_MODES.includes(settings.mode) &&
       arenaState === ARENA_MODE_DRAFT) ||
     (!OVERLAY_DRAFT_MODES.includes(settings.mode) &&
       arenaState === ARENA_MODE_MATCH) ||
-    (isEditMode && arenaState === ARENA_MODE_IDLE);
+    (editMode && arenaState === ARENA_MODE_IDLE);
 
   return settings.show && (currentModeApplies || settings.show_always);
 }

--- a/src/overlay/CardDetailsWindowlet.tsx
+++ b/src/overlay/CardDetailsWindowlet.tsx
@@ -6,7 +6,12 @@ import db from "../shared/database";
 import { getCardImage } from "../shared/util";
 import DraftRatings from "../shared/DraftRatings";
 
-import { getEditModeClass, useEditModeOnRef, OddsData } from "./overlayUtil";
+import {
+  getEditModeClass,
+  useEditModeOnRef,
+  OddsData,
+  SettingsData
+} from "./overlayUtil";
 import { DbCardData } from "../shared/types/Metadata";
 
 const NO_IMG_URL = "./images/nocard.png";
@@ -39,9 +44,11 @@ export interface CardDetailsWindowletProps {
   card?: DbCardData | any; // TODO remove group lands hack
   cardsSizeHoverCard: number;
   editMode: boolean;
+  handleToggleEditMode: () => void;
   odds?: OddsData;
   overlayHover: { x: number; y: number };
   overlayScale: number;
+  settings: SettingsData;
 }
 
 /**
@@ -57,10 +64,12 @@ export default function CardDetailsWindowlet(
     arenaState,
     card,
     cardsSizeHoverCard,
+    handleToggleEditMode,
     editMode,
     odds,
     overlayHover,
-    overlayScale
+    overlayScale,
+    settings
   } = props;
 
   // TODO remove group lands hack
@@ -100,7 +109,11 @@ export default function CardDetailsWindowlet(
       }}
     >
       {editMode ? (
-        <div>
+        <div
+          onDoubleClick={handleToggleEditMode}
+          title={`${settings.shortcut_editmode} or double click me
+to stop editing overlay positions`}
+        >
           <img {...imgProps} />
         </div>
       ) : (

--- a/src/overlay/OverlayController.tsx
+++ b/src/overlay/OverlayController.tsx
@@ -266,9 +266,11 @@ export default function OverlayController(): JSX.Element {
     card: hoverCard,
     cardsSizeHoverCard,
     editMode,
+    handleToggleEditMode,
     odds: match ? match.playerCardsOdds : undefined,
     overlayHover,
-    overlayScale
+    overlayScale,
+    settings
   };
 
   return (

--- a/src/overlay/OverlayController.tsx
+++ b/src/overlay/OverlayController.tsx
@@ -191,12 +191,8 @@ export default function OverlayController(): JSX.Element {
   );
 
   const handleSettingsUpdated = useCallback((): void => {
-    // mid-match Arena updates can make edit-mode difficult
-    // temporarily allow the overlays to go stale during editing
-    // (should be okay since ending edit-mode causes a refresh)
-    if (editMode) return;
     setSettings({ ...playerData.settings });
-  }, [editMode]);
+  }, []);
 
   const handleSetMatch = useCallback((event: unknown, arg: string): void => {
     const newMatch = JSON.parse(arg);

--- a/src/overlay/OverlayController.tsx
+++ b/src/overlay/OverlayController.tsx
@@ -103,10 +103,15 @@ export default function OverlayController(): JSX.Element {
     }
   }, [lastBeep, soundPriorityVolume]);
 
+  const handleToggleEditMode = useCallback(() => ipcSend("toggle_edit_mode"), []);
+
   // Note: no useCallback because of dependency on deep overlays state
-  const handleToggleEditMode = (): void => {
+  const handleSetEditMode = (
+    event: unknown,
+    _editMode: boolean
+  ) => {
     // Save current windowlet dimensions before we leave edit mode
-    if (editMode) {
+    if (editMode && !_editMode) {
       // Compute current dimensions of overlay windowlets in DOM
       const newOverlays = overlays.map(
         (overlay: OverlaySettingsData, index: number) => {
@@ -141,8 +146,7 @@ export default function OverlayController(): JSX.Element {
         skip_refresh: true
       });
     }
-    // Always toggle edit mode
-    setEditMode(!editMode);
+    setEditMode(_editMode);
   };
 
   const handleActionLog = useCallback(
@@ -220,7 +224,7 @@ export default function OverlayController(): JSX.Element {
   // register all IPC listeners
   useEffect(() => {
     ipc.on("action_log", handleActionLog);
-    ipc.on("edit", handleToggleEditMode);
+    ipc.on("set_edit_mode", handleSetEditMode);
     ipc.on("close", handleClose);
     ipc.on("set_arena_state", handleSetArenaState);
     ipc.on("set_draft_cards", handleSetDraftCards);
@@ -231,7 +235,7 @@ export default function OverlayController(): JSX.Element {
     return (): void => {
       // unregister all IPC listeners
       ipc.removeListener("action_log", handleActionLog);
-      ipc.removeListener("edit", handleToggleEditMode);
+      ipc.removeListener("set_edit_mode", handleSetEditMode);
       ipc.removeListener("close", handleClose);
       ipc.removeListener("set_arena_state", handleSetArenaState);
       ipc.removeListener("set_draft_cards", handleSetDraftCards);

--- a/src/overlay/OverlayWindowlet.tsx
+++ b/src/overlay/OverlayWindowlet.tsx
@@ -161,9 +161,13 @@ export default function OverlayWindowlet(
       {overlaySettings.top && (
         <div className="outer_wrapper top_nav_wrapper">
           <div
-            className="flex_item overlay_icon click-on"
+            className="button overlay_icon click-on"
             onClick={handleToggleEditMode}
-            style={{ backgroundColor: `var(--color-${COLORS_ALL[index]})` }}
+            style={{
+              backgroundColor: `var(--color-${COLORS_ALL[index]})`,
+              marginRight: "auto"
+            }}
+            title={settings.shortcut_editmode}
           />
           <div
             className="button settings click-on"

--- a/src/overlay/OverlayWindowlet.tsx
+++ b/src/overlay/OverlayWindowlet.tsx
@@ -90,6 +90,8 @@ export default function OverlayWindowlet(
   //   xhr.send();
   // }, [backgroundImage]);
   const overlaySettings = settings.overlays[index];
+  // Note: ensure this logic matches the logic in main.getOverlayVisible
+  // TODO: extract a common utility?
   const currentModeApplies =
     (OVERLAY_DRAFT_MODES.includes(overlaySettings.mode) &&
       arenaState === ARENA_MODE_DRAFT) ||

--- a/src/overlay/OverlayWindowlet.tsx
+++ b/src/overlay/OverlayWindowlet.tsx
@@ -3,6 +3,7 @@ import React, { useRef } from "react";
 import {
   ARENA_MODE_MATCH,
   ARENA_MODE_DRAFT,
+  ARENA_MODE_IDLE,
   COLORS_ALL,
   OVERLAY_DRAFT_MODES
 } from "../shared/constants";
@@ -93,7 +94,8 @@ export default function OverlayWindowlet(
     (OVERLAY_DRAFT_MODES.includes(overlaySettings.mode) &&
       arenaState === ARENA_MODE_DRAFT) ||
     (!OVERLAY_DRAFT_MODES.includes(overlaySettings.mode) &&
-      arenaState === ARENA_MODE_MATCH);
+      arenaState === ARENA_MODE_MATCH) ||
+      (editMode && arenaState === ARENA_MODE_IDLE);
   const isVisible =
     overlaySettings.show && (currentModeApplies || overlaySettings.show_always);
   const tileStyle = parseInt(settings.card_tile_style + "");

--- a/src/overlay/overlayUtil.tsx
+++ b/src/overlay/overlayUtil.tsx
@@ -87,6 +87,7 @@ export interface SettingsData {
   overlay_scale: number;
   overlays: OverlaySettingsData[];
   overlayHover: { x: number; y: number };
+  shortcut_editmode: string;
 }
 
 const restrictMinSize =

--- a/src/shared/constants.js
+++ b/src/shared/constants.js
@@ -755,7 +755,7 @@ export const SHORTCUT_NAMES = {
   shortcut_overlay_3: "Toggle Overlay 3",
   shortcut_overlay_4: "Toggle Overlay 4",
   shortcut_overlay_5: "Toggle Overlay 5",
-  shortcut_editmode: "Toggle Overlay Move/Resize",
+  shortcut_editmode: "Toggle Edit Overlay Positions",
   shortcut_devtools_main: "Toggle Developer Tools (main)",
   shortcut_devtools_overlay: "Toggle Developer Tools (overlays)"
 };

--- a/src/window_background/arena-log-watcher.js
+++ b/src/window_background/arena-log-watcher.js
@@ -48,7 +48,11 @@ import {
   setData,
   updateLoading
 } from "./background-util";
-import { ARENA_MODE_MATCH, ARENA_MODE_DRAFT } from "../shared/constants";
+import {
+  ARENA_MODE_MATCH,
+  ARENA_MODE_DRAFT,
+  ARENA_MODE_IDLE
+} from "../shared/constants";
 import update_deck from "./updateDeck";
 import globals from "./globals";
 
@@ -475,6 +479,8 @@ function finishLoading() {
       update_deck(false);
     } else if (globals.duringDraft) {
       ipc_send("set_arena_state", ARENA_MODE_DRAFT);
+    } else {
+      ipc_send("set_arena_state", ARENA_MODE_IDLE);
     }
 
     ipc_send("set_settings", JSON.stringify(playerData.settings));

--- a/src/window_main/index.css
+++ b/src/window_main/index.css
@@ -2741,6 +2741,11 @@ a:hover {
     margin: 0px 64px 20px 16px;
 }
 
+.settings_row {
+    display: inline-flex;
+    margin-left: 16px;
+}
+
 .deck_visual_stats {
     padding: 0 !important;
     margin: 32px !important;

--- a/src/window_main/settings.js
+++ b/src/window_main/settings.js
@@ -465,9 +465,7 @@ function appendArenaData(section) {
 function appendOverlay(section) {
   section.appendChild(createDiv(["settings_title"], "Overlays"));
 
-  const displayControls = createDiv([]);
-  displayControls.style.display = "inline-flex";
-  displayControls.style.marginLeft = "16px";
+  const displayControls = createDiv(["settings_row"]);
   // Toggle Edit Mode Button
   const editModeButton = createDiv(
     ["button_simple"],

--- a/src/window_main/settings.js
+++ b/src/window_main/settings.js
@@ -22,7 +22,8 @@ import {
   SETTINGS_SHORTCUTS,
   SETTINGS_PRIVACY,
   SETTINGS_ABOUT,
-  SETTINGS_LOGIN
+  SETTINGS_LOGIN,
+  IPC_OVERLAY
 } from "../shared/constants";
 import db from "../shared/database";
 import pd from "../shared/player-data";
@@ -465,6 +466,45 @@ function appendArenaData(section) {
 function appendOverlay(section) {
   section.appendChild(createDiv(["settings_title"], "Overlays"));
 
+  const displayControls = createDiv([]);
+  displayControls.style.display = "inline-flex";
+  displayControls.style.marginLeft = "16px";
+  // Toggle Edit Mode Button
+  const editModeButton = createDiv(
+    ["button_simple"],
+    "Edit Overlay Positions",
+    { title: pd.settings.shortcut_editmode }
+  );
+  editModeButton.addEventListener("click", function() {
+    ipcSend("edit", null, IPC_OVERLAY);
+  });
+  displayControls.appendChild(editModeButton);
+  // Set Overlay Display Screen
+  const overlayDisplay = pd.settings.overlay_display
+    ? pd.settings.overlay_display
+    : remote.screen.getPrimaryDisplay().id;
+  const label = createLabel(["but_container_label"], "Overlay Display:");
+  label.style.marginTop = "auto";
+  const displaySelect = createSelect(
+    label,
+    remote.screen.getAllDisplays().map(display => display.id),
+    overlayDisplay,
+    filter => ipcSend("save_user_settings", { overlay_display: filter }),
+    "overlay_display",
+    filter => {
+      const displayNumber = remote.screen
+        .getAllDisplays()
+        .findIndex(d => d.id == filter);
+      const primary = filter == remote.screen.getPrimaryDisplay().id;
+
+      return `Display ${displayNumber} ${primary ? "(primary)" : ""}`;
+    }
+  );
+  displaySelect.style.width = "180px";
+  displaySelect.style.marginLeft = "32px";
+  displayControls.appendChild(label);
+  section.appendChild(displayControls);
+
   const sliderScale = createDiv(["slidecontainer_settings"]);
   const sliderScaleLabel = createLabel(
     ["card_size_container"],
@@ -492,6 +532,17 @@ function appendOverlay(section) {
 
   addCheckbox(
     section,
+    "Always on top when shown",
+    `overlay_ontop`,
+    pd.settings.overlay_ontop,
+    () =>
+      ipcSend("save_user_settings", {
+        overlay_ontop: byId(`overlay_ontop`).checked
+      })
+  );
+
+  const soundPriorityBox = addCheckbox(
+    section,
     "Sound when priority changes",
     "settings_soundpriority",
     pd.settings.sound_priority,
@@ -500,13 +551,15 @@ function appendOverlay(section) {
         sound_priority: byId("settings_soundpriority").checked
       })
   );
+  soundPriorityBox.style.marginTop = "24px";
 
   const sliderSoundVolume = createDiv(["slidecontainer_settings"]);
+  sliderSoundVolume.style.marginLeft = "52px";
   const sliderSoundVolumeLabel = createLabel(
     [],
     "Volume: " + Math.round(pd.settings.sound_priority_volume * 100) + "%"
   );
-  sliderSoundVolumeLabel.style.width = "400px";
+  sliderSoundVolumeLabel.style.width = "348px";
   sliderSoundVolume.appendChild(sliderSoundVolumeLabel);
 
   const sliderSoundVolumeInput = createInput(
@@ -540,50 +593,12 @@ function appendOverlay(section) {
   const helpDiv = createDiv(
     ["settings_note"],
     `You can enable up to 5 independent overlay windows. Customize each overlay
-    using the settings below.</br>
-    To edit the overlay's position and size press ${
-      pd.settings.shortcut_editmode
-    }`
+    using the settings below.</br>`
   );
   helpDiv.style.margin = "24px 64px 0px 16px";
   section.appendChild(helpDiv);
 
   const topCont = createDiv(["overlay_section_selector_cont", "top_nav_icons"]);
-
-  let overlayDisplay = pd.settings.overlay_display
-    ? pd.settings.overlay_display
-    : remote.screen.getPrimaryDisplay().id;
-
-  addCheckbox(
-    section,
-    "Always on top when shown",
-    `overlay_ontop`,
-    pd.settings.overlay_ontop,
-    () =>
-      ipcSend("save_user_settings", {
-        overlay_ontop: byId(`overlay_ontop`).checked
-      })
-  );
-
-  const label = createLabel(["but_container_label"], "Overlay Display:");
-  const displaySelect = createSelect(
-    label,
-    remote.screen.getAllDisplays().map(display => display.id),
-    overlayDisplay,
-    filter => ipcSend("save_user_settings", { overlay_display: filter }),
-    "overlay_display",
-    filter => {
-      let displayNumber = remote.screen
-        .getAllDisplays()
-        .findIndex(d => d.id == filter);
-      let primary = filter == remote.screen.getPrimaryDisplay().id;
-
-      return `Display ${displayNumber} ${primary ? "(primary)" : ""}`;
-    }
-  );
-  displaySelect.style.width = "180px";
-  displaySelect.style.marginLeft = "32px";
-  section.appendChild(label);
 
   pd.settings.overlays.forEach((settings, index) => {
     const overlaySettingsNav = createDiv([

--- a/src/window_main/settings.js
+++ b/src/window_main/settings.js
@@ -22,8 +22,7 @@ import {
   SETTINGS_SHORTCUTS,
   SETTINGS_PRIVACY,
   SETTINGS_ABOUT,
-  SETTINGS_LOGIN,
-  IPC_OVERLAY
+  SETTINGS_LOGIN
 } from "../shared/constants";
 import db from "../shared/database";
 import pd from "../shared/player-data";
@@ -476,7 +475,7 @@ function appendOverlay(section) {
     { title: pd.settings.shortcut_editmode }
   );
   editModeButton.addEventListener("click", function() {
-    ipcSend("edit", null, IPC_OVERLAY);
+    ipcSend("toggle_edit_mode");
   });
   displayControls.appendChild(editModeButton);
   // Set Overlay Display Screen


### PR DESCRIPTION
### Motivation
We have received several instances of feedback that the current "Edit Mode" feature of the Overlays is hard to find and/or understand, see #602.

This PR makes several changes to attempt to make "Edit Mode" more discoverable:
  - adds an "Edit Overlay Positions" button to the settings page with hover text
  - reorganizes the common settings on the "Settings > Overlay" page
  - standardizes the display text on "Edit Overlay Positions" in the context menu/shortcuts page
  - ensures that all enabled overlays are visible to move/resize during arena idle mode

### Demo
![image](https://user-images.githubusercontent.com/14894693/68810860-20606900-0624-11ea-9a79-3f878536049f.png)
