### PR TITLE
bugfix decks table archived column filter and sort

### DIFF
--- a/src/window_main/DecksTab.tsx
+++ b/src/window_main/DecksTab.tsx
@@ -49,18 +49,26 @@ function getDefaultStats(): DeckStats {
 }
 
 function setFilters(selected: AggregatorFilters = {}): void {
+  const { decksTableState } = pd.settings;
+  const showArchived = decksTableState?.filters?.archivedCol !== "hideArchived";
+
   if (selected.date) {
     // clear all dependent filters
     filters = {
       ...Aggregator.getDefaultFilters(),
       date: filters.date,
       onlyCurrentDecks: true,
-      showArchived: filters.showArchived,
-      ...selected
+      ...selected,
+      showArchived
     };
   } else {
     // default case
-    filters = { ...filters, date: pd.settings.last_date_filter, ...selected };
+    filters = {
+      ...filters,
+      date: pd.settings.last_date_filter,
+      ...selected,
+      showArchived
+    };
   }
 }
 
@@ -98,6 +106,7 @@ export function openDecksTab(newFilters: AggregatorFilters = {}): void {
   const data = pd.deckList.map(
     (deck: SerializedDeck): DecksData => {
       const id = deck.id ?? "";
+      const archivedSortVal = deck.archived ? 1 : deck.custom ? 0.5 : 0;
       const colorSortVal = deck.colors ? deck.colors.join("") : "";
       // compute winrate metrics
       const deckStats: DeckStats =
@@ -120,6 +129,7 @@ export function openDecksTab(newFilters: AggregatorFilters = {}): void {
         avgDuration,
         ...missingWildcards,
         boosterCost,
+        archivedSortVal,
         colorSortVal,
         timeUpdated: isValid(lastUpdated) ? lastUpdated.getTime() : NaN,
         timePlayed: isValid(lastPlayed) ? lastPlayed.getTime() : NaN,

--- a/src/window_main/components/decks/DecksTable.tsx
+++ b/src/window_main/components/decks/DecksTable.tsx
@@ -223,13 +223,16 @@ export default function DecksTable({
       { accessor: "uncommon" },
       { accessor: "mythic" },
       { accessor: "custom" },
+      { accessor: "archived" },
       {
+        id: "archivedCol",
         Header: ArchiveHeader,
-        accessor: "archived",
+        accessor: "archivedSortVal",
         filter: "showArchived",
         Filter: ArchiveColumnFilter,
         disableFilters: false,
-        Cell: CellWrapper(ArchivedCell)
+        Cell: CellWrapper(ArchivedCell),
+        sortType: "basic"
       }
     ],
     [CellWrapper]
@@ -271,7 +274,6 @@ export default function DecksTable({
           "winrateLow",
           "winrateHigh"
         ],
-        filters: { archived: "hideArchived" },
         sortBy: [{ id: "timeTouched", desc: true }]
       }),
     [cachedState]
@@ -295,13 +297,8 @@ export default function DecksTable({
       useControlledState: (state: DecksTableState) => {
         return React.useMemo(() => {
           tableStateCallback(state);
-          const aggFilter = filters.showArchived;
-          const tableFilter = state.filters.archived === "showArchived";
-          if (aggFilter !== tableFilter) {
-            filterMatchesCallback({ ...filters, showArchived: tableFilter });
-          }
           return state;
-        }, [state, tableStateCallback, filters, filterMatchesCallback]);
+        }, [state, tableStateCallback]);
       },
       defaultColumn,
       filterTypes,
@@ -380,7 +377,7 @@ export default function DecksTable({
         <span style={{ paddingBottom: "8px" }}>Presets:</span>
         <PresetButton
           onClick={(): void => {
-            setAllFilters({ archived: "hideArchived" });
+            setAllFilters({ archivedCol: "hideArchived" });
             setFiltersVisible(initialFiltersVisible);
             toggleSortBy("timeTouched", true);
             for (const columnId of toggleableIds) {
@@ -400,7 +397,7 @@ export default function DecksTable({
         <PresetButton
           onClick={(): void => {
             setAllFilters({
-              archived: "hideArchived",
+              archivedCol: "hideArchived",
               wins: [5, undefined],
               winrate100: [50, undefined]
             });
@@ -428,7 +425,7 @@ export default function DecksTable({
         <PresetButton
           onClick={(): void => {
             setAllFilters({
-              archived: "hideArchived",
+              archivedCol: "hideArchived",
               boosterCost: [1, undefined]
             });
             setFiltersVisible({ ...initialFiltersVisible, boosterCost: true });
@@ -521,9 +518,10 @@ export default function DecksTable({
                           <div
                             style={{ marginRight: 0 }}
                             className={"button close"}
-                            onClick={(): void =>
-                              setFilter(column.id, undefined)
-                            }
+                            onClick={(e): void => {
+                              e.stopPropagation();
+                              setFilter(column.id, undefined);
+                            }}
                             title={"clear column filter"}
                           />
                         </div>
@@ -550,9 +548,10 @@ export default function DecksTable({
                             <div
                               style={{ marginRight: 0 }}
                               className={"button close"}
-                              onClick={(): void =>
-                                setFilter(column.id, undefined)
-                              }
+                              onClick={(e): void => {
+                                e.stopPropagation();
+                                setFilter(column.id, undefined);
+                              }}
                               title={"clear search"}
                             />
                           </div>

--- a/src/window_main/components/decks/cells.tsx
+++ b/src/window_main/components/decks/cells.tsx
@@ -495,8 +495,8 @@ export function ArchivedCell({
   cell,
   archiveDeckCallback
 }: CellProps): JSX.Element {
-  const isArchived = !!cell.value;
   const data = cell.row.values;
+  const isArchived = data.archived;
   if (!data.custom) {
     return <></>;
   }

--- a/src/window_main/components/decks/filters.tsx
+++ b/src/window_main/components/decks/filters.tsx
@@ -179,13 +179,13 @@ export function ArchiveColumnFilter({
 }): JSX.Element {
   return (
     <StyledCheckboxContainer>
-      show all
+      archived
       <input
         type="checkbox"
         checked={filterValue !== "hideArchived"}
         onChange={(e): void => {
           const val = e.target.checked;
-          setFilter(val ? "showArchived" : "hideArchived");
+          setFilter(val ? undefined : "hideArchived");
         }}
       />
       <span className={"checkmark"} />

--- a/src/window_main/components/decks/types.ts
+++ b/src/window_main/components/decks/types.ts
@@ -20,6 +20,7 @@ export interface MissingWildcards {
 
 export interface DecksData extends SerializedDeck, DeckStats, MissingWildcards {
   winrate100: number;
+  archivedSortVal: number;
   avgDuration: number;
   boosterCost: number;
   colorSortVal: string;


### PR DESCRIPTION
Fixes some misc problems with the decks table archived column:
- makes the filter checkbox work
- makes the sort work
- renames the checkbox to match the old "archived" checkbox

Bonus:
- clicking a clear filter "x" button no longer sorts by that column