### PR TITLE
bugfix initial log pass player detection

### DIFF
--- a/src/window_background/background.js
+++ b/src/window_background/background.js
@@ -516,23 +516,23 @@ async function logLoop() {
     }
 
     // Get player Id
-    strCheck = '"playerId": "';
+    strCheck = '\\"playerId\\": \\"';
     if (value.includes(strCheck)) {
       parsedData.arenaId = debugArenaID
         ? debugArenaID
-        : unleakString(dataChop(value, strCheck, '"'));
+        : unleakString(dataChop(value, strCheck, '\\"'));
     }
 
     // Get User name
-    strCheck = '"screenName": "';
+    strCheck = '\\"screenName\\": \\"';
     if (value.includes(strCheck)) {
-      parsedData.name = unleakString(dataChop(value, strCheck, '"'));
+      parsedData.name = unleakString(dataChop(value, strCheck, '\\"'));
     }
 
     // Get Client Version
-    strCheck = '"clientVersion": "';
+    strCheck = '\\"clientVersion\\": "\\';
     if (value.includes(strCheck)) {
-      parsedData.arenaVersion = unleakString(dataChop(value, strCheck, '"'));
+      parsedData.arenaVersion = unleakString(dataChop(value, strCheck, '\\"'));
     }
     /*
     if (globals.firstPass) {


### PR DESCRIPTION
This gets us past the first v3 log parsing obstacle: detecting the player during the initial log pass (this happens before we apply any of the detailed regexes).

Example fragment of new log format that this now handles:
```
...\"payloadObject\": {\r\n      \"playerId\": \"XFHXKJUVVJA73K3Q4ASNE6SLCM\",\r\n      \"screenName\": \"velocicopter#83538\",\r\n      \"clientVersion\": \"1952.745934\",\r\n...
```