### PR TITLE
Convert MANA to dictionary to access it by index

### DIFF
--- a/src/overlay/DraftElements.tsx
+++ b/src/overlay/DraftElements.tsx
@@ -13,7 +13,6 @@ import DeckList from "./DeckList";
 import { DbCardData } from "../shared/types/Metadata";
 
 const packSizeMap: { [key: string]: number } = PACK_SIZES;
-const manaColorMap: { [key: number]: string } = MANA;
 
 export interface DraftElementsProps {
   draft: DraftData;
@@ -131,10 +130,7 @@ export default function DraftElements(props: DraftElementsProps): JSX.Element {
       {!!settings.title && !!visibleDeck && (
         <div className="overlay_deckcolors">
           {visibleDeck.colors.get().map((color: number) => (
-            <div
-              className={"mana_s20 mana_" + manaColorMap[color]}
-              key={color}
-            />
+            <div className={"mana_s20 mana_" + MANA[color]} key={color} />
           ))}
         </div>
       )}

--- a/src/overlay/MatchElements.tsx
+++ b/src/overlay/MatchElements.tsx
@@ -16,8 +16,6 @@ import Clock from "./Clock";
 import DeckList from "./DeckList";
 import { DbCardData } from "../shared/types/Metadata";
 
-const manaColorMap: { [key: number]: string } = MANA;
-
 export interface MatchElementsProps {
   actionLog: LogData[];
   index: number;
@@ -101,10 +99,7 @@ export default function MatchElements(props: MatchElementsProps): JSX.Element {
       {!!settings.title && !!visibleDeck && (
         <div className="overlay_deckcolors">
           {visibleDeck.colors.get().map((color: number) => (
-            <div
-              className={"mana_s20 mana_" + manaColorMap[color]}
-              key={color}
-            />
+            <div className={"mana_s20 mana_" + MANA[color]} key={color} />
           ))}
         </div>
       )}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -735,7 +735,7 @@ export const MANA_COLORS = [
   "#E3E3E3"
 ] as const;
 
-export const MANA = {
+export const MANA: { [key: number]: string } = {
   0: "",
   1: "white",
   2: "blue",

--- a/src/window_main/components/decks/cells.tsx
+++ b/src/window_main/components/decks/cells.tsx
@@ -123,12 +123,7 @@ export function ColorsCell({ cell }: CellProps): JSX.Element {
   return (
     <StyledFlexRightCell>
       {data.colors.map((color: number, index: number) => {
-        return (
-          <div
-            key={index}
-            className={"mana_s20 mana_" + (MANA as any)[color]}
-          />
-        );
+        return <div key={index} className={"mana_s20 mana_" + MANA[color]} />;
       })}
     </StyledFlexRightCell>
   );

--- a/src/window_main/components/decks/filters.tsx
+++ b/src/window_main/components/decks/filters.tsx
@@ -129,9 +129,7 @@ export function uberSearchFilterFn(
         "values.tags",
         (row: any): string => {
           const { colors } = row.values;
-          return colors
-            .map((color: number): string => (MANA as any)[color])
-            .join(" ");
+          return colors.map((color: number): string => MANA[color]).join(" ");
         }
       ]
     })


### PR DESCRIPTION
This converts the `MANA` const from an enum to a dictionary type so that it can be accessed by index in TypeScript files.
This makes some conversions to dictionaries obsolete, so they were removed.