### PR TITLE
Migrate mtga-log to TypeScript

### DIFF
--- a/src/window_background/background.js
+++ b/src/window_background/background.js
@@ -11,7 +11,7 @@ import { getReadableFormat } from "../shared/util";
 import { HIDDEN_PW, MAIN_DECKS } from "../shared/constants";
 import { ipc_send, setData, unleakString } from "./backgroundUtil";
 import { createDeck } from "./data";
-import * as mtgaLog from "./mtga-log";
+import * as mtgaLog from "./mtgaLog";
 import globals from "./globals";
 import addCustomDeck from "./addCustomDeck";
 import forceDeckUpdate from "./forceDeckUpdate";

--- a/src/window_background/mtgaLog.ts
+++ b/src/window_background/mtgaLog.ts
@@ -8,7 +8,7 @@ const fsPromises = {
   read: promisify(fs.read)
 };
 
-export function defaultLogUri() {
+export function defaultLogUri(): string {
   if (process.platform !== "win32") {
     return (
       process.env.HOME +
@@ -17,13 +17,16 @@ export function defaultLogUri() {
       "/AppData/LocalLow/Wizards of the Coast/MTGA/output_log.txt"
     );
   }
-  return process.env.APPDATA.replace(
-    "Roaming",
-    "LocalLow\\Wizards Of The Coast\\MTGA\\output_log.txt"
+
+  const windowsMtgaLogFolder =
+    "LocalLow\\Wizards Of The Coast\\MTGA\\output_log.txt";
+  return (
+    process.env.APPDATA?.replace("Roaming", windowsMtgaLogFolder) ??
+    "c:\\users\\" + process.env.USER + "\\AppData\\" + windowsMtgaLogFolder
   );
 }
 
-export async function exists(path) {
+export async function exists(path: fs.PathLike) {
   try {
     await fsPromises.access(path, fs.constants.R_OK);
     return true;
@@ -32,11 +35,15 @@ export async function exists(path) {
   }
 }
 
-export async function stat(path) {
+export async function stat(path: fs.PathLike) {
   return await fsPromises.stat(path);
 }
 
-export async function readSegment(path, start, length) {
+export async function readSegment(
+  path: fs.PathLike,
+  start: number | null,
+  length: number
+) {
   const fd = await fsPromises.open(path, "r");
   try {
     const buffer = Buffer.alloc(length);

--- a/src/window_background/mtgaLog.ts
+++ b/src/window_background/mtgaLog.ts
@@ -26,7 +26,7 @@ export function defaultLogUri(): string {
   );
 }
 
-export async function exists(path: fs.PathLike) {
+export async function exists(path: fs.PathLike): Promise<boolean> {
   try {
     await fsPromises.access(path, fs.constants.R_OK);
     return true;
@@ -35,7 +35,7 @@ export async function exists(path: fs.PathLike) {
   }
 }
 
-export async function stat(path: fs.PathLike) {
+export async function stat(path: fs.PathLike): Promise<fs.Stats> {
   return await fsPromises.stat(path);
 }
 
@@ -43,7 +43,7 @@ export async function readSegment(
   path: fs.PathLike,
   start: number | null,
   length: number
-) {
+): Promise<string> {
   const fd = await fsPromises.open(path, "r");
   try {
     const buffer = Buffer.alloc(length);


### PR DESCRIPTION
Just a small migration from `mtga-log.js` to TypeScript.

TS was complaining about `APPDATA` possibly being undefined, so I introduced the fallback case where the folder path is constructed using default windows settings.