### PR TITLE
Bugfix add card hover types

### DIFF
--- a/src/shared/cardHover.tsx
+++ b/src/shared/cardHover.tsx
@@ -26,10 +26,7 @@ export function attachOwnerhipStars(
   ReactDOM.render(<OwnershipStars card={card} />, starContainer);
 }
 
-export function addCardHover(
-  element: HTMLElement,
-  card: false | DbCardData
-): void {
+export function addCardHover(element: HTMLElement, card?: DbCardData): void {
   if (!card) return;
 
   const dbCard = card;

--- a/src/window_main/components/economy/EconomyRow.tsx
+++ b/src/window_main/components/economy/EconomyRow.tsx
@@ -23,6 +23,7 @@ import React, { useState } from "react";
 import EconomyValueRecord, { EconomyIcon } from "./EconomyValueRecord";
 import ReactDOM from "react-dom";
 import LocalTime from "../../../shared/time-components/LocalTime";
+import { DbCardData } from "../../../shared/types/Metadata";
 
 function EconomyRowDate(date: Date) {
   return (
@@ -427,7 +428,7 @@ function FlexRight(props: FlexRightProps) {
 }
 
 interface InventoryCardProps {
-  card: any;
+  card?: DbCardData;
   isAetherized?: boolean;
   quantity?: number;
 }
@@ -437,7 +438,7 @@ function InventoryCard(props: InventoryCardProps) {
   const inventoryCardRef = React.useRef<HTMLDivElement>(null);
   const onCardClick = React.useCallback(
     (e: React.MouseEvent<HTMLDivElement>) => {
-      const lookupCard = card.dfc == "SplitHalf" ? db.card(card.dfcId) : card;
+      const lookupCard = db.card(card?.dfcId) ?? card;
       openScryfallCard(lookupCard);
     },
     [card]

--- a/src/window_main/components/economy/EconomyRow.tsx
+++ b/src/window_main/components/economy/EconomyRow.tsx
@@ -453,7 +453,7 @@ function InventoryCard(props: InventoryCardProps) {
 
   const tooltip = isAetherized
     ? computeAetherizedTooltip(card, quantity)
-    : card.name;
+    : card?.name ?? "";
   return (
     <div
       ref={inventoryCardRef}


### PR DESCRIPTION
Current `develop` has a broken build because of a call to `addCardHover` that got merged in `collectionStats` but not handled well when `db.card` had its TS signature adjusted. Instead of fixing the build by adding a janky `card ?? false` expression, I opted to make the singature of `addCardHover` match `db.card`. This change is also more correct for all other existing calls to `addCardHover` in `.ts` and `.js`.

There is also a bonus bugfix for dual cards in `EconomyRow`.