### PR TITLE
update bounds calculation

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -446,15 +446,25 @@ function updateOverlayVisibility() {
     electron.screen.getAllDisplays().forEach(display => {
       newBounds.x = Math.min(newBounds.x, display.bounds.x);
       newBounds.y = Math.min(newBounds.y, display.bounds.y);
+    });
+    electron.screen.getAllDisplays().forEach(display => {
       newBounds.width = Math.max(
         newBounds.width,
-        display.bounds.x + display.bounds.width
+        Math.abs(newBounds.x) + display.bounds.x + display.bounds.width
       );
       newBounds.height = Math.max(
         newBounds.height,
-        display.bounds.y + display.bounds.height
+        Math.abs(newBounds.y) + display.bounds.y + display.bounds.height
       );
     });
+
+    console.log(
+      "Overlay bounds: ",
+      newBounds.x,
+      newBounds.y,
+      newBounds.width,
+      newBounds.height
+    );
 
     overlay.setBounds(newBounds);
     overlay.show();

--- a/src/main.js
+++ b/src/main.js
@@ -442,21 +442,22 @@ function updateOverlayVisibility() {
     clearTimeout(overlayHideTimeout);
     overlayHideTimeout = undefined;
 
-    const newBounds = { x: 0, y: 0, width: 0, height: 0 };
+    let minX = 0;
+    let minY = 0;
+    let maxX = 0;
+    let maxY = 0;
     electron.screen.getAllDisplays().forEach(display => {
-      newBounds.x = Math.min(newBounds.x, display.bounds.x);
-      newBounds.y = Math.min(newBounds.y, display.bounds.y);
+      minX = Math.min(minX, display.bounds.x);
+      minY = Math.min(minY, display.bounds.y);
+      maxX = Math.max(maxX, display.bounds.x + display.bounds.width);
+      maxY = Math.max(maxY, display.bounds.y + display.bounds.height);
     });
-    electron.screen.getAllDisplays().forEach(display => {
-      newBounds.width = Math.max(
-        newBounds.width,
-        Math.abs(newBounds.x) + display.bounds.x + display.bounds.width
-      );
-      newBounds.height = Math.max(
-        newBounds.height,
-        Math.abs(newBounds.y) + display.bounds.y + display.bounds.height
-      );
-    });
+    const newBounds = {
+      x: minX,
+      y: minY,
+      width: maxX - minX,
+      height: maxY - minY
+    };
 
     console.log(
       "Overlay bounds: ",

--- a/src/main.js
+++ b/src/main.js
@@ -442,22 +442,21 @@ function updateOverlayVisibility() {
     clearTimeout(overlayHideTimeout);
     overlayHideTimeout = undefined;
 
-    let minX = 0;
-    let minY = 0;
-    let maxX = 0;
-    let maxY = 0;
+    const newBounds = { x: 0, y: 0, width: 0, height: 0 };
     electron.screen.getAllDisplays().forEach(display => {
-      minX = Math.min(minX, display.bounds.x);
-      minY = Math.min(minY, display.bounds.y);
-      maxX = Math.max(maxX, display.bounds.x + display.bounds.width);
-      maxY = Math.max(maxY, display.bounds.y + display.bounds.height);
+      newBounds.x = Math.min(newBounds.x, display.bounds.x);
+      newBounds.y = Math.min(newBounds.y, display.bounds.y);
     });
-    const newBounds = {
-      x: minX,
-      y: minY,
-      width: maxX - minX,
-      height: maxY - minY
-    };
+    electron.screen.getAllDisplays().forEach(display => {
+      newBounds.width = Math.max(
+        newBounds.width,
+        Math.abs(newBounds.x) + display.bounds.x + display.bounds.width
+      );
+      newBounds.height = Math.max(
+        newBounds.height,
+        Math.abs(newBounds.y) + display.bounds.y + display.bounds.height
+      );
+    });
 
     console.log(
       "Overlay bounds: ",


### PR DESCRIPTION
An attempt to fix the bounds algorithm as show fauly in #763 

As show in debug, the setup was:
```
w 1920 h 1080 x 347 y -1080 
w 1080 h 1920 x -1080 y -158
w 1080 h 1920 x  2560 y -158
w 2560 h 1440 x 0 y 0
```
Using our previous code the result was:
```
-1080 -1080 3640 1762
```

While the expected result should be:
```
-1080 -1080 4720 2842
```
Which is what the current output (this PR) is.

In detail, what I do now is calculate the lowest X and Y coodinates fin the first loop and then calculate the longest width and height values using the lowest X and Y as a base for the size calculation.

Also added debug code just in case.