### PR TITLE
Bugfix overlay decklist sorting

### DIFF
--- a/src/overlay/DeckList.tsx
+++ b/src/overlay/DeckList.tsx
@@ -159,7 +159,7 @@ export default function DeckList(props: DeckListProps): JSX.Element {
     mainCards.add(groupedLandsCard, landsNumber, true);
   }
   mainCards.get().sort(sortFunc);
-  mainCards.get().forEach((card: any) => {
+  mainCards.get().forEach((card: any, index: number) => {
     let quantity = card.quantity;
     if (settings.mode === OVERLAY_MIXED) {
       const odds = (card.chance !== undefined ? card.chance : "0") + "%";
@@ -196,7 +196,7 @@ export default function DeckList(props: DeckListProps): JSX.Element {
       mainCardTiles.push(
         <div
           className="overlay_card_quantity"
-          key={"maincardtile_owned_" + card.id}
+          key={"maincardtile_owned_" + index + "_" + card.id}
         >
           <OwnershipStars card={fullCard} />
         </div>
@@ -232,7 +232,7 @@ export default function DeckList(props: DeckListProps): JSX.Element {
     const sideCards = deckClone.sideboard;
     sideCards.removeDuplicates();
     sideCards.get().sort(sortFunc);
-    sideCards.get().forEach((card: any) => {
+    sideCards.get().forEach((card: any, index: number) => {
       const quantity =
         settings.mode === OVERLAY_ODDS || settings.mode === OVERLAY_MIXED
           ? "0%"
@@ -250,7 +250,7 @@ export default function DeckList(props: DeckListProps): JSX.Element {
           style={tileStyle}
           card={fullCard}
           dfcCard={dfcCard}
-          key={"sideboardcardtile_" + card.id}
+          key={"sideboardcardtile_" + index + "_" + card.id}
           indent="a"
           isSideboard={true}
           quantity={quantity}


### PR DESCRIPTION
### Motivation
On current `master`, overlays "lose track" of their initial sorting over the course of each game.

https://discordapp.com/channels/463844727654187020/467737642306371584/646428993884520464
![image](https://user-images.githubusercontent.com/14894693/69205671-7a1ed280-0aff-11ea-9a52-de8c7ecc7b89.png)

This was caused by my conversion of the overlay into React components, and is probably a classic case study for folks learning React (or just idiots like me). The problem was caused by the special `key` field being "not specific enough", which I find _not at all obvious_. The prior code only keyed the card tiles of a deck list based on the card ids, which was enough to guarantee uniqueness, but _not order_. So when the quantity of a card changed, React knew to re-render the changed card tile, but it also "helpfully" left all of the other card tiles in place and just stuck the changed tiles at the end of the list, hence making the sorting drift.

The super easy fix is to just stick an index on the `key` as well, and therefore guarantee a unique card and deck ordering for every render.

