### PR TITLE
bugfix overlay mis-tracking cards used

### DIFF
--- a/src/overlay/OverlayController.tsx
+++ b/src/overlay/OverlayController.tsx
@@ -201,7 +201,11 @@ export default function OverlayController(): JSX.Element {
   const handleSetMatch = useCallback((event: unknown, arg: string): void => {
     const newMatch = JSON.parse(arg);
     newMatch.oppCards = new Deck(newMatch.oppCards);
+    // WARNING: this hack to circumvent the Deck object is required!
+    // TODO do something other than this hack
+    const temp = newMatch.playerCardsLeft.mainDeck;
     newMatch.playerCardsLeft = new Deck(newMatch.playerCardsLeft);
+    newMatch.playerCardsLeft.mainboard._list = temp;
     newMatch.player.deck = new Deck(newMatch.player.deck);
     newMatch.player.originalDeck = new Deck(newMatch.player.originalDeck);
     setMatch(newMatch);

--- a/src/overlay/OverlayController.tsx
+++ b/src/overlay/OverlayController.tsx
@@ -201,11 +201,7 @@ export default function OverlayController(): JSX.Element {
   const handleSetMatch = useCallback((event: unknown, arg: string): void => {
     const newMatch = JSON.parse(arg);
     newMatch.oppCards = new Deck(newMatch.oppCards);
-    // WARNING: this hack to circumvent the Deck object is required!
-    // TODO do something other than this hack
-    const temp = newMatch.playerCardsLeft.mainDeck;
     newMatch.playerCardsLeft = new Deck(newMatch.playerCardsLeft);
-    newMatch.playerCardsLeft.mainboard._list = temp;
     newMatch.player.deck = new Deck(newMatch.player.deck);
     newMatch.player.originalDeck = new Deck(newMatch.player.originalDeck);
     setMatch(newMatch);

--- a/src/shared/cards-list.js
+++ b/src/shared/cards-list.js
@@ -15,9 +15,9 @@ class CardsList {
     } else if (typeof list[0] === "object") {
       this._list = list.map(obj => {
         return {
+          quantity: 1, // TODO remove group lands hack
+          id: obj, // TODO remove group lands hack
           ...obj,
-          quantity: obj.quantity || 1,
-          id: obj.id || obj,
           measurable: true
         };
       });

--- a/src/window_background/gre-to-client-interpreter.js
+++ b/src/window_background/gre-to-client-interpreter.js
@@ -611,6 +611,7 @@ function getPlayerUsedCards() {
     const ignoreZones = [
       "ZoneType_Limbo",
       "ZoneType_Library",
+      "ZoneType_Sideboard",
       "ZoneType_Revealed"
     ];
     if (zone.objectInstanceIds && !ignoreZones.includes(zoneType)) {

--- a/src/window_background/labels.js
+++ b/src/window_background/labels.js
@@ -500,7 +500,7 @@ export function onLabelClientToMatchServiceMessageTypeClientToGREMessage(
     const msgType = entry.label.split("_")[1];
     payload = decodePayload(payload, msgType);
     payload = normaliseFields(payload);
-    console.log("Client To GRE: ", payload);
+    // console.log("Client To GRE: ", payload);
   }
 
   if (payload.submitdeckresp) {

--- a/src/window_background/labels.js
+++ b/src/window_background/labels.js
@@ -258,7 +258,7 @@ function select_deck(arg) {
   } else {
     globals.currentDeck = new Deck(arg);
   }
-  console.log("Select deck: ", globals.currentDeck, arg);
+  // console.log("Select deck: ", globals.currentDeck, arg);
   globals.originalDeck = globals.currentDeck.clone();
   ipc_send("set_deck", globals.currentDeck.getSave(), IPC_OVERLAY);
 }
@@ -500,7 +500,7 @@ export function onLabelClientToMatchServiceMessageTypeClientToGREMessage(
     const msgType = entry.label.split("_")[1];
     payload = decodePayload(payload, msgType);
     payload = normaliseFields(payload);
-    //console.log("Client To GRE: ", payload);
+    console.log("Client To GRE: ", payload);
   }
 
   if (payload.submitdeckresp) {


### PR DESCRIPTION
### Motivation
- The new log formats now include a sideboard zone in many of the update messages. This caused our "cards used" logic to be wrong for matches with decks that had sideboards.
- Our `CardsList` constructor had a hacky bit of logic to support my old nemesis, the "Group lands hack". It "helpfully" upgraded all zeros to 1, hence messing up the counts for decks with singletons.

https://discordapp.com/channels/463844727654187020/467737642306371584/648570671009628172
![image](https://user-images.githubusercontent.com/14894693/69570001-bf198d80-0f73-11ea-9027-ecc79b9842e5.png)
