### PR TITLE
bugfix grouped lands

### DIFF
--- a/src/overlay/CardDetailsWindowlet.tsx
+++ b/src/overlay/CardDetailsWindowlet.tsx
@@ -41,7 +41,7 @@ const SCALAR = 0.71808510638; // ???
 
 export interface CardDetailsWindowletProps {
   arenaState: number;
-  card?: DbCardData | any; // TODO remove group lands hack
+  card?: DbCardData;
   cardsSizeHoverCard: number;
   editMode: boolean;
   handleToggleEditMode: () => void;
@@ -124,7 +124,7 @@ to stop editing overlay positions`}
           unmountOnExit
         >
           <div style={{ display: "flex" }}>
-            {!!card && <img {...imgProps} />}
+            {!!card && !isCardGroupedLands && <img {...imgProps} />}
             {!!card && arenaState === ARENA_MODE_DRAFT && (
               <div className="main_hover_ratings">
                 <DraftRatings card={card} />

--- a/src/overlay/DeckList.tsx
+++ b/src/overlay/DeckList.tsx
@@ -160,6 +160,12 @@ export default function DeckList(props: DeckListProps): JSX.Element {
   }
   mainCards.get().sort(sortFunc);
   mainCards.get().forEach((card: any, index: number) => {
+    // TODO remove group lands hack
+    const isCardGroupedLands =
+      card && card.id && card.id.id && card.id.id === 100;
+    if (isCardGroupedLands) {
+      card = card.id;
+    }
     let quantity = card.quantity;
     if (settings.mode === OVERLAY_MIXED) {
       const odds = (card.chance !== undefined ? card.chance : "0") + "%";
@@ -179,10 +185,6 @@ export default function DeckList(props: DeckListProps): JSX.Element {
       const rank = getRank(card.id);
       quantity = DRAFT_RANKS[rank];
     }
-
-    // TODO remove group lands hack
-    const isCardGroupedLands =
-      card && card.id && card.id.id && card.id.id === 100;
 
     let fullCard = card;
     if (card && card.id && !isCardGroupedLands) {

--- a/src/shared/CardTile.tsx
+++ b/src/shared/CardTile.tsx
@@ -19,7 +19,7 @@ import { DbCardData, Rarity } from "./types/Metadata";
 import _ from "lodash";
 
 export interface CardTileProps {
-  card: DbCardData | any; // TODO remove group lands hack
+  card: DbCardData;
   deck?: Deck;
   dfcCard?: DbCardData;
   indent: string;
@@ -409,16 +409,11 @@ function FlatCardTile(props: CardTileProps): JSX.Element {
 
 export default function CardTile(props: CardTileProps): JSX.Element {
   const { card, quantity } = props;
-  // TODO remove group lands hack
-  const haxxorProps = { ...props };
-  if (card.id && typeof card.id === "object" && card.id.name) {
-    haxxorProps.card = card.id;
-  }
   if (!card || quantity === 0) {
     return <></>;
   }
-  if (haxxorProps.style === CARD_TILE_FLAT) {
-    return FlatCardTile(haxxorProps);
+  if (props.style === CARD_TILE_FLAT) {
+    return FlatCardTile(props);
   }
-  return ArenaCardTile(haxxorProps);
+  return ArenaCardTile(props);
 }

--- a/src/shared/DeckTypesStats.tsx
+++ b/src/shared/DeckTypesStats.tsx
@@ -12,7 +12,6 @@ function getDeckTypesAmount(deck: DeckData): { [key: string]: number } {
   deck.mainDeck.forEach(function(card: CardData | any) {
     // TODO remove group lands hack
     if (card.id.id && card.id.id == 100) {
-      types.lan += card.quantity;
       return;
     }
     const c = db.card(card.id);

--- a/src/shared/deck-drawer.js
+++ b/src/shared/deck-drawer.js
@@ -21,14 +21,7 @@ export const cardTile = function(
 ) {
   if (quantity === 0) return false;
 
-  let card;
-  if (grpId && typeof grpId == "object" && grpId.name) {
-    // TODO remove group lands hack
-    card = grpId;
-    grpId = grpId.id;
-  } else {
-    card = db.card(grpId);
-  }
+  const card = db.card(grpId);
   let dfcCard;
   if (card && card.dfcId) {
     dfcCard = db.card(card.dfcId);


### PR DESCRIPTION
### Motivation
When I converted the overlay process into React components, I introduced some bugs into the "Compact lands" feature (aka the Group lands hack).

https://discordapp.com/channels/463844727654187020/467737642306371584/646044433971937300
![image](https://user-images.githubusercontent.com/14894693/69312443-cfccab00-0be3-11ea-949e-a01ae8a46ae9.png)

This PR fixes these bugs:
- "Next Draw" mode did not show probability for compact lands
- Draw and Odds mode did not show probability for compact lands
- Hovering over compact lands would show Fblthp underneath the mana color odds display
