### PR TITLE
hotfix ensure log IDs are unique

### DIFF
--- a/src/window_background/arena-log-decoder/arena-log-decoder.js
+++ b/src/window_background/arena-log-decoder/arena-log-decoder.js
@@ -37,10 +37,12 @@ export default function ArenaLogDecoder() {
     let bufferUsed = false;
     let match;
     while ((match = logEntryPattern.exec(buffer))) {
+      const position = bufferDiscarded + match.index;
       const [type, length, entry] = parseLogEntry(
         buffer,
         match[0],
-        match.index
+        match.index,
+        position
       );
       switch (type) {
         case "invalid":
@@ -53,7 +55,7 @@ export default function ArenaLogDecoder() {
           bufferUsed = match.index + length;
           callback({
             ...entry,
-            position: bufferDiscarded + match.index
+            position
           });
           break;
       }
@@ -73,7 +75,7 @@ export default function ArenaLogDecoder() {
   }
 }
 
-function parseLogEntry(text, matchText, position) {
+function parseLogEntry(text, matchText, position, absPosition) {
   let rematches;
 
   if ((rematches = matchText.match(LABEL_ARROW_JSON_PATTERN))) {
@@ -105,7 +107,7 @@ function parseLogEntry(text, matchText, position) {
       {
         type: "label_arrow_json",
         ..._.mapValues(rematches.groups, unleakString),
-        hash: sha1(jsonString),
+        hash: sha1(jsonString + absPosition),
         json: () => {
           try {
             // console.log(jsonString, jsonStart, jsonLen);
@@ -156,7 +158,7 @@ function parseLogEntry(text, matchText, position) {
       {
         type: "label_json",
         ..._.mapValues(rematches.groups, unleakString),
-        hash: sha1(jsonString),
+        hash: sha1(jsonString + absPosition),
         text: jsonString,
         json: () => {
           try {

--- a/src/window_background/labels.js
+++ b/src/window_background/labels.js
@@ -569,6 +569,7 @@ export function onLabelInEventGetActiveEventsV2(entry) {
 export function onLabelRankUpdated(entry) {
   const json = entry.json();
   if (!json) return;
+  json.id = entry.hash;
   json.date = json.timestamp;
   json.timestamp = globals.logTime;
   json.lastMatchId = globals.currentMatch.matchId;
@@ -584,11 +585,7 @@ export function onLabelRankUpdated(entry) {
   rank[updateType].step = json.newStep;
   rank[updateType].seasonOrdinal = json.seasonOrdinal;
 
-  json.id = sha1(
-    updateType + json.seasonOrdinal + json.lastMatchId + json.date
-  );
-
-  let seasonal_rank = playerData.addSeasonalRank(
+  const seasonal_rank = playerData.addSeasonalRank(
     json,
     json.seasonOrdinal,
     updateType
@@ -743,7 +740,7 @@ export function onLabelInDeckUpdateDeckV3(entry) {
   json = convertDeckFromV3(json);
   const _deck = playerData.deck(json.id);
 
-  const changeId = sha1(json.id + "-" + json.lastUpdated);
+  const changeId = entry.hash;
   const deltaDeck = {
     id: changeId,
     deckId: _deck.id,
@@ -853,7 +850,7 @@ export function onLabelInventoryUpdated(entry) {
       delta.context = transaction.context + "." + update.context.source;
     }
     // Construct a unique ID
-    delta.id = sha1(JSON.stringify(delta));
+    delta.id = sha1(JSON.stringify(delta) + entry.hash);
     // Add missing data
     delta.date = globals.logTime;
     // Add delta to our current values
@@ -927,7 +924,7 @@ function inventoryUpdate(entry, update) {
     subContext: update.context // preserve sub-context object data
   };
   // Construct a unique ID
-  transaction.id = sha1(JSON.stringify(transaction));
+  transaction.id = sha1(JSON.stringify(transaction) + entry.hash);
   // Add missing data
   transaction.date = globals.logTime;
 
@@ -1069,6 +1066,7 @@ export function onLabelTrackRewardTierUpdated(entry) {
   const economy = { ...playerData.economy };
 
   const transaction = {
+    id: entry.hash,
     context: "Track.RewardTier.Updated",
     timestamp: json.timestamp,
     date: parseWotcTimeFallback(json.timestamp),
@@ -1092,8 +1090,6 @@ export function onLabelTrackRewardTierUpdated(entry) {
     }
   }
 
-  // Construct a unique ID
-  transaction.id = sha1(JSON.stringify(transaction));
   saveEconomyTransaction(transaction);
 
   // console.log(economy);


### PR DESCRIPTION
### Motivation
https://discordapp.com/channels/463844727654187020/506793351786266624/651806532651974660
![image](https://user-images.githubusercontent.com/14894693/70198342-75dbe300-16c3-11ea-9b4b-a2b3933c09df.png)

### Approach
- add some plumbing to pass around the absolute position of an entry match
- hash the absolute position along with the data to reduce the likelihood of ID collisions (they are still possible with this approach, especially as players build up lots of play history)
- update all places in `labels` where we generate IDs to either use `entry.hash` or a combination of `entry.hash` and the relevent sub-entry data