### PR TITLE
Decks table misc

### DIFF
--- a/src/window_main/components/decks/DecksTable.tsx
+++ b/src/window_main/components/decks/DecksTable.tsx
@@ -455,29 +455,29 @@ export default function DecksTable({
       >
         {headers
           .filter((header: any) => header.isVisible)
-          .map((header: any, ii: number) => (
+          .map((column: any, ii: number) => (
             <div
-              {...header.getHeaderProps(header.getSortByToggleProps())}
+              {...column.getHeaderProps(column.getSortByToggleProps())}
               className={"hover_label"}
               style={{
                 height: "64px",
                 gridArea: `1 / ${ii + 1} / 1 / ${ii + 2}`
               }}
-              key={header.id}
+              key={column.id}
             >
               <div className={"decks_table_head_container"}>
                 <div
                   className={
-                    header.isSorted
-                      ? header.isSortedDesc
+                    column.isSorted
+                      ? column.isSortedDesc
                         ? " sort_desc"
                         : " sort_asc"
                       : ""
                   }
                   style={{ marginRight: "4px", width: "16px" }}
                 />
-                <div className={"flex_item"}>{header.render("Header")}</div>
-                {header.canFilter && header.id !== "deckTileId" && (
+                <div className={"flex_item"}>{column.render("Header")}</div>
+                {column.canFilter && column.id !== "deckTileId" && (
                   <div
                     style={{ marginRight: 0 }}
                     className={"button settings"}
@@ -485,28 +485,28 @@ export default function DecksTable({
                       e.stopPropagation();
                       setFiltersVisible({
                         ...filtersVisible,
-                        [header.id]: !filtersVisible[header.id]
+                        [column.id]: !filtersVisible[column.id]
                       });
                     }}
                     title={
-                      (filtersVisible[header.id] ? "hide" : "show") +
+                      (filtersVisible[column.id] ? "hide" : "show") +
                       " column filter"
                     }
                   />
                 )}
-                {header.filterValue && header.id !== "deckTileId" && (
+                {column.filterValue && column.id !== "deckTileId" && (
                   <div
                     style={{ marginRight: 0 }}
                     className={"button close"}
                     onClick={(e): void => {
                       e.stopPropagation();
-                      setFilter(header.id, undefined);
+                      setFilter(column.id, undefined);
                     }}
                     title={"clear column filter"}
                   />
                 )}
               </div>
-              {header.canFilter && filtersVisible[header.id] && (
+              {column.canFilter && filtersVisible[column.id] && (
                 <div
                   onClick={(e): void => e.stopPropagation()}
                   style={{
@@ -515,14 +515,14 @@ export default function DecksTable({
                   }}
                   title={"filter column"}
                 >
-                  {header.render("Filter")}
-                  {header.filterValue && header.id === "deckTileId" && (
+                  {column.render("Filter")}
+                  {column.filterValue && column.id === "deckTileId" && (
                     <div
                       style={{ marginRight: 0 }}
                       className={"button close"}
                       onClick={(e): void => {
                         e.stopPropagation();
-                        setFilter(header.id, undefined);
+                        setFilter(column.id, undefined);
                       }}
                       title={"clear search"}
                     />

--- a/src/window_main/components/decks/DecksTable.tsx
+++ b/src/window_main/components/decks/DecksTable.tsx
@@ -260,6 +260,7 @@ export default function DecksTable({
 
   const {
     flatColumns,
+    headers,
     getTableProps,
     getTableBodyProps,
     headerGroups,
@@ -452,88 +453,84 @@ export default function DecksTable({
         }}
         {...getTableProps()}
       >
-        {headerGroups.map((headerGroup: any) => {
-          return (
-            <>
-              {headerGroup.headers.map((column: any, ii: number) => (
+        {headers
+          .filter((header: any) => header.isVisible)
+          .map((header: any, ii: number) => (
+            <div
+              {...header.getHeaderProps(header.getSortByToggleProps())}
+              className={"hover_label"}
+              style={{
+                height: "64px",
+                gridArea: `1 / ${ii + 1} / 1 / ${ii + 2}`
+              }}
+              key={header.id}
+            >
+              <div className={"decks_table_head_container"}>
                 <div
-                  {...column.getHeaderProps(column.getSortByToggleProps())}
-                  className={"hover_label"}
+                  className={
+                    header.isSorted
+                      ? header.isSortedDesc
+                        ? " sort_desc"
+                        : " sort_asc"
+                      : ""
+                  }
+                  style={{ marginRight: "4px", width: "16px" }}
+                />
+                <div className={"flex_item"}>{header.render("Header")}</div>
+                {header.canFilter && header.id !== "deckTileId" && (
+                  <div
+                    style={{ marginRight: 0 }}
+                    className={"button settings"}
+                    onClick={(e): void => {
+                      e.stopPropagation();
+                      setFiltersVisible({
+                        ...filtersVisible,
+                        [header.id]: !filtersVisible[header.id]
+                      });
+                    }}
+                    title={
+                      (filtersVisible[header.id] ? "hide" : "show") +
+                      " column filter"
+                    }
+                  />
+                )}
+                {header.filterValue && header.id !== "deckTileId" && (
+                  <div
+                    style={{ marginRight: 0 }}
+                    className={"button close"}
+                    onClick={(e): void => {
+                      e.stopPropagation();
+                      setFilter(header.id, undefined);
+                    }}
+                    title={"clear column filter"}
+                  />
+                )}
+              </div>
+              {header.canFilter && filtersVisible[header.id] && (
+                <div
+                  onClick={(e): void => e.stopPropagation()}
                   style={{
-                    height: "64px",
-                    gridArea: `1 / ${ii + 1} / 1 / ${ii + 2}`
+                    display: "flex",
+                    justifyContent: "center"
                   }}
-                  key={column.id}
+                  title={"filter column"}
                 >
-                  <div className={"decks_table_head_container"}>
+                  {header.render("Filter")}
+                  {header.filterValue && header.id === "deckTileId" && (
                     <div
-                      className={
-                        column.isSorted
-                          ? column.isSortedDesc
-                            ? " sort_desc"
-                            : " sort_asc"
-                          : ""
-                      }
-                      style={{ marginRight: "4px", width: "16px" }}
-                    />
-                    <div className={"flex_item"}>{column.render("Header")}</div>
-                    {column.canFilter && column.id !== "deckTileId" && (
-                      <div
-                        style={{ marginRight: 0 }}
-                        className={"button settings"}
-                        onClick={(e): void => {
-                          e.stopPropagation();
-                          setFiltersVisible({
-                            ...filtersVisible,
-                            [column.id]: !filtersVisible[column.id]
-                          });
-                        }}
-                        title={
-                          (filtersVisible[column.id] ? "hide" : "show") +
-                          " column filter"
-                        }
-                      />
-                    )}
-                    {column.filterValue && column.id !== "deckTileId" && (
-                      <div
-                        style={{ marginRight: 0 }}
-                        className={"button close"}
-                        onClick={(e): void => {
-                          e.stopPropagation();
-                          setFilter(column.id, undefined);
-                        }}
-                        title={"clear column filter"}
-                      />
-                    )}
-                  </div>
-                  {column.canFilter && filtersVisible[column.id] && (
-                    <div
-                      onClick={(e): void => e.stopPropagation()}
-                      style={{
-                        display: "flex",
-                        justifyContent: "center"
+                      style={{ marginRight: 0 }}
+                      className={"button close"}
+                      onClick={(e): void => {
+                        e.stopPropagation();
+                        setFilter(header.id, undefined);
                       }}
-                      title={"filter column"}
-                    >
-                      {column.render("Filter")}
-                      {column.filterValue && column.id === "deckTileId" && (
-                        <div
-                          style={{ marginRight: 0 }}
-                          className={"button close"}
-                          onClick={(e): void => {
-                            e.stopPropagation();
-                            setFilter(column.id, undefined);
-                          }}
-                          title={"clear search"}
-                        />
-                      )}
-                    </div>
+                      title={"clear search"}
+                    />
                   )}
                 </div>
-              ))}
-            </>
-          );
-        })}
+              )}
+            </div>
+          ))}
       </div>
       <div className="decks_table_body" {...getTableBodyProps()}>
         {rows.map((row: any) => {

--- a/src/window_main/index.css
+++ b/src/window_main/index.css
@@ -3854,6 +3854,7 @@ a:hover {
 
 .decks_table_body_row:hover {
     background-color: rgba(0,0,0,0.4);
+    cursor: pointer;
 }
 
 .decks_table_body_row .inner_div {
@@ -3866,4 +3867,5 @@ a:hover {
 
 .hover_label:hover {
     background-color: rgba(0,0,0,0.4);
+    cursor: pointer;
 }


### PR DESCRIPTION
Fixes 2 misc regressions introduced in #814:
- restores the `cursor: pointer` style to the table rows and header cells
- bugfixes rendering performance by eliminating the react `key` error
  - instead of adding a `headerGroup` wrapping element with a key, I chose to simplify the number of rendering loops to make it unnecessary.