### PR TITLE
make overlay settings independent of decklist

### DIFF
--- a/src/overlay/DeckList.tsx
+++ b/src/overlay/DeckList.tsx
@@ -268,7 +268,7 @@ export default function DeckList(props: DeckListProps): JSX.Element {
   return (
     <div className="overlay_decklist click-on">
       <div className="decklist_title">{subTitle}</div>
-      {mainCardTiles}
+      {!!settings.deck && mainCardTiles}
       {!!settings.sideboard && sideboardCardTiles.length && (
         <div className="card_tile_separator">Sideboard</div>
       )}

--- a/src/overlay/DraftElements.tsx
+++ b/src/overlay/DraftElements.tsx
@@ -138,7 +138,7 @@ export default function DraftElements(props: DraftElementsProps): JSX.Element {
           ))}
         </div>
       )}
-      {!!settings.deck && !!visibleDeck && (
+      {!!visibleDeck && (
         <DeckList
           deck={visibleDeck}
           subTitle={subTitle}

--- a/src/overlay/MatchElements.tsx
+++ b/src/overlay/MatchElements.tsx
@@ -114,7 +114,7 @@ export default function MatchElements(props: MatchElementsProps): JSX.Element {
           setHoverCardCallback={setHoverCardCallback}
         />
       )}
-      {!!settings.deck && !!visibleDeck && (
+      {!!visibleDeck && (
         <DeckList
           deck={visibleDeck}
           subTitle={subTitle}


### PR DESCRIPTION
solves #615 and extends the idea to allow the charts to be used independently as well