### PR TITLE
Commander display

### DIFF
--- a/src/window_background/data.ts
+++ b/src/window_background/data.ts
@@ -293,6 +293,7 @@ export function completeMatch(match: ExtendedMatchData, matchData: MatchData, ma
   match.eventId = matchData.eventId;
   match.playerDeck = matchData.player.originalDeck.getSave();
   match.oppDeck = getOpponentDeck();
+  match.oppDeck.commandZoneGRPIds = matchData.opponent.commanderGrpIds;
 
   if (
     (!match.tags || !match.tags.length) &&

--- a/src/window_main/renderer-util.js
+++ b/src/window_main/renderer-util.js
@@ -182,7 +182,7 @@ function drawDeck(div, deck, showWildcards = false) {
   div.innerHTML = "";
   const unique = makeId(4);
 
-  if (deck.commandZoneGRPIds) {
+  if (deck.commandZoneGRPIds && deck.commandZoneGRPIds.length > 0) {
     let separator = deckDrawer.cardSeparator(`Commander`);
     div.appendChild(separator);
 


### PR DESCRIPTION
Fixes a couple issues with Brawl;
- Does not show commander field when there are no commanders in decklist. (commander array is empty)
- Shows the opponent's commander in its decklist.