### PR TITLE
Port actionLog.js to TypeScript

### DIFF
--- a/src/window_background/actionLog.ts
+++ b/src/window_background/actionLog.ts
@@ -7,8 +7,12 @@ import format from "date-fns/format";
 
 var currentActionLog = "";
 
-const actionLog = function(seat, time, str, grpId = 0) {
-  if (!time) time = new Date();
+const actionLog = function(
+  seat: number,
+  time = new Date(),
+  str: string,
+  grpId = 0
+): void {
   if (seat == -99) {
     currentActionLog = "version: 1\r\n";
   } else {


### PR DESCRIPTION
Just a small TS port.

One thing I noticed though is that if the `if` evaluates to `true`, `currentActionLog` is set, but not used. I guess the file write should happen outside of the `if`-block, but I don't know if there is any rationale behind writing only in the "not -99" case.

Another thing is that while `-99` is handled as exceptional case, other negative values that are used in callers (`-2` and `-1`) aren't. I didn't touch the condition for now, but maybe we should in the future?