### PR TITLE
hotfix economy page js error

### DIFF
--- a/src/window_main/components/economy/EconomyRow.tsx
+++ b/src/window_main/components/economy/EconomyRow.tsx
@@ -33,7 +33,17 @@ interface BoosterDeltaProps {
 function BoosterDelta(props: BoosterDeltaProps) {
   const { booster } = props;
   const set = getCollationSet(booster.collationId);
-  return <EconomyValueRecord iconClassName={"set_logo_med"} iconUrl={"url(../images/sets/" + db.sets[set].code + ".png)"} title={set} deltaContent={"x" + Math.abs(booster.count)} />
+  const imagePath = db.sets[set] && db.sets[set].code
+    ? "sets/" + db.sets[set].code + ".png"
+    : "notfound.png";
+  return (
+    <EconomyValueRecord
+      iconClassName={"set_logo_med"}
+      iconUrl={"url(../images/" + imagePath + ")"}
+      title={set}
+      deltaContent={"x" + Math.abs(booster.count)}
+    />
+  );
 }
 
 interface PossibleModifiedEconomyStats {


### PR DESCRIPTION
Fixes a JS error on the economy page caused by winning a Theros booster pack in the promo event.
![image](https://user-images.githubusercontent.com/14894693/70834989-989b8500-1db0-11ea-99af-2fde4343bab1.png)
