### PR TITLE
bugfix draft event and date

### DIFF
--- a/src/window_background/labels.js
+++ b/src/window_background/labels.js
@@ -93,15 +93,11 @@ function startDraft() {
 }
 
 function getDraftData(id, entry) {
-  const json = entry.json();
   const data = playerData.draft(id) || createDraft(id, entry);
-
-  if (!data.date && json.timestamp) {
+  if (!data.date) {
     // the first event we see we set the date.
-    data.timestamp = json.timestamp;
-    data.date = parseWotcTimeFallback(json.timestamp);
+    data.date = globals.logTime;
   }
-
   return data;
 }
 
@@ -1175,7 +1171,6 @@ export function onLabelInDraftDraftStatus(entry) {
   startDraft();
   const {
     DraftId: draftId,
-    EventName: eventName,
     PackNumber: packNumber,
     PickNumber: pickNumber,
     PickedCards
@@ -1190,7 +1185,6 @@ export function onLabelInDraftDraftStatus(entry) {
     currentPack: (json.DraftPack || []).slice(0)
   };
   data.draftId = data.id;
-  data.set = getDraftSet(eventName) || data.set;
 
   setDraftData(data);
 }
@@ -1201,7 +1195,6 @@ export function onLabelInDraftMakePick(entry) {
   if (!json) return;
   const {
     DraftId: draftId,
-    EventName: eventName,
     PackNumber: packNumber,
     PickNumber: pickNumber,
     PickedCards: pickedCards
@@ -1210,14 +1203,12 @@ export function onLabelInDraftMakePick(entry) {
   const data = {
     ...getDraftData(draftId, entry),
     draftId,
-    eventName,
     packNumber,
     pickNumber,
     pickedCards,
     currentPack: (json.DraftPack || []).slice(0)
   };
   data.draftId = data.id;
-  data.set = getDraftSet(eventName) || data.set;
   setDraftData(data);
 }
 
@@ -1247,6 +1238,7 @@ export function onLabelInEventCompleteDraft(entry) {
     ...getDraftData(draftId, entry),
     ...json
   };
+  data.set = getDraftSet(json.InternalEventName) || data.set;
   data.id = toolId;
   // clear working-space draft data
   clearDraftData(draftId);


### PR DESCRIPTION
Yet more bugfixes for draft data:
- none of the draft log events have a data or timestamp, so we should use `logTime`
- none of the draft log events have `eventName` or `EventName`, so we need to rely on the final draft completion event `InternalEventName`

These bugs caused draft replays to not show up on the history page and instead throw JS errors and make the page not render. (needs a separate PR to handle gracefully?)