### PR TITLE
hotfix default logTime must be valid

### DIFF
--- a/src/window_background/globals.ts
+++ b/src/window_background/globals.ts
@@ -34,7 +34,7 @@ let instanceToCardIdMap: any = {};
 
 let logReadStart: any = null;
 
-let logTime = false;
+let logTime = new Date();
 
 let matchCompletedOnGameNumber = 0;
 


### PR DESCRIPTION
### Motivation
Users reported that they see the tool occasionally miss recording economy transactions. The irregular nature of the reports probably has to do with differences in user session length/timing, because the underlying bug appears to be "the tool fails to save economy transactions correctly before I play my first game / do my first draft".

https://discordapp.com/channels/463844727654187020/467737642306371584/650612160426147840
![image](https://user-images.githubusercontent.com/14894693/69918732-ad7c2e00-142a-11ea-9736-72c3aa4c32ac.png)

### Approach
This hotfix abandons relying on a stable previous `globals.logTime` value and instead just relies on the current date being a "good enough" value to fall back on. (Note that this means that processing older output logs will result in past transactions "time travelling" to the present.)
