### PR TITLE
Decks Table Control Upgrades

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -807,3 +807,7 @@ export const DATE_LAST_DAY = "Last 24 Hours";
 export const DATE_LAST_30 = "Last 30 Days";
 export const DATE_SEASON = "Current Season";
 export const DATE_ALL_TIME = "All Time";
+
+export const DECK_ART_MODE = "Deck Art View";
+export const TABLE_MODE = "Table View";
+export const TABLE_MODES = [DECK_ART_MODE, TABLE_MODE];

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -808,6 +808,6 @@ export const DATE_LAST_30 = "Last 30 Days";
 export const DATE_SEASON = "Current Season";
 export const DATE_ALL_TIME = "All Time";
 
-export const DECK_ART_MODE = "Deck Art View";
-export const TABLE_MODE = "Table View";
-export const TABLE_MODES = [DECK_ART_MODE, TABLE_MODE];
+export const DECKS_ART_MODE = "Deck Art View";
+export const DECKS_TABLE_MODE = "Table View";
+export const DECKS_TABLE_MODES = [DECKS_ART_MODE, DECKS_TABLE_MODE];

--- a/src/shared/player-data.js
+++ b/src/shared/player-data.js
@@ -3,7 +3,7 @@ import _ from "lodash";
 import {
   CARD_TILE_FLAT,
   DATE_LAST_30,
-  DECK_ART_MODE,
+  DECKS_ART_MODE,
   DEFAULT_TILE,
   BLACK,
   BLUE,
@@ -78,7 +78,7 @@ const defaultCfg = {
     last_date_filter: DATE_LAST_30,
     last_open_tab: -1,
     decksTableState: undefined,
-    decksTableMode: DECK_ART_MODE,
+    decksTableMode: DECKS_ART_MODE,
     card_tile_style: CARD_TILE_FLAT,
     skip_firstpass: false,
     overlay_scale: 100,

--- a/src/shared/player-data.js
+++ b/src/shared/player-data.js
@@ -3,6 +3,7 @@ import _ from "lodash";
 import {
   CARD_TILE_FLAT,
   DATE_LAST_30,
+  DECK_ART_MODE,
   DEFAULT_TILE,
   BLACK,
   BLUE,
@@ -77,6 +78,7 @@ const defaultCfg = {
     last_date_filter: DATE_LAST_30,
     last_open_tab: -1,
     decksTableState: undefined,
+    decksTableMode: DECK_ART_MODE,
     card_tile_style: CARD_TILE_FLAT,
     skip_firstpass: false,
     overlay_scale: 100,

--- a/src/shared/shared.css
+++ b/src/shared/shared.css
@@ -628,7 +628,7 @@ label {
     background-size: contain;
     width: 20px;
     height: 20px;
-    margin: 0 2px auto 2px;
+    margin: auto 2px auto 2px;
     background-repeat: no-repeat;
     filter: drop-shadow(-1px 1px black);
 }
@@ -637,11 +637,11 @@ label {
     z-index: 15;
     pointer-events: none;
     background-size: contain;
-    box-shadow: -1px 1px black;
-    border-radius: 100%;
     width: 16px;
     height: 16px;
     margin: auto 2px auto 2px;
+    background-repeat: no-repeat;
+    filter: drop-shadow(-1px 1px black);
 }
 
 .mana_16 {

--- a/src/window_main/DecksTab.tsx
+++ b/src/window_main/DecksTab.tsx
@@ -142,12 +142,13 @@ export function openDecksTab(newFilters: AggregatorFilters = {}): void {
     }
   );
 
-  const { decksTableState } = pd.settings;
+  const { decksTableState, decksTableMode } = pd.settings;
   mountReactComponent(
     <DecksTable
       data={data}
       filters={filters}
       cachedState={decksTableState}
+      cachedTableMode={decksTableMode}
       filterMatchesCallback={openDecksTab}
       tableStateCallback={(state: DecksTableState): void =>
         ipcSend("save_user_settings", {

--- a/src/window_main/DecksTab.tsx
+++ b/src/window_main/DecksTab.tsx
@@ -93,9 +93,7 @@ function updateStatsPanel(
 
   const drag = createDiv(["dragger"]);
   wrapR.appendChild(drag);
-  if (deckId === Aggregator.DEFAULT_DECK) {
-    makeResizable(drag, statsPanel.handleResize);
-  }
+  makeResizable(drag, statsPanel.handleResize);
   wrapR.appendChild(decksTopWinrate);
 }
 

--- a/src/window_main/DecksTab.tsx
+++ b/src/window_main/DecksTab.tsx
@@ -4,7 +4,7 @@ import isValid from "date-fns/isValid";
 
 import { EASING_DEFAULT } from "../shared/constants";
 import pd from "../shared/player-data";
-import { createDiv, queryElements } from "../shared/dom-fns";
+import { createDiv } from "../shared/dom-fns";
 import {
   get_deck_missing as getDeckMissing,
   getBoosterCountEstimate,
@@ -31,9 +31,6 @@ import {
   DecksTableState
 } from "./components/decks/types";
 
-let filters: AggregatorFilters = Aggregator.getDefaultFilters();
-const tagPrompt = "Add";
-
 function getDefaultStats(): DeckStats {
   return {
     wins: 0,
@@ -47,74 +44,74 @@ function getDefaultStats(): DeckStats {
   };
 }
 
-function setFilters(selected: AggregatorFilters = {}): void {
-  const { decksTableState } = pd.settings;
-  const showArchived = decksTableState?.filters?.archivedCol !== "hideArchived";
+function openDeckDetails(id: string, filters: AggregatorFilters): void {
+  const deck = pd.deck(id);
+  if (!deck) return;
+  openDeck(deck, { ...filters, deckId: id });
+  anime({
+    targets: ".moving_ux",
+    left: "-100%",
+    easing: EASING_DEFAULT,
+    duration: 350
+  });
+}
 
-  if (selected.date) {
-    // clear all dependent filters
-    filters = {
-      ...Aggregator.getDefaultFilters(),
-      date: filters.date,
-      ...selected,
-      showArchived
-    };
-  } else {
-    // default case
-    filters = {
-      ...filters,
-      date: pd.settings.last_date_filter,
-      ...selected,
-      showArchived
-    };
-  }
+function addTag(deckid: string, tag: string): void {
+  const deck = pd.deck(deckid);
+  if (!deck || !tag) return;
+  if (getReadableFormat(deck.format) === tag) return;
+  if (tag === "Add") return;
+  if (deck.tags && deck.tags.includes(tag)) return;
+  ipcSend("add_tag", { deckid, tag });
+}
+
+function editTag(tag: string, color: string): void {
+  ipcSend("edit_tag", { tag, color });
+}
+
+function deleteTag(deckid: string, tag: string): void {
+  const deck = pd.deck(deckid);
+  if (!deck || !tag) return;
+  if (!deck.tags || !deck.tags.includes(tag)) return;
+  ipcSend("delete_tag", { deckid, tag });
+}
+
+function toggleDeckArchived(id: string): void {
+  ipcSend("toggle_deck_archived", id);
+}
+
+function saveUserState(state: DecksTableState): void {
+  ipcSend("save_user_settings", {
+    decksTableState: state,
+    decksTableMode: state.decksTableMode,
+    skip_refresh: true
+  });
 }
 
 function updateStatsPanel(
-  deckId: string | string[] = Aggregator.DEFAULT_DECK
+  container: HTMLElement,
+  aggregator: Aggregator
 ): void {
-  const wrapR = queryElements(".sidebar_column_l")[0];
-  if (!wrapR) {
-    return;
-  }
-  wrapR.innerHTML = "";
-  const aggregator: any = new Aggregator({ ...filters, deckId });
+  container.innerHTML = "";
   const statsPanel = new StatsPanel(
     "decks_top",
     aggregator,
     pd.settings.right_panel_width,
     true
   );
-  const decksTopWinrate = statsPanel.render();
-  decksTopWinrate.style.display = "flex";
-  decksTopWinrate.style.flexDirection = "column";
-  decksTopWinrate.style.marginTop = "16px";
-  decksTopWinrate.style.padding = "12px";
-
+  const statsPanelDiv = statsPanel.render();
+  statsPanelDiv.style.display = "flex";
+  statsPanelDiv.style.flexDirection = "column";
+  statsPanelDiv.style.marginTop = "16px";
+  statsPanelDiv.style.padding = "12px";
   const drag = createDiv(["dragger"]);
-  wrapR.appendChild(drag);
+  container.appendChild(drag);
   makeResizable(drag, statsPanel.handleResize);
-  wrapR.appendChild(decksTopWinrate);
+  container.appendChild(statsPanelDiv);
 }
 
-export function openDecksTab(newFilters: AggregatorFilters = {}): void {
-  hideLoadingBars();
-  const mainDiv = resetMainContainer() as HTMLElement;
-  mainDiv.classList.add("flex_item");
-  setFilters(newFilters);
-  const aggregator: any = new Aggregator(filters);
-
-  const wrapR = createDiv(["wrapper_column", "sidebar_column_l"]);
-  wrapR.style.width = pd.settings.right_panel_width + "px";
-  wrapR.style.flex = `0 0 ${wrapR.style.width}`;
-
-  const wrapL = createDiv(["wrapper_column"]);
-  wrapL.style.overflowX = "auto";
-  mainDiv.appendChild(wrapL);
-  mainDiv.appendChild(wrapR);
-  updateStatsPanel();
-
-  const data = pd.deckList.map(
+function getDecksData(aggregator: any): DecksData[] {
+  return pd.deckList.map(
     (deck: SerializedDeck): DecksData => {
       const id = deck.id ?? "";
       const archivedSortVal = deck.archived ? 1 : deck.custom ? 0.5 : 0;
@@ -152,63 +149,90 @@ export function openDecksTab(newFilters: AggregatorFilters = {}): void {
       };
     }
   );
+}
 
-  const { decksTableState, decksTableMode } = pd.settings;
-  mountReactComponent(
-    <DecksTable
-      data={data}
-      filters={filters}
-      cachedState={decksTableState}
-      cachedTableMode={decksTableMode}
-      filterMatchesCallback={openDecksTab}
-      tableStateCallback={(state: DecksTableState): void =>
-        ipcSend("save_user_settings", {
-          decksTableState: state,
-          decksTableMode: state.decksTableMode,
-          skip_refresh: true
-        })
+export function DecksTab({
+  aggFiltersArg
+}: {
+  aggFiltersArg: AggregatorFilters;
+}): JSX.Element {
+  const {
+    decksTableMode,
+    decksTableState,
+    last_date_filter: dateFilter,
+    right_panel_width: panelWidth
+  } = pd.settings;
+  const showArchived = decksTableState?.filters?.archivedCol !== "hideArchived";
+  const defaultAggFilters = {
+    ...Aggregator.getDefaultFilters(),
+    date: dateFilter,
+    ...aggFiltersArg,
+    showArchived
+  };
+  const [aggFilters, setAggFilters] = React.useState(
+    defaultAggFilters as AggregatorFilters
+  );
+  const aggregator = React.useMemo(() => new Aggregator(aggFilters), [
+    aggFilters
+  ]);
+  const data = getDecksData(aggregator);
+
+  const sidePanelWidth = panelWidth + "px";
+  const rightPanelRef = React.useRef<HTMLDivElement>(null);
+  const updateStatsCallback: (
+    deckId?: string | string[]
+  ) => void = React.useMemo(
+    () => (deckId?: string | string[]): void => {
+      if (rightPanelRef?.current) {
+        updateStatsPanel(
+          rightPanelRef.current,
+          new Aggregator({ ...aggFilters, deckId })
+        );
       }
-      filterDecksCallback={updateStatsPanel}
-      openDeckCallback={(id: string): void => openDeckCallback(id, filters)}
-      archiveDeckCallback={(id: string): void =>
-        ipcSend("toggle_deck_archived", id)
-      }
-      tagDeckCallback={addTag}
-      editTagCallback={(tag: string, color: string): void =>
-        ipcSend("edit_tag", { tag, color })
-      }
-      deleteTagCallback={deleteTag}
-    />,
-    wrapL
+    },
+    [rightPanelRef, aggFilters]
+  );
+
+  return (
+    <>
+      <div
+        className={"wrapper_column"}
+        style={{
+          overflowX: "auto"
+        }}
+      >
+        <DecksTable
+          data={data}
+          filters={aggFilters}
+          cachedState={decksTableState}
+          cachedTableMode={decksTableMode}
+          filterMatchesCallback={setAggFilters}
+          tableStateCallback={saveUserState}
+          filterDecksCallback={updateStatsCallback}
+          openDeckCallback={(id: string): void =>
+            openDeckDetails(id, aggFilters)
+          }
+          archiveDeckCallback={toggleDeckArchived}
+          tagDeckCallback={addTag}
+          editTagCallback={editTag}
+          deleteTagCallback={deleteTag}
+        />
+      </div>
+      <div
+        ref={rightPanelRef}
+        className={"wrapper_column sidebar_column_l"}
+        style={{
+          width: sidePanelWidth,
+          flex: `0 0 ${sidePanelWidth}`
+        }}
+      ></div>
+    </>
   );
 }
 
-function openDeckCallback(id: string, filters: AggregatorFilters): void {
-  const deck = pd.deck(id);
-  if (!deck) return;
-  openDeck(deck, { ...filters, deckId: id });
-  anime({
-    targets: ".moving_ux",
-    left: "-100%",
-    easing: EASING_DEFAULT,
-    duration: 350
-  });
-}
-
-function addTag(deckid: string, tag: string): void {
-  const deck = pd.deck(deckid);
-  if (!deck || !tag) return;
-  if (getReadableFormat(deck.format) === tag) return;
-  if (tag === tagPrompt) return;
-  if (deck.tags && deck.tags.includes(tag)) return;
-
-  ipcSend("add_tag", { deckid, tag });
-}
-
-function deleteTag(deckid: string, tag: string): void {
-  const deck = pd.deck(deckid);
-  if (!deck || !tag) return;
-  if (!deck.tags || !deck.tags.includes(tag)) return;
-
-  ipcSend("delete_tag", { deckid, tag });
+export function openDecksTab(aggFilters: AggregatorFilters = {}): void {
+  hideLoadingBars();
+  const mainDiv = resetMainContainer() as HTMLElement;
+  mainDiv.classList.add("flex_item");
+  mountReactComponent(<DecksTab aggFiltersArg={aggFilters} />, mainDiv);
 }

--- a/src/window_main/DecksTab.tsx
+++ b/src/window_main/DecksTab.tsx
@@ -153,6 +153,7 @@ export function openDecksTab(newFilters: AggregatorFilters = {}): void {
       tableStateCallback={(state: DecksTableState): void =>
         ipcSend("save_user_settings", {
           decksTableState: state,
+          decksTableMode: state.decksTableMode,
           skip_refresh: true
         })
       }

--- a/src/window_main/DecksTab.tsx
+++ b/src/window_main/DecksTab.tsx
@@ -172,17 +172,15 @@ export function DecksTab({
   const [aggFilters, setAggFilters] = React.useState(
     defaultAggFilters as AggregatorFilters
   );
-  const aggregator = React.useMemo(() => new Aggregator(aggFilters), [
-    aggFilters
-  ]);
-  const data = getDecksData(aggregator);
+  const data = React.useMemo(() => {
+    const aggregator = new Aggregator(aggFilters);
+    return getDecksData(aggregator);
+  }, [aggFilters]);
 
   const sidePanelWidth = panelWidth + "px";
   const rightPanelRef = React.useRef<HTMLDivElement>(null);
-  const updateStatsCallback: (
-    deckId?: string | string[]
-  ) => void = React.useMemo(
-    () => (deckId?: string | string[]): void => {
+  const filterDecksCallback = React.useCallback(
+    (deckId?: string | string[]): void => {
       if (rightPanelRef?.current) {
         updateStatsPanel(
           rightPanelRef.current,
@@ -192,7 +190,10 @@ export function DecksTab({
     },
     [rightPanelRef, aggFilters]
   );
-
+  const openDeckCallback = React.useCallback(
+    (id: string): void => openDeckDetails(id, aggFilters),
+    [aggFilters]
+  );
   return (
     <>
       <div
@@ -208,10 +209,8 @@ export function DecksTab({
           cachedTableMode={decksTableMode}
           filterMatchesCallback={setAggFilters}
           tableStateCallback={saveUserState}
-          filterDecksCallback={updateStatsCallback}
-          openDeckCallback={(id: string): void =>
-            openDeckDetails(id, aggFilters)
-          }
+          filterDecksCallback={filterDecksCallback}
+          openDeckCallback={openDeckCallback}
           archiveDeckCallback={toggleDeckArchived}
           tagDeckCallback={addTag}
           editTagCallback={editTag}

--- a/src/window_main/ManaFilter.tsx
+++ b/src/window_main/ManaFilter.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { COLORS_BRIEF } from "../shared/constants";
+import { ManaSymbol } from "./components/display";
 
 export type ManaFilterKeys = "w" | "u" | "b" | "r" | "g" | "multi";
 
@@ -10,9 +11,10 @@ export interface ManaFilterProps {
   prefixId: string;
   filters: { [key: string]: ColorFilter };
   onFilterChanged: (colors: ColorFilter) => void;
+  symbolSize?: number;
 }
 
-export default function ManaFilter(props: ManaFilterProps) {
+export default function ManaFilter(props: ManaFilterProps): JSX.Element {
   const { filterKey, prefixId, filters } = props;
   const colors = filters[filterKey];
 
@@ -26,7 +28,9 @@ export default function ManaFilter(props: ManaFilterProps) {
   };
 
   const onClickColorFilter = React.useCallback(
-    (code: ManaFilterKeys) => (event: React.MouseEvent<HTMLDivElement>) => {
+    (code: ManaFilterKeys) => (
+      event: React.MouseEvent<HTMLDivElement>
+    ): void => {
       colors[code] = event.currentTarget.classList.contains("mana_filter_on");
       event.currentTarget.classList.toggle("mana_filter_on");
       props.onFilterChanged(colors);
@@ -36,31 +40,36 @@ export default function ManaFilter(props: ManaFilterProps) {
 
   const allFilters: ManaFilterKeys[] = [...COLORS_BRIEF, "multi"];
 
-  const manasStyles = {
-    display: "flex",
-    height: "32px"
+  const symbolSize = props.symbolSize ?? 20;
+  const symbolStyle = {
+    width: symbolSize + "px",
+    height: symbolSize + "px"
   };
 
   return (
-    <div className={prefixId + "_query_mana"} style={manasStyles}>
-      {allFilters.map(code => {
+    <div
+      className={prefixId + "_query_mana"}
+      style={{
+        display: "flex",
+        height: symbolSize + 4 + "px"
+      }}
+    >
+      {allFilters.map((code, index) => {
         const classNamesList =
-          "mana_filter" +
-          (code === "multi" ? " icon_search_inclusive" : "") +
-          (colors[code] ? "" : " mana_filter_on");
-        const additionalStyles = {
-          width: "30px",
-          backgroundImage:
-            code === "multi" ? undefined : `url(../images/${code}20.png)`
-        };
+          "mana_filter" + (colors[code] ? "" : " mana_filter_on");
         return (
           <div
             key={code}
             onClick={onClickColorFilter(code)}
             className={classNamesList}
-            style={additionalStyles}
             title={filterLabels[code]}
-          />
+          >
+            {code === "multi" ? (
+              <div className={"icon_search_inclusive"} style={symbolStyle} />
+            ) : (
+              <ManaSymbol colorIndex={index + 1} style={symbolStyle} />
+            )}
+          </div>
         );
       })}
     </div>

--- a/src/window_main/ManaFilter.tsx
+++ b/src/window_main/ManaFilter.tsx
@@ -39,12 +39,7 @@ export default function ManaFilter(props: ManaFilterProps): JSX.Element {
   );
 
   const allFilters: ManaFilterKeys[] = [...COLORS_BRIEF, "multi"];
-
   const symbolSize = props.symbolSize ?? 20;
-  const symbolStyle = {
-    width: symbolSize + "px",
-    height: symbolSize + "px"
-  };
 
   return (
     <div
@@ -65,9 +60,21 @@ export default function ManaFilter(props: ManaFilterProps): JSX.Element {
             title={filterLabels[code]}
           >
             {code === "multi" ? (
-              <div className={"icon_search_inclusive"} style={symbolStyle} />
+              <div
+                className={"icon_search_inclusive"}
+                style={{
+                  width: symbolSize + 2 + "px",
+                  height: symbolSize + 2 + "px"
+                }}
+              />
             ) : (
-              <ManaSymbol colorIndex={index + 1} style={symbolStyle} />
+              <ManaSymbol
+                colorIndex={index + 1}
+                style={{
+                  width: symbolSize + "px",
+                  height: symbolSize + "px"
+                }}
+              />
             )}
           </div>
         );

--- a/src/window_main/aggregator.js
+++ b/src/window_main/aggregator.js
@@ -92,7 +92,6 @@ class Aggregator {
       tag: DEFAULT_TAG,
       colors: Aggregator.getDefaultColorFilter(),
       deckId: DEFAULT_DECK,
-      onlyCurrentDecks: false,
       arch: DEFAULT_ARCH,
       oppColors: Aggregator.getDefaultColorFilter(),
       date: pd.settings.last_date_filter,
@@ -167,27 +166,19 @@ class Aggregator {
   }
 
   filterDeck(deck) {
-    const {
-      tag,
-      colors,
-      deckId,
-      onlyCurrentDecks,
-      showArchived
-    } = this.filters;
+    const { tag, colors, deckId } = this.filters;
     if (!deck) return deckId === DEFAULT_DECK;
-    const passesDeckFilter = deckId === DEFAULT_DECK || deckId === deck.id;
+    const passesDeckFilter =
+      deckId === DEFAULT_DECK ||
+      deckId === deck.id ||
+      this.validDecks.has(deck.id);
     if (!passesDeckFilter) return false;
-
-    const currentDeck = pd.deck(deck.id);
-    const passesArchiveFilter =
-      !onlyCurrentDecks ||
-      (currentDeck && (showArchived || !currentDeck.archived));
-    if (!passesArchiveFilter) return false;
 
     const deckTags = [deck.format];
     if (deck.tags) {
       deckTags.push(...deck.tags);
     }
+    const currentDeck = pd.deck(deck.id);
     if (currentDeck) {
       deckTags.push(currentDeck.format);
       if (currentDeck.tags) {
@@ -260,6 +251,11 @@ class Aggregator {
       ...this.filters,
       ...filters
     };
+    if (this.filters.deckId instanceof Array) {
+      this.validDecks = new Set(this.filters.deckId);
+    } else {
+      this.validDecks = new Set();
+    }
     this._eventIds = [];
     this.eventLastPlayed = {};
     this._decks = [];

--- a/src/window_main/components/PagingControls.tsx
+++ b/src/window_main/components/PagingControls.tsx
@@ -31,30 +31,31 @@ export const StyledInputContainer = styled.div.attrs(props => ({
   }
 `;
 
-export default function PagingControls(props: {
-  canPreviousPage: any;
-  canNextPage: any;
+export interface PagingControlsProps {
+  canPreviousPage: boolean;
+  canNextPage: boolean;
   pageOptions: any;
-  pageCount: any;
+  pageCount: number;
   gotoPage: any;
   nextPage: any;
   previousPage: any;
   setPageSize: any;
-  pageIndex: any;
-  pageSize: any;
-}): JSX.Element {
-  const {
-    canPreviousPage,
-    canNextPage,
-    pageOptions,
-    pageCount,
-    gotoPage,
-    nextPage,
-    previousPage,
-    setPageSize,
-    pageIndex,
-    pageSize
-  } = props;
+  pageIndex: number;
+  pageSize: number;
+}
+
+export default function PagingControls({
+  canPreviousPage,
+  canNextPage,
+  pageOptions,
+  pageCount,
+  gotoPage,
+  nextPage,
+  previousPage,
+  setPageSize,
+  pageIndex,
+  pageSize
+}: PagingControlsProps): JSX.Element {
   const expandButtons = pageCount < 10;
 
   let pageButtons: JSX.Element[] | JSX.Element = [];

--- a/src/window_main/components/PagingControls.tsx
+++ b/src/window_main/components/PagingControls.tsx
@@ -5,12 +5,12 @@ import { InputContainer, PagingButton } from "./display";
 export interface PagingControlsProps {
   canPreviousPage: boolean;
   canNextPage: boolean;
-  pageOptions: any;
+  pageOptions: any[];
   pageCount: number;
-  gotoPage: any;
-  nextPage: any;
-  previousPage: any;
-  setPageSize: any;
+  gotoPage: (index: number) => void;
+  nextPage: () => void;
+  previousPage: () => void;
+  setPageSize: (index: number) => void;
   pageIndex: number;
   pageSize: number;
 }
@@ -60,9 +60,9 @@ export default function PagingControls({
               gotoPage(page);
               e.target.value = "";
             }}
-            onKeyUp={(e: any): void => {
+            onKeyUp={(e: React.KeyboardEvent<HTMLInputElement>): void => {
               if (e.keyCode === 13) {
-                e.target.blur();
+                (e.target as HTMLInputElement).blur();
               }
             }}
             style={{ width: "40px" }}

--- a/src/window_main/components/PagingControls.tsx
+++ b/src/window_main/components/PagingControls.tsx
@@ -1,0 +1,175 @@
+import React from "react";
+import styled from "styled-components";
+import { ReactSelect } from "../../shared/ReactSelect";
+
+export const StyledInputContainer = styled.div.attrs(props => ({
+  className: (props.className ?? "") + " input_container"
+}))`
+  display: inline-flex;
+  margin: inherit;
+  position: relative;
+  width: 100%;
+  height: 26px;
+  padding-bottom: 4px;
+  input[type="number"]::-webkit-inner-spin-button,
+  input[type="number"]::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+  &.input_container input {
+    margin: 0;
+    width: calc(100% - 10px);
+    padding: 2px 4px;
+    position: absolute;
+    left: 0;
+    right: 0;
+  }
+  &:hover input {
+    color: rgba(255, 255, 255, 1);
+    background-color: var(--color-mid-50);
+    border: 1px solid var(--color-light);
+  }
+`;
+
+export default function PagingControls(props: {
+  canPreviousPage: any;
+  canNextPage: any;
+  pageOptions: any;
+  pageCount: any;
+  gotoPage: any;
+  nextPage: any;
+  previousPage: any;
+  setPageSize: any;
+  pageIndex: any;
+  pageSize: any;
+}): JSX.Element {
+  const {
+    canPreviousPage,
+    canNextPage,
+    pageOptions,
+    pageCount,
+    gotoPage,
+    nextPage,
+    previousPage,
+    setPageSize,
+    pageIndex,
+    pageSize
+  } = props;
+  const expandButtons = pageCount < 10;
+
+  let pageButtons: JSX.Element[] | JSX.Element = [];
+  if (expandButtons) {
+    for (let n = 0; n < pageCount; n++) {
+      pageButtons.push(
+        <button
+          key={n}
+          className={
+            pageIndex === n
+              ? "paging_active paging_button_disabled"
+              : "paging_button"
+          }
+          style={{ width: "initial", height: "initial", minWidth: "30px" }}
+          onClick={(): void => gotoPage(n)}
+          disabled={pageIndex === n}
+        >
+          {n + 1}
+        </button>
+      );
+    }
+  } else {
+    const prompt = "Go to page";
+    pageButtons = (
+      <>
+        <span className={"paging_text"}>Page</span>
+        <StyledInputContainer
+          title={prompt}
+          style={{ width: "50px", margin: "0 4px" }}
+        >
+          <input
+            type="number"
+            defaultValue={""}
+            onBlur={(e): void => {
+              const page = e.target.value ? Number(e.target.value) - 1 : 0;
+              gotoPage(page);
+              e.target.value = "";
+            }}
+            onKeyUp={(e: any): void => {
+              if (e.keyCode === 13) {
+                e.target.blur();
+              }
+            }}
+            style={{ width: "40px" }}
+            placeholder={pageIndex + 1}
+          />
+        </StyledInputContainer>
+        <span className={"paging_text"}>
+          <strong>of {pageOptions?.length}</strong>{" "}
+        </span>
+      </>
+    );
+  }
+
+  return (
+    <div className={"paging_container"}>
+      {!expandButtons && (
+        <button
+          className={
+            canPreviousPage
+              ? "paging_button"
+              : "paging_active paging_button_disabled"
+          }
+          style={{ width: "initial", height: "initial", minWidth: "30px" }}
+          onClick={(): void => gotoPage(0)}
+          disabled={!canPreviousPage}
+        >
+          {"<<"}
+        </button>
+      )}
+      <button
+        className={
+          canPreviousPage ? "paging_button" : " paging_button_disabled"
+        }
+        style={{ width: "initial", height: "initial", minWidth: "30px" }}
+        onClick={(): void => previousPage()}
+        disabled={!canPreviousPage}
+      >
+        {"<"}
+      </button>
+      {pageButtons}
+      <button
+        className={canNextPage ? "paging_button" : " paging_button_disabled"}
+        style={{ width: "initial", height: "initial", minWidth: "30px" }}
+        onClick={(): void => nextPage()}
+        disabled={!canNextPage}
+      >
+        {">"}
+      </button>
+      {!expandButtons && (
+        <button
+          className={
+            canNextPage
+              ? "paging_button"
+              : "paging_active paging_button_disabled"
+          }
+          style={{ width: "initial", height: "initial", minWidth: "30px" }}
+          onClick={(): void => gotoPage(pageCount - 1)}
+          disabled={!canNextPage}
+        >
+          {">>"}
+        </button>
+      )}
+      <div className={"select_container"} style={{ width: "140px" }}>
+        <ReactSelect
+          current={String(pageSize)}
+          options={["10", "25", "50", "100"]}
+          optionFormatter={(pageSize): JSX.Element => (
+            <option key={pageSize} value={pageSize}>
+              Show {pageSize}
+            </option>
+          )}
+          callback={(val): void => setPageSize(Number(val))}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/window_main/components/PagingControls.tsx
+++ b/src/window_main/components/PagingControls.tsx
@@ -100,7 +100,7 @@ export default function PagingControls({
               }
             }}
             style={{ width: "40px" }}
-            placeholder={pageIndex + 1}
+            placeholder={String(pageIndex + 1)}
           />
         </StyledInputContainer>
         <span className={"paging_text"}>

--- a/src/window_main/components/PagingControls.tsx
+++ b/src/window_main/components/PagingControls.tsx
@@ -107,15 +107,15 @@ export default function PagingControls({
           {">>"}
         </PagingButton>
       )}
-      <div className={"select_container"} style={{ width: "140px" }}>
+      <div
+        className={"select_container"}
+        style={{ width: "140px" }}
+        key={pageSize} // for some reason, React needs this to refresht the ReactSelect
+      >
         <ReactSelect
           current={String(pageSize)}
           options={["10", "25", "50", "100"]}
-          optionFormatter={(pageSize): JSX.Element => (
-            <option key={pageSize} value={pageSize}>
-              Show {pageSize}
-            </option>
-          )}
+          optionFormatter={(pageSize): string => "Show " + pageSize}
           callback={(val): void => setPageSize(Number(val))}
         />
       </div>

--- a/src/window_main/components/PagingControls.tsx
+++ b/src/window_main/components/PagingControls.tsx
@@ -1,35 +1,6 @@
 import React from "react";
-import styled from "styled-components";
 import { ReactSelect } from "../../shared/ReactSelect";
-
-export const StyledInputContainer = styled.div.attrs(props => ({
-  className: (props.className ?? "") + " input_container"
-}))`
-  display: inline-flex;
-  margin: inherit;
-  position: relative;
-  width: 100%;
-  height: 26px;
-  padding-bottom: 4px;
-  input[type="number"]::-webkit-inner-spin-button,
-  input[type="number"]::-webkit-outer-spin-button {
-    -webkit-appearance: none;
-    margin: 0;
-  }
-  &.input_container input {
-    margin: 0;
-    width: calc(100% - 10px);
-    padding: 2px 4px;
-    position: absolute;
-    left: 0;
-    right: 0;
-  }
-  &:hover input {
-    color: rgba(255, 255, 255, 1);
-    background-color: var(--color-mid-50);
-    border: 1px solid var(--color-light);
-  }
-`;
+import { InputContainer, PagingButton } from "./display";
 
 export interface PagingControlsProps {
   canPreviousPage: boolean;
@@ -62,19 +33,14 @@ export default function PagingControls({
   if (expandButtons) {
     for (let n = 0; n < pageCount; n++) {
       pageButtons.push(
-        <button
+        <PagingButton
           key={n}
-          className={
-            pageIndex === n
-              ? "paging_active paging_button_disabled"
-              : "paging_button"
-          }
-          style={{ width: "initial", height: "initial", minWidth: "30px" }}
           onClick={(): void => gotoPage(n)}
           disabled={pageIndex === n}
+          selected={pageIndex === n}
         >
           {n + 1}
-        </button>
+        </PagingButton>
       );
     }
   } else {
@@ -82,7 +48,7 @@ export default function PagingControls({
     pageButtons = (
       <>
         <span className={"paging_text"}>Page</span>
-        <StyledInputContainer
+        <InputContainer
           title={prompt}
           style={{ width: "50px", margin: "0 4px" }}
         >
@@ -102,7 +68,7 @@ export default function PagingControls({
             style={{ width: "40px" }}
             placeholder={String(pageIndex + 1)}
           />
-        </StyledInputContainer>
+        </InputContainer>
         <span className={"paging_text"}>
           <strong>of {pageOptions?.length}</strong>{" "}
         </span>
@@ -113,51 +79,33 @@ export default function PagingControls({
   return (
     <div className={"paging_container"}>
       {!expandButtons && (
-        <button
-          className={
-            canPreviousPage
-              ? "paging_button"
-              : "paging_active paging_button_disabled"
-          }
-          style={{ width: "initial", height: "initial", minWidth: "30px" }}
+        <PagingButton
           onClick={(): void => gotoPage(0)}
           disabled={!canPreviousPage}
+          selected={!canPreviousPage}
         >
           {"<<"}
-        </button>
+        </PagingButton>
       )}
-      <button
-        className={
-          canPreviousPage ? "paging_button" : " paging_button_disabled"
-        }
-        style={{ width: "initial", height: "initial", minWidth: "30px" }}
+      <PagingButton
         onClick={(): void => previousPage()}
         disabled={!canPreviousPage}
       >
         {"<"}
-      </button>
+      </PagingButton>
       {pageButtons}
-      <button
-        className={canNextPage ? "paging_button" : " paging_button_disabled"}
-        style={{ width: "initial", height: "initial", minWidth: "30px" }}
-        onClick={(): void => nextPage()}
-        disabled={!canNextPage}
-      >
+      <PagingButton onClick={(): void => nextPage()} disabled={!canNextPage}>
         {">"}
-      </button>
+      </PagingButton>
       {!expandButtons && (
-        <button
-          className={
-            canNextPage
-              ? "paging_button"
-              : "paging_active paging_button_disabled"
-          }
+        <PagingButton
           style={{ width: "initial", height: "initial", minWidth: "30px" }}
           onClick={(): void => gotoPage(pageCount - 1)}
           disabled={!canNextPage}
+          selected={!canNextPage}
         >
           {">>"}
-        </button>
+        </PagingButton>
       )}
       <div className={"select_container"} style={{ width: "140px" }}>
         <ReactSelect

--- a/src/window_main/components/TableHeaders.tsx
+++ b/src/window_main/components/TableHeaders.tsx
@@ -1,0 +1,94 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React from "react";
+
+export interface TableHeadersProps {
+  filtersVisible: any;
+  getTableProps: any;
+  gridTemplateColumns: any;
+  setFilter: any;
+  setFiltersVisible: any;
+  visibleHeaders: any;
+}
+
+export default function TableHeaders({
+  filtersVisible,
+  getTableProps,
+  gridTemplateColumns,
+  setFilter,
+  setFiltersVisible,
+  visibleHeaders
+}: TableHeadersProps): JSX.Element {
+  return (
+    <div
+      className="decks_table_head line_dark"
+      style={{ gridTemplateColumns }}
+      {...getTableProps()}
+    >
+      {visibleHeaders.map((column: any, ii: number) => (
+        <div
+          {...column.getHeaderProps(column.getSortByToggleProps())}
+          className={"hover_label"}
+          style={{
+            height: "64px",
+            gridArea: `1 / ${ii + 1} / 1 / ${ii + 2}`
+          }}
+          key={column.id}
+        >
+          <div className={"decks_table_head_container"}>
+            <div
+              className={
+                column.isSorted
+                  ? column.isSortedDesc
+                    ? " sort_desc"
+                    : " sort_asc"
+                  : ""
+              }
+              style={{ marginRight: "4px", width: "16px" }}
+            />
+            <div className={"flex_item"}>{column.render("Header")}</div>
+            {column.canFilter && (
+              <div
+                style={{ marginRight: 0 }}
+                className={"button settings"}
+                onClick={(e): void => {
+                  e.stopPropagation();
+                  setFiltersVisible({
+                    ...filtersVisible,
+                    [column.id]: !filtersVisible[column.id]
+                  });
+                }}
+                title={
+                  (filtersVisible[column.id] ? "hide" : "show") +
+                  " column filter"
+                }
+              />
+            )}
+            {column.filterValue && (
+              <div
+                style={{ marginRight: 0 }}
+                className={"button close"}
+                onClick={(e): void => {
+                  e.stopPropagation();
+                  setFilter(column.id, undefined);
+                }}
+                title={"clear column filter"}
+              />
+            )}
+          </div>
+          {column.canFilter && filtersVisible[column.id] && (
+            <div
+              onClick={(e): void => e.stopPropagation()}
+              style={{
+                display: "flex",
+                justifyContent: "center"
+              }}
+              title={"filter column"}
+            >
+              {column.render("Filter")}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/window_main/components/decks/DecksTable.tsx
+++ b/src/window_main/components/decks/DecksTable.tsx
@@ -29,7 +29,6 @@ import {
   deckSearchFilterFn
 } from "./filters";
 import {
-  CellProps,
   DecksTableProps,
   DecksTableState,
   DecksTableControlsProps
@@ -51,12 +50,6 @@ export default function DecksTable({
   openDeckCallback,
   ...cellCallbacks
 }: DecksTableProps): JSX.Element {
-  const CellWrapper = (
-    component: (props: CellProps) => JSX.Element
-  ): ((props: CellProps) => JSX.Element) => {
-    return (props: CellProps): JSX.Element =>
-      component({ ...props, ...cellCallbacks });
-  };
   const defaultColumn = React.useMemo(
     () => ({
       disableFilters: true
@@ -74,7 +67,7 @@ export default function DecksTable({
         filter: "fuzzyText",
         Filter: TextBoxFilter,
         sortType: "alphanumeric",
-        Cell: CellWrapper(NameCell),
+        Cell: NameCell,
         gridWidth: "200px"
       },
       {
@@ -95,7 +88,7 @@ export default function DecksTable({
         disableFilters: false,
         Filter: TextBoxFilter,
         filter: "fuzzyText",
-        Cell: CellWrapper(FormatCell),
+        Cell: FormatCell,
         gridWidth: "150px",
         mayToggle: true
       },
@@ -106,7 +99,7 @@ export default function DecksTable({
         Filter: TextBoxFilter,
         filter: "fuzzyText",
         disableSortBy: true,
-        Cell: CellWrapper(TagsCell),
+        Cell: TagsCell,
         gridWidth: "200px",
         mayToggle: true
       },
@@ -215,12 +208,12 @@ export default function DecksTable({
         Filter: ArchiveColumnFilter,
         minWidth: 98,
         disableFilters: false,
-        Cell: CellWrapper(ArchivedCell),
+        Cell: ArchivedCell,
         sortType: "basic",
         mayToggle: true
       }
     ],
-    [CellWrapper]
+    []
   );
   const filterTypes = React.useMemo(
     () => ({
@@ -304,7 +297,8 @@ export default function DecksTable({
       initialState,
       autoResetFilters: false,
       autoResetGlobalFilter: false,
-      autoResetSortBy: false
+      autoResetSortBy: false,
+      ...cellCallbacks
     },
     ReactTable.useFilters,
     ReactTable.useGlobalFilter,

--- a/src/window_main/components/decks/DecksTable.tsx
+++ b/src/window_main/components/decks/DecksTable.tsx
@@ -362,7 +362,9 @@ export default function DecksTable({
         {page.map((row: any, index: number) => {
           prepareRow(row);
           const RowRenderer =
-            tableMode === DECKS_TABLE_MODE ? DecksTableViewRow : DecksArtViewRow;
+            tableMode === DECKS_TABLE_MODE
+              ? DecksTableViewRow
+              : DecksArtViewRow;
           return (
             <RowRenderer
               openDeckCallback={openDeckCallback}

--- a/src/window_main/components/decks/DecksTable.tsx
+++ b/src/window_main/components/decks/DecksTable.tsx
@@ -26,7 +26,7 @@ import {
   fuzzyTextFilterFn,
   archivedFilterFn,
   colorsFilterFn,
-  uberSearchFilterFn
+  deckSearchFilterFn
 } from "./filters";
 import {
   CellProps,
@@ -300,7 +300,7 @@ export default function DecksTable({
       data: React.useMemo(() => data, [data]),
       defaultColumn,
       filterTypes,
-      globalFilter: uberSearchFilterFn,
+      globalFilter: deckSearchFilterFn,
       initialState,
       autoResetFilters: false,
       autoResetGlobalFilter: false,

--- a/src/window_main/components/decks/DecksTable.tsx
+++ b/src/window_main/components/decks/DecksTable.tsx
@@ -85,7 +85,8 @@ export default function DecksTable({
         filter: "colors",
         minWidth: 170,
         Cell: ColorsCell,
-        gridWidth: "150px"
+        gridWidth: "150px",
+        mayToggle: true
       },
       { accessor: "colors" },
       {
@@ -95,7 +96,8 @@ export default function DecksTable({
         Filter: TextBoxFilter,
         filter: "fuzzyText",
         Cell: CellWrapper(FormatCell),
-        gridWidth: "150px"
+        gridWidth: "150px",
+        mayToggle: true
       },
       {
         Header: "Tags",
@@ -105,25 +107,29 @@ export default function DecksTable({
         filter: "fuzzyText",
         disableSortBy: true,
         Cell: CellWrapper(TagsCell),
-        gridWidth: "200px"
+        gridWidth: "200px",
+        mayToggle: true
       },
       {
         Header: "Last Updated",
         accessor: "timeUpdated",
         Cell: DatetimeCell,
-        sortDescFirst: true
+        sortDescFirst: true,
+        mayToggle: true
       },
       {
         Header: "Last Played",
         accessor: "timePlayed",
         Cell: DatetimeCell,
-        sortDescFirst: true
+        sortDescFirst: true,
+        mayToggle: true
       },
       {
         Header: "Last Touched",
         accessor: "timeTouched",
         Cell: DatetimeCell,
-        sortDescFirst: true
+        sortDescFirst: true,
+        mayToggle: true
       },
       {
         Header: "Won",
@@ -131,7 +137,8 @@ export default function DecksTable({
         Cell: MetricCell,
         disableFilters: false,
         Filter: NumberRangeColumnFilter,
-        filter: "between"
+        filter: "between",
+        mayToggle: true
       },
       {
         Header: "Lost",
@@ -139,7 +146,8 @@ export default function DecksTable({
         Cell: MetricCell,
         disableFilters: false,
         Filter: NumberRangeColumnFilter,
-        filter: "between"
+        filter: "between",
+        mayToggle: true
       },
       {
         Header: "Total",
@@ -147,17 +155,20 @@ export default function DecksTable({
         Cell: MetricCell,
         disableFilters: false,
         Filter: NumberRangeColumnFilter,
-        filter: "between"
+        filter: "between",
+        mayToggle: true
       },
       {
         Header: "Total Duration",
         accessor: "duration",
-        Cell: DurationCell
+        Cell: DurationCell,
+        mayToggle: true
       },
       {
         Header: "Avg. Duration",
         accessor: "avgDuration",
-        Cell: DurationCell
+        Cell: DurationCell,
+        mayToggle: true
       },
       {
         Header: "Winrate",
@@ -165,7 +176,8 @@ export default function DecksTable({
         Cell: WinRateCell,
         disableFilters: false,
         Filter: NumberRangeColumnFilter,
-        filter: "between"
+        filter: "between",
+        mayToggle: true
       },
       { accessor: "winrate" },
       { accessor: "interval", sortInverted: true },
@@ -174,7 +186,8 @@ export default function DecksTable({
       {
         Header: "Since last edit",
         accessor: "lastEditWinrate",
-        Cell: LastEditWinRateCell
+        Cell: LastEditWinRateCell,
+        mayToggle: true
       },
       { accessor: "lastEditWins" },
       { accessor: "lastEditLosses" },
@@ -185,7 +198,8 @@ export default function DecksTable({
         Cell: MissingCardsCell,
         disableFilters: false,
         Filter: NumberRangeColumnFilter,
-        filter: "between"
+        filter: "between",
+        mayToggle: true
       },
       { accessor: "rare" },
       { accessor: "common" },
@@ -202,7 +216,8 @@ export default function DecksTable({
         minWidth: 98,
         disableFilters: false,
         Cell: CellWrapper(ArchivedCell),
-        sortType: "basic"
+        sortType: "basic",
+        mayToggle: true
       }
     ],
     [CellWrapper]

--- a/src/window_main/components/decks/DecksTable.tsx
+++ b/src/window_main/components/decks/DecksTable.tsx
@@ -338,7 +338,7 @@ export default function DecksTable({
   const initialFiltersVisible: { [key: string]: boolean } = {};
   for (const column of flatColumns) {
     if (column.canFilter) {
-      initialFiltersVisible[column.id] = false;
+      initialFiltersVisible[column.id] = !!column.filterValue;
     }
   }
   const [filtersVisible, setFiltersVisible] = useState(initialFiltersVisible);
@@ -383,6 +383,8 @@ export default function DecksTable({
     pageIndex,
     pageSize
   };
+
+  const visibleHeaders = headers.filter((header: any) => header.isVisible);
 
   return (
     <div className="decks_table_wrap">
@@ -511,78 +513,76 @@ export default function DecksTable({
         className="decks_table_head line_dark"
         style={{
           gridTemplateColumns: `200px 150px 150px ${"1fr ".repeat(
-            headers.length - 3
+            visibleHeaders.length - 3
           )}`
         }}
         {...getTableProps()}
       >
-        {headers
-          .filter((header: any) => header.isVisible)
-          .map((column: any, ii: number) => (
-            <div
-              {...column.getHeaderProps(column.getSortByToggleProps())}
-              className={"hover_label"}
-              style={{
-                height: "64px",
-                gridArea: `1 / ${ii + 1} / 1 / ${ii + 2}`
-              }}
-              key={column.id}
-            >
-              <div className={"decks_table_head_container"}>
+        {visibleHeaders.map((column: any, ii: number) => (
+          <div
+            {...column.getHeaderProps(column.getSortByToggleProps())}
+            className={"hover_label"}
+            style={{
+              height: "64px",
+              gridArea: `1 / ${ii + 1} / 1 / ${ii + 2}`
+            }}
+            key={column.id}
+          >
+            <div className={"decks_table_head_container"}>
+              <div
+                className={
+                  column.isSorted
+                    ? column.isSortedDesc
+                      ? " sort_desc"
+                      : " sort_asc"
+                    : ""
+                }
+                style={{ marginRight: "4px", width: "16px" }}
+              />
+              <div className={"flex_item"}>{column.render("Header")}</div>
+              {column.canFilter && (
                 <div
-                  className={
-                    column.isSorted
-                      ? column.isSortedDesc
-                        ? " sort_desc"
-                        : " sort_asc"
-                      : ""
-                  }
-                  style={{ marginRight: "4px", width: "16px" }}
-                />
-                <div className={"flex_item"}>{column.render("Header")}</div>
-                {column.canFilter && (
-                  <div
-                    style={{ marginRight: 0 }}
-                    className={"button settings"}
-                    onClick={(e): void => {
-                      e.stopPropagation();
-                      setFiltersVisible({
-                        ...filtersVisible,
-                        [column.id]: !filtersVisible[column.id]
-                      });
-                    }}
-                    title={
-                      (filtersVisible[column.id] ? "hide" : "show") +
-                      " column filter"
-                    }
-                  />
-                )}
-                {column.filterValue && (
-                  <div
-                    style={{ marginRight: 0 }}
-                    className={"button close"}
-                    onClick={(e): void => {
-                      e.stopPropagation();
-                      setFilter(column.id, undefined);
-                    }}
-                    title={"clear column filter"}
-                  />
-                )}
-              </div>
-              {column.canFilter && filtersVisible[column.id] && (
-                <div
-                  onClick={(e): void => e.stopPropagation()}
-                  style={{
-                    display: "flex",
-                    justifyContent: "center"
+                  style={{ marginRight: 0 }}
+                  className={"button settings"}
+                  onClick={(e): void => {
+                    e.stopPropagation();
+                    setFiltersVisible({
+                      ...filtersVisible,
+                      [column.id]: !filtersVisible[column.id]
+                    });
                   }}
-                  title={"filter column"}
-                >
-                  {column.render("Filter")}
-                </div>
+                  title={
+                    (filtersVisible[column.id] ? "hide" : "show") +
+                    " column filter"
+                  }
+                />
+              )}
+              {column.filterValue && (
+                <div
+                  style={{ marginRight: 0 }}
+                  className={"button close"}
+                  onClick={(e): void => {
+                    e.stopPropagation();
+                    setFilter(column.id, undefined);
+                  }}
+                  title={"clear column filter"}
+                />
               )}
             </div>
-          ))}
+            {column.canFilter && filtersVisible[column.id] && (
+              <div
+                onClick={(e): void => e.stopPropagation()}
+                style={{
+                  display: "flex",
+                  justifyContent: "center"
+                }}
+                title={"filter column"}
+              >
+                {column.render("Filter")}
+              </div>
+            )}
+          </div>
+        ))}
       </div>
       <div className="decks_table_body" {...getTableBodyProps()}>
         {page.map((row: any, index: number) => {

--- a/src/window_main/components/decks/DecksTable.tsx
+++ b/src/window_main/components/decks/DecksTable.tsx
@@ -656,7 +656,6 @@ function DeckTile({
   return (
     <div
       className={"decks_table_deck_tile"}
-      style={{ width: "200px" }}
       title={`show ${row.values.name} details`}
       onMouseEnter={mouseEnter}
       onMouseLeave={mouseLeave}
@@ -670,6 +669,7 @@ function DeckTile({
         return (
           <div
             className="inner_div"
+            style={hover ? { backgroundColor: "rgba(0,0,0,0.4)" } : undefined}
             {...cell.getCellProps()}
             key={cell.column.id + "_" + row.index}
           >

--- a/src/window_main/components/decks/DecksTable.tsx
+++ b/src/window_main/components/decks/DecksTable.tsx
@@ -262,6 +262,7 @@ export default function DecksTable({
     }
     return state;
   }, [cachedState]);
+  const [tableMode, setTableMode] = useState(cachedTableMode);
 
   const {
     flatColumns,
@@ -281,9 +282,9 @@ export default function DecksTable({
       data: React.useMemo(() => data, [data]),
       useControlledState: (state: DecksTableState) => {
         return React.useMemo(() => {
-          tableStateCallback(state);
+          tableStateCallback({ ...state, decksTableMode: tableMode });
           return state;
-        }, [state, tableStateCallback]);
+        }, [state, tableMode, tableStateCallback]);
       },
       defaultColumn,
       filterTypes,
@@ -330,7 +331,6 @@ export default function DecksTable({
   }
   const [filtersVisible, setFiltersVisible] = useState(initialFiltersVisible);
   const [togglesVisible, setTogglesVisible] = useState(false);
-  const [tableMode, setTableMode] = useState(cachedTableMode);
   const filterPanel = new FilterPanel(
     "decks_top",
     filterMatchesCallback,

--- a/src/window_main/components/decks/DecksTable.tsx
+++ b/src/window_main/components/decks/DecksTable.tsx
@@ -74,7 +74,8 @@ export default function DecksTable({
         filter: "fuzzyText",
         Filter: TextBoxFilter,
         sortType: "alphanumeric",
-        Cell: CellWrapper(NameCell)
+        Cell: CellWrapper(NameCell),
+        gridWidth: "200px"
       },
       {
         Header: "Colors",
@@ -83,7 +84,8 @@ export default function DecksTable({
         Filter: ColorColumnFilter,
         filter: "colors",
         minWidth: 170,
-        Cell: ColorsCell
+        Cell: ColorsCell,
+        gridWidth: "150px"
       },
       { accessor: "colors" },
       {
@@ -92,7 +94,8 @@ export default function DecksTable({
         disableFilters: false,
         Filter: TextBoxFilter,
         filter: "fuzzyText",
-        Cell: CellWrapper(FormatCell)
+        Cell: CellWrapper(FormatCell),
+        gridWidth: "150px"
       },
       {
         Header: "Tags",
@@ -101,7 +104,8 @@ export default function DecksTable({
         Filter: TextBoxFilter,
         filter: "fuzzyText",
         disableSortBy: true,
-        Cell: CellWrapper(TagsCell)
+        Cell: CellWrapper(TagsCell),
+        gridWidth: "200px"
       },
       {
         Header: "Last Updated",
@@ -315,6 +319,11 @@ export default function DecksTable({
     pageSize
   };
 
+  const visibleHeaders = headers.filter((header: any) => header.isVisible);
+  const gridTemplateColumns = visibleHeaders
+    .map((header: any) => header.gridWidth ?? "1fr")
+    .join(" ");
+
   const tableControlsProps: DecksTableControlsProps = {
     canNextPage,
     canPreviousPage,
@@ -324,7 +333,7 @@ export default function DecksTable({
     getTableProps,
     globalFilter,
     gotoPage,
-    headers,
+    gridTemplateColumns,
     nextPage,
     pageCount,
     pageIndex,
@@ -339,7 +348,8 @@ export default function DecksTable({
     setTableMode,
     tableMode,
     toggleHideColumn,
-    toggleSortBy
+    toggleSortBy,
+    visibleHeaders
   };
 
   return (
@@ -356,6 +366,7 @@ export default function DecksTable({
               row={row}
               index={index}
               key={row.index}
+              gridTemplateColumns={gridTemplateColumns}
             />
           );
         })}

--- a/src/window_main/components/decks/DecksTable.tsx
+++ b/src/window_main/components/decks/DecksTable.tsx
@@ -68,7 +68,8 @@ export default function DecksTable({
         Filter: TextBoxFilter,
         sortType: "alphanumeric",
         Cell: NameCell,
-        gridWidth: "200px"
+        gridWidth: "200px",
+        defaultVisible: true
       },
       {
         Header: "Colors",
@@ -79,7 +80,8 @@ export default function DecksTable({
         minWidth: 170,
         Cell: ColorsCell,
         gridWidth: "150px",
-        mayToggle: true
+        mayToggle: true,
+        defaultVisible: true
       },
       { accessor: "colors" },
       {
@@ -90,7 +92,8 @@ export default function DecksTable({
         filter: "fuzzyText",
         Cell: FormatCell,
         gridWidth: "150px",
-        mayToggle: true
+        mayToggle: true,
+        defaultVisible: true
       },
       {
         Header: "Tags",
@@ -108,21 +111,25 @@ export default function DecksTable({
         accessor: "timeUpdated",
         Cell: DatetimeCell,
         sortDescFirst: true,
-        mayToggle: true
+        mayToggle: true,
+        needsTileLabel: true
       },
       {
         Header: "Last Played",
         accessor: "timePlayed",
         Cell: DatetimeCell,
         sortDescFirst: true,
-        mayToggle: true
+        mayToggle: true,
+        needsTileLabel: true
       },
       {
         Header: "Last Touched",
         accessor: "timeTouched",
         Cell: DatetimeCell,
         sortDescFirst: true,
-        mayToggle: true
+        mayToggle: true,
+        defaultVisible: true,
+        needsTileLabel: true
       },
       {
         Header: "Won",
@@ -131,7 +138,8 @@ export default function DecksTable({
         disableFilters: false,
         Filter: NumberRangeColumnFilter,
         filter: "between",
-        mayToggle: true
+        mayToggle: true,
+        needsTileLabel: true
       },
       {
         Header: "Lost",
@@ -140,7 +148,8 @@ export default function DecksTable({
         disableFilters: false,
         Filter: NumberRangeColumnFilter,
         filter: "between",
-        mayToggle: true
+        mayToggle: true,
+        needsTileLabel: true
       },
       {
         Header: "Total",
@@ -149,19 +158,22 @@ export default function DecksTable({
         disableFilters: false,
         Filter: NumberRangeColumnFilter,
         filter: "between",
-        mayToggle: true
+        mayToggle: true,
+        needsTileLabel: true
       },
       {
         Header: "Total Duration",
         accessor: "duration",
         Cell: DurationCell,
-        mayToggle: true
+        mayToggle: true,
+        needsTileLabel: true
       },
       {
         Header: "Avg. Duration",
         accessor: "avgDuration",
         Cell: DurationCell,
-        mayToggle: true
+        mayToggle: true,
+        needsTileLabel: true
       },
       {
         Header: "Winrate",
@@ -170,7 +182,9 @@ export default function DecksTable({
         disableFilters: false,
         Filter: NumberRangeColumnFilter,
         filter: "between",
-        mayToggle: true
+        mayToggle: true,
+        defaultVisible: true,
+        needsTileLabel: true
       },
       { accessor: "winrate" },
       { accessor: "interval", sortInverted: true },
@@ -180,7 +194,8 @@ export default function DecksTable({
         Header: "Since last edit",
         accessor: "lastEditWinrate",
         Cell: LastEditWinRateCell,
-        mayToggle: true
+        mayToggle: true,
+        needsTileLabel: true
       },
       { accessor: "lastEditWins" },
       { accessor: "lastEditLosses" },
@@ -210,7 +225,8 @@ export default function DecksTable({
         disableFilters: false,
         Cell: ArchivedCell,
         sortType: "basic",
-        mayToggle: true
+        mayToggle: true,
+        defaultVisible: true
       }
     ],
     []
@@ -224,45 +240,23 @@ export default function DecksTable({
     []
   );
   const initialState: DecksTableState = React.useMemo(() => {
+    // default hidden columns
+    const hiddenColumns = columns
+      .filter(column => !column.defaultVisible)
+      .map(column => column.id ?? column.accessor);
     const state = _.defaultsDeep(cachedState, {
-      hiddenColumns: [
-        "deckTileId",
-        "archived",
-        "deckId",
-        "custom",
-        "boosterCost",
-        "colors",
-        "lastEditLosses",
-        "lastEditTotal",
-        "lastEditWinrate",
-        "lastEditWins",
-        "timePlayed",
-        "timeUpdated",
-        "wins",
-        "losses",
-        "total",
-        "rare",
-        "common",
-        "uncommon",
-        "mythic",
-        "duration",
-        "avgDuration",
-        "interval",
-        "winrate",
-        "winrateLow",
-        "winrateHigh"
-      ],
+      hiddenColumns,
       sortBy: [{ id: "timeTouched", desc: true }],
       pageSize: 25
     });
-    if (!state.hiddenColumns.includes("archived")) {
-      state.hiddenColumns.push("archived");
-    }
-    if (!state.hiddenColumns.includes("deckTileId")) {
-      state.hiddenColumns.push("deckTileId");
+    // ensure data-only columns are all invisible
+    for (const column of columns) {
+      if (!column.defaultVisible && !column.mayToggle) {
+        state.hiddenColumns.push(column.id);
+      }
     }
     return state;
-  }, [cachedState]);
+  }, [cachedState, columns]);
 
   const {
     flatColumns,

--- a/src/window_main/components/decks/DecksTable.tsx
+++ b/src/window_main/components/decks/DecksTable.tsx
@@ -297,7 +297,8 @@ export default function DecksTable({
       filterTypes,
       initialState,
       autoResetFilters: false,
-      autoResetSortBy: false
+      autoResetSortBy: false,
+      autoResetPage: false
     },
     ReactTable.useFilters,
     ReactTable.useSortBy,
@@ -669,6 +670,19 @@ function DeckTile({
     openDeckCallback(deckId);
   }, [deckId]);
 
+  const requireLabelIds = [
+    "duration",
+    "avgDuration",
+    "winrate100",
+    "lastEditWinrate",
+    "timePlayed",
+    "timeUpdated",
+    "timeTouched",
+    "losses",
+    "total",
+    "wins"
+  ];
+
   return (
     <div
       className={"decks_table_deck_tile"}
@@ -689,10 +703,24 @@ function DeckTile({
             {...cell.getCellProps()}
             key={cell.column.id + "_" + row.index}
           >
+            {requireLabelIds.includes(cell.column.id) && (
+              <MetricText
+                style={{
+                  paddingRight: "8px",
+                  fontSize: "small",
+                  whiteSpace: "nowrap",
+                  fontWeight: 300,
+                  color: "var(--color-light-50)"
+                }}
+              >
+                {cell.column.render("Header")}:
+              </MetricText>
+            )}
             {cell.render("Cell")}
           </div>
         );
       })}
+      <div className="inner_div"> </div>
     </div>
   );
 }

--- a/src/window_main/components/decks/DecksTable.tsx
+++ b/src/window_main/components/decks/DecksTable.tsx
@@ -2,6 +2,11 @@
 import _ from "lodash";
 import React, { useState } from "react";
 import styled from "styled-components";
+import { CSSTransition } from "react-transition-group";
+
+import { getCardArtCrop } from "../../../shared/util";
+import { ReactSelect } from "../../../shared/ReactSelect";
+import { TABLE_MODES, TABLE_MODE } from "../../../shared/constants";
 
 import FilterPanel from "../../FilterPanel";
 import {
@@ -32,9 +37,6 @@ import {
   uberSearchFilterFn
 } from "./filters";
 import { CellProps, DecksTableProps, DecksTableState } from "./types";
-import { CSSTransition } from "react-transition-group";
-import { getCardArtCrop } from "../../../shared/util";
-import { ReactSelect } from "../../../shared/ReactSelect";
 
 const ReactTable = require("react-table"); // no @types package for current rc yet
 
@@ -51,6 +53,7 @@ export default function DecksTable({
   filterMatchesCallback,
   tableStateCallback,
   cachedState,
+  cachedTableMode,
   openDeckCallback,
   ...cellCallbacks
 }: DecksTableProps): JSX.Element {
@@ -327,7 +330,7 @@ export default function DecksTable({
   }
   const [filtersVisible, setFiltersVisible] = useState(initialFiltersVisible);
   const [togglesVisible, setTogglesVisible] = useState(false);
-  const [tableMode, setTableMode] = useState("Table View");
+  const [tableMode, setTableMode] = useState(cachedTableMode);
   const filterPanel = new FilterPanel(
     "decks_top",
     filterMatchesCallback,
@@ -457,7 +460,7 @@ export default function DecksTable({
           <div className={"select_container"}>
             <ReactSelect
               current={tableMode}
-              options={["Table View", "Deck Art View"]}
+              options={TABLE_MODES}
               callback={setTableMode}
             />
           </div>
@@ -555,7 +558,7 @@ export default function DecksTable({
       <div className="decks_table_body" {...getTableBodyProps()}>
         {rows.map((row: any, index: number) => {
           prepareRow(row);
-          return tableMode === "Table View" ? (
+          return tableMode === TABLE_MODE ? (
             <RowContainer
               openDeckCallback={openDeckCallback}
               row={row}

--- a/src/window_main/components/decks/DecksTable.tsx
+++ b/src/window_main/components/decks/DecksTable.tsx
@@ -285,8 +285,7 @@ export default function DecksTable({
       initialState,
       autoResetFilters: false,
       autoResetGlobalFilter: false,
-      autoResetSortBy: false,
-      autoResetPage: false
+      autoResetSortBy: false
     },
     ReactTable.useFilters,
     ReactTable.useGlobalFilter,

--- a/src/window_main/components/decks/DecksTable.tsx
+++ b/src/window_main/components/decks/DecksTable.tsx
@@ -2,7 +2,7 @@
 import _ from "lodash";
 import React from "react";
 
-import { TABLE_MODE } from "../../../shared/constants";
+import { DECKS_TABLE_MODE } from "../../../shared/constants";
 
 import {
   NameCell,
@@ -35,7 +35,7 @@ import {
 } from "./types";
 import PagingControls, { PagingControlsProps } from "../PagingControls";
 import DecksTableControls from "./DecksTableControls";
-import { TableViewRow, DeckTile } from "./rows";
+import { DecksTableViewRow, DecksArtViewRow } from "./rows";
 
 const ReactTable = require("react-table"); // no @types package for current rc yet
 
@@ -362,7 +362,7 @@ export default function DecksTable({
         {page.map((row: any, index: number) => {
           prepareRow(row);
           const RowRenderer =
-            tableMode === TABLE_MODE ? TableViewRow : DeckTile;
+            tableMode === DECKS_TABLE_MODE ? DecksTableViewRow : DecksArtViewRow;
           return (
             <RowRenderer
               openDeckCallback={openDeckCallback}

--- a/src/window_main/components/decks/DecksTable.tsx
+++ b/src/window_main/components/decks/DecksTable.tsx
@@ -28,8 +28,13 @@ import {
   colorsFilterFn,
   uberSearchFilterFn
 } from "./filters";
-import { CellProps, DecksTableProps, DecksTableState } from "./types";
-import PagingControls from "../PagingControls";
+import {
+  CellProps,
+  DecksTableProps,
+  DecksTableState,
+  DecksTableControlsProps
+} from "./types";
+import PagingControls, { PagingControlsProps } from "../PagingControls";
 import DecksTableControls from "./DecksTableControls";
 import { TableViewRow, DeckTile } from "./rows";
 
@@ -298,7 +303,7 @@ export default function DecksTable({
     filterDecksCallback(rows.map((row: any) => row.values.deckId));
   }, [filterDecksCallback, rows]);
 
-  const pagingProps = {
+  const pagingProps: PagingControlsProps = {
     canPreviousPage,
     canNextPage,
     pageOptions,
@@ -311,7 +316,7 @@ export default function DecksTable({
     pageSize
   };
 
-  const tableControlsProps = {
+  const tableControlsProps: DecksTableControlsProps = {
     canNextPage,
     canPreviousPage,
     filterMatchesCallback,

--- a/src/window_main/components/decks/DecksTable.tsx
+++ b/src/window_main/components/decks/DecksTable.tsx
@@ -54,6 +54,7 @@ export default function DecksTable({
   tableStateCallback,
   cachedState,
   cachedTableMode,
+  filterDecksCallback,
   openDeckCallback,
   ...cellCallbacks
 }: DecksTableProps): JSX.Element {
@@ -275,17 +276,12 @@ export default function DecksTable({
     toggleSortBy,
     toggleHideColumn,
     setAllFilters,
-    setFilter
+    setFilter,
+    state
   } = ReactTable.useTable(
     {
       columns,
       data: React.useMemo(() => data, [data]),
-      useControlledState: (state: DecksTableState) => {
-        return React.useMemo(() => {
-          tableStateCallback({ ...state, decksTableMode: tableMode });
-          return state;
-        }, [state, tableMode, tableStateCallback]);
-      },
       defaultColumn,
       filterTypes,
       initialState,
@@ -295,6 +291,13 @@ export default function DecksTable({
     ReactTable.useFilters,
     ReactTable.useSortBy
   );
+
+  React.useEffect(() => {
+    tableStateCallback({ ...state, decksTableMode: tableMode });
+  }, [state, tableMode, tableStateCallback]);
+  React.useEffect(() => {
+    filterDecksCallback(rows.map((row: any) => row.values.deckId));
+  }, [filterDecksCallback, rows]);
 
   const toggleableIds = [
     "name",

--- a/src/window_main/components/decks/DecksTable.tsx
+++ b/src/window_main/components/decks/DecksTable.tsx
@@ -37,6 +37,7 @@ import {
   uberSearchFilterFn
 } from "./filters";
 import { CellProps, DecksTableProps, DecksTableState } from "./types";
+import PagingControls from "../PagingControls";
 
 const ReactTable = require("react-table"); // no @types package for current rc yet
 
@@ -253,7 +254,8 @@ export default function DecksTable({
         "winrateLow",
         "winrateHigh"
       ],
-      sortBy: [{ id: "timeTouched", desc: true }]
+      sortBy: [{ id: "timeTouched", desc: true }],
+      pageSize: 25
     });
     if (!state.hiddenColumns.includes("archived")) {
       state.hiddenColumns.push("archived");
@@ -272,11 +274,20 @@ export default function DecksTable({
     getTableBodyProps,
     headerGroups,
     rows,
+    page,
     prepareRow,
     toggleSortBy,
     toggleHideColumn,
     setAllFilters,
     setFilter,
+    canPreviousPage,
+    canNextPage,
+    pageOptions,
+    pageCount,
+    gotoPage,
+    nextPage,
+    previousPage,
+    setPageSize,
     state
   } = ReactTable.useTable(
     {
@@ -289,8 +300,10 @@ export default function DecksTable({
       autoResetSortBy: false
     },
     ReactTable.useFilters,
-    ReactTable.useSortBy
+    ReactTable.useSortBy,
+    ReactTable.usePagination
   );
+  const { pageIndex, pageSize } = state;
 
   React.useEffect(() => {
     tableStateCallback({ ...state, decksTableMode: tableMode });
@@ -361,6 +374,19 @@ export default function DecksTable({
     { id: "archivedCol", value: "hideArchived" },
     { id: "boosterCost", value: [1, undefined] }
   ];
+
+  const pagingProps = {
+    canPreviousPage,
+    canNextPage,
+    pageOptions,
+    pageCount,
+    gotoPage,
+    nextPage,
+    previousPage,
+    setPageSize,
+    pageIndex,
+    pageSize
+  };
 
   return (
     <div className="decks_table_wrap">
@@ -470,7 +496,7 @@ export default function DecksTable({
           {deckTileColumn.render("Filter")}
           {deckTileColumn.filterValue && (
             <div
-              style={{ marginRight: 0 }}
+              style={{ marginRight: 0, minWidth: "24px" }}
               className={"button close"}
               onClick={(e): void => {
                 e.stopPropagation();
@@ -479,6 +505,7 @@ export default function DecksTable({
               title={"clear column filter"}
             />
           )}
+          <PagingControls {...pagingProps} />
         </div>
       </div>
       <div
@@ -559,7 +586,7 @@ export default function DecksTable({
           ))}
       </div>
       <div className="decks_table_body" {...getTableBodyProps()}>
-        {rows.map((row: any, index: number) => {
+        {page.map((row: any, index: number) => {
           prepareRow(row);
           return tableMode === TABLE_MODE ? (
             <RowContainer
@@ -578,6 +605,7 @@ export default function DecksTable({
           );
         })}
       </div>
+      <PagingControls {...pagingProps} />
     </div>
   );
 }

--- a/src/window_main/components/decks/DecksTable.tsx
+++ b/src/window_main/components/decks/DecksTable.tsx
@@ -5,7 +5,7 @@ import styled from "styled-components";
 import { CSSTransition } from "react-transition-group";
 
 import { getCardArtCrop } from "../../../shared/util";
-import { ReactSelect } from "../../../shared/ReactSelect";
+import { WrappedReactSelect } from "../../../shared/ReactSelect";
 import { TABLE_MODES, TABLE_MODE } from "../../../shared/constants";
 
 import FilterPanel from "../../FilterPanel";
@@ -486,13 +486,12 @@ export default function DecksTable({
             ))}
         </div>
         <div className="decks_table_search_cont">
-          <div className={"select_container"}>
-            <ReactSelect
-              current={tableMode}
-              options={TABLE_MODES}
-              callback={setTableMode}
-            />
-          </div>
+          <WrappedReactSelect
+            current={tableMode}
+            options={TABLE_MODES}
+            callback={setTableMode}
+            className={"decks_table_mode"}
+          />
           {deckTileColumn.render("Filter")}
           {deckTileColumn.filterValue && (
             <div
@@ -588,15 +587,10 @@ export default function DecksTable({
       <div className="decks_table_body" {...getTableBodyProps()}>
         {page.map((row: any, index: number) => {
           prepareRow(row);
-          return tableMode === TABLE_MODE ? (
-            <RowContainer
-              openDeckCallback={openDeckCallback}
-              row={row}
-              index={index}
-              key={row.index}
-            />
-          ) : (
-            <DeckTile
+          const RowRenderer =
+            tableMode === TABLE_MODE ? TableViewRow : DeckTile;
+          return (
+            <RowRenderer
               openDeckCallback={openDeckCallback}
               row={row}
               index={index}
@@ -610,7 +604,7 @@ export default function DecksTable({
   );
 }
 
-function RowContainer({
+function TableViewRow({
   row,
   index,
   openDeckCallback
@@ -619,20 +613,10 @@ function RowContainer({
   index: number;
   openDeckCallback: (id: string) => void;
 }): JSX.Element {
-  const [hover, setHover] = React.useState(false);
-
-  const mouseEnter = React.useCallback(() => {
-    setHover(true);
-  }, []);
-
-  const mouseLeave = React.useCallback(() => {
-    setHover(false);
-  }, []);
-
+  const deckId = row.values.deckId;
   const mouseClick = React.useCallback(() => {
-    openDeckCallback(row.values.deckId);
-  }, []);
-
+    openDeckCallback(deckId);
+  }, [deckId]);
   return (
     <div
       className={
@@ -643,12 +627,9 @@ function RowContainer({
           row.cells.length - 3
         )}`
       }}
-      onMouseEnter={mouseEnter}
-      onMouseLeave={mouseLeave}
       onClick={mouseClick}
     >
       {row.cells.map((cell: any) => {
-        cell.hover = hover;
         return (
           <div
             className="inner_div"
@@ -683,9 +664,10 @@ function DeckTile({
     setHover(false);
   }, []);
 
+  const deckId = row.values.deckId;
   const mouseClick = React.useCallback(() => {
-    openDeckCallback(row.values.deckId);
-  }, []);
+    openDeckCallback(deckId);
+  }, [deckId]);
 
   return (
     <div

--- a/src/window_main/components/decks/DecksTableControls.tsx
+++ b/src/window_main/components/decks/DecksTableControls.tsx
@@ -6,6 +6,7 @@ import { TABLE_MODES } from "../../../shared/constants";
 
 import FilterPanel from "../../FilterPanel";
 import PagingControls from "../PagingControls";
+import TableHeaders from "../TableHeaders";
 import {
   CheckboxContainer,
   SmallTextButton,
@@ -95,6 +96,14 @@ export default function DecksTableControls({
     setPageSize,
     pageIndex,
     pageSize
+  };
+  const headersProps = {
+    filtersVisible,
+    getTableProps,
+    gridTemplateColumns,
+    setFilter,
+    setFiltersVisible,
+    visibleHeaders
   };
   return (
     <>
@@ -219,77 +228,7 @@ export default function DecksTableControls({
           <PagingControls {...pagingProps} />
         </div>
       </div>
-      <div
-        className="decks_table_head line_dark"
-        style={{ gridTemplateColumns }}
-        {...getTableProps()}
-      >
-        {visibleHeaders.map((column: any, ii: number) => (
-          <div
-            {...column.getHeaderProps(column.getSortByToggleProps())}
-            className={"hover_label"}
-            style={{
-              height: "64px",
-              gridArea: `1 / ${ii + 1} / 1 / ${ii + 2}`
-            }}
-            key={column.id}
-          >
-            <div className={"decks_table_head_container"}>
-              <div
-                className={
-                  column.isSorted
-                    ? column.isSortedDesc
-                      ? " sort_desc"
-                      : " sort_asc"
-                    : ""
-                }
-                style={{ marginRight: "4px", width: "16px" }}
-              />
-              <div className={"flex_item"}>{column.render("Header")}</div>
-              {column.canFilter && (
-                <div
-                  style={{ marginRight: 0 }}
-                  className={"button settings"}
-                  onClick={(e): void => {
-                    e.stopPropagation();
-                    setFiltersVisible({
-                      ...filtersVisible,
-                      [column.id]: !filtersVisible[column.id]
-                    });
-                  }}
-                  title={
-                    (filtersVisible[column.id] ? "hide" : "show") +
-                    " column filter"
-                  }
-                />
-              )}
-              {column.filterValue && (
-                <div
-                  style={{ marginRight: 0 }}
-                  className={"button close"}
-                  onClick={(e): void => {
-                    e.stopPropagation();
-                    setFilter(column.id, undefined);
-                  }}
-                  title={"clear column filter"}
-                />
-              )}
-            </div>
-            {column.canFilter && filtersVisible[column.id] && (
-              <div
-                onClick={(e): void => e.stopPropagation()}
-                style={{
-                  display: "flex",
-                  justifyContent: "center"
-                }}
-                title={"filter column"}
-              >
-                {column.render("Filter")}
-              </div>
-            )}
-          </div>
-        ))}
-      </div>
+      <TableHeaders {...headersProps} />
     </>
   );
 }

--- a/src/window_main/components/decks/DecksTableControls.tsx
+++ b/src/window_main/components/decks/DecksTableControls.tsx
@@ -6,7 +6,11 @@ import { TABLE_MODES } from "../../../shared/constants";
 
 import FilterPanel from "../../FilterPanel";
 import PagingControls from "../PagingControls";
-import { MetricText, CheckboxContainer, SmallTextButton } from "../display";
+import {
+  CheckboxContainer,
+  SmallTextButton,
+  MediumTextButton
+} from "../display";
 import { GlobalFilter } from "./filters";
 import { DecksTableControlsProps } from "./types";
 
@@ -171,13 +175,12 @@ export default function DecksTableControls({
           >
             Wanted
           </SmallTextButton>
-          <MetricText
+          <MediumTextButton
             onClick={(): void => setTogglesVisible(!togglesVisible)}
-            className="button_simple"
             style={{ margin: "0 0 5px 12px" }}
           >
             {togglesVisible ? "Hide" : "Show"} Column Toggles
-          </MetricText>
+          </MediumTextButton>
         </div>
         <div className="decks_table_toggles">
           {togglesVisible &&

--- a/src/window_main/components/decks/DecksTableControls.tsx
+++ b/src/window_main/components/decks/DecksTableControls.tsx
@@ -1,22 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from "react";
-import styled from "styled-components";
 
 import { WrappedReactSelect } from "../../../shared/ReactSelect";
 import { TABLE_MODES } from "../../../shared/constants";
 
 import FilterPanel from "../../FilterPanel";
-import { MetricText } from "./cells";
-import { StyledCheckboxContainer, GlobalFilter } from "./filters";
 import PagingControls from "../PagingControls";
+import { MetricText, CheckboxContainer, SmallTextButton } from "../display";
+import { GlobalFilter } from "./filters";
 import { DecksTableControlsProps } from "./types";
-
-const PresetButton = styled(MetricText).attrs(props => ({
-  className: (props.className ?? "") + " button_simple"
-}))`
-  margin: 0 4px 5px 4px;
-  width: 90px;
-`;
 
 const recentFilters = (): { id: string; value: any }[] => [
   { id: "archivedCol", value: "hideArchived" }
@@ -114,7 +106,7 @@ export default function DecksTableControls({
           <span style={{ paddingBottom: "8px" }}>Filter match results:</span>
           <span style={{ width: "260px" }}>{filterPanel.render()}</span>
           <span style={{ paddingBottom: "8px" }}>Presets:</span>
-          <PresetButton
+          <SmallTextButton
             onClick={(): void => {
               setAllFilters(recentFilters);
               setFiltersVisible(initialFiltersVisible);
@@ -132,8 +124,8 @@ export default function DecksTableControls({
             }}
           >
             Recent
-          </PresetButton>
-          <PresetButton
+          </SmallTextButton>
+          <SmallTextButton
             onClick={(): void => {
               setAllFilters(bestFilters);
               setFiltersVisible({
@@ -156,8 +148,8 @@ export default function DecksTableControls({
             }}
           >
             Best
-          </PresetButton>
-          <PresetButton
+          </SmallTextButton>
+          <SmallTextButton
             onClick={(): void => {
               setAllFilters(wantedFilters);
               setFiltersVisible({
@@ -178,7 +170,7 @@ export default function DecksTableControls({
             }}
           >
             Wanted
-          </PresetButton>
+          </SmallTextButton>
           <MetricText
             onClick={(): void => setTogglesVisible(!togglesVisible)}
             className="button_simple"
@@ -190,11 +182,11 @@ export default function DecksTableControls({
         <div className="decks_table_toggles">
           {togglesVisible &&
             toggleableColumns.map((column: any) => (
-              <StyledCheckboxContainer key={column.id}>
+              <CheckboxContainer key={column.id}>
                 {column.render("Header")}
                 <input type="checkbox" {...column.getToggleHiddenProps()} />
                 <span className={"checkmark"} />
-              </StyledCheckboxContainer>
+              </CheckboxContainer>
             ))}
         </div>
         <div className="decks_table_search_cont">

--- a/src/window_main/components/decks/DecksTableControls.tsx
+++ b/src/window_main/components/decks/DecksTableControls.tsx
@@ -1,0 +1,317 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React from "react";
+import styled from "styled-components";
+
+import { WrappedReactSelect } from "../../../shared/ReactSelect";
+import { TABLE_MODES } from "../../../shared/constants";
+
+import FilterPanel from "../../FilterPanel";
+import { MetricText } from "./cells";
+import { StyledCheckboxContainer, GlobalFilter } from "./filters";
+import PagingControls from "../PagingControls";
+
+const PresetButton = styled(MetricText).attrs(props => ({
+  className: (props.className ?? "") + " button_simple"
+}))`
+  margin: 0 4px 5px 4px;
+  width: 90px;
+`;
+
+const toggleableIds = [
+  "name",
+  "format",
+  "colorSortVal",
+  "duration",
+  "avgDuration",
+  "boosterCost",
+  "lastEditWinrate",
+  "timePlayed",
+  "timeUpdated",
+  "timeTouched",
+  "losses",
+  "tags",
+  "total",
+  "winrate100",
+  "wins",
+  "archivedCol"
+];
+const recentFilters = (): { id: string; value: any }[] => [
+  { id: "archivedCol", value: "hideArchived" }
+];
+const bestFilters = (): { id: string; value: any }[] => [
+  { id: "archivedCol", value: "hideArchived" },
+  { id: "wins", value: [5, undefined] },
+  { id: "winrate100", value: [50, undefined] }
+];
+const wantedFilters = (): { id: string; value: any }[] => [
+  { id: "archivedCol", value: "hideArchived" },
+  { id: "boosterCost", value: [1, undefined] }
+];
+
+export default function DecksTableControls({
+  canNextPage,
+  canPreviousPage,
+  filterMatchesCallback,
+  filters,
+  flatColumns,
+  getTableProps,
+  globalFilter,
+  gotoPage,
+  headers,
+  nextPage,
+  pageCount,
+  pageIndex,
+  pageOptions,
+  pageSize,
+  preGlobalFilteredRows,
+  previousPage,
+  setAllFilters,
+  setFilter,
+  setGlobalFilter,
+  setPageSize,
+  setTableMode,
+  tableMode,
+  toggleHideColumn,
+  toggleSortBy
+}: any): JSX.Element {
+  const toggleableColumns = flatColumns.filter((column: any) =>
+    toggleableIds.includes(column.id)
+  );
+  const visibleHeaders = headers.filter((header: any) => header.isVisible);
+  const initialFiltersVisible: { [key: string]: boolean } = {};
+  for (const column of flatColumns) {
+    if (column.canFilter) {
+      initialFiltersVisible[column.id] = !!column.filterValue;
+    }
+  }
+  const [filtersVisible, setFiltersVisible] = React.useState(
+    initialFiltersVisible
+  );
+  const [togglesVisible, setTogglesVisible] = React.useState(false);
+  const filterPanel = new FilterPanel(
+    "decks_top",
+    filterMatchesCallback,
+    filters,
+    [],
+    [],
+    [],
+    false,
+    [],
+    false,
+    null,
+    false,
+    false
+  );
+  const pagingProps = {
+    canPreviousPage,
+    canNextPage,
+    pageOptions,
+    pageCount,
+    gotoPage,
+    nextPage,
+    previousPage,
+    setPageSize,
+    pageIndex,
+    pageSize
+  };
+  return (
+    <>
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          color: "var(--color-light)",
+          paddingBottom: "8px"
+        }}
+      >
+        <div className="decks_table_toggles">
+          <span style={{ paddingBottom: "8px" }}>Filter match results:</span>
+          <span style={{ width: "260px" }}>{filterPanel.render()}</span>
+          <span style={{ paddingBottom: "8px" }}>Presets:</span>
+          <PresetButton
+            onClick={(): void => {
+              setAllFilters(recentFilters);
+              setFiltersVisible(initialFiltersVisible);
+              toggleSortBy("timeTouched", true);
+              for (const columnId of toggleableIds) {
+                const isVisible = [
+                  "name",
+                  "format",
+                  "colorSortVal",
+                  "timeTouched",
+                  "lastEditWinrate"
+                ].includes(columnId);
+                toggleHideColumn(columnId, !isVisible);
+              }
+            }}
+          >
+            Recent
+          </PresetButton>
+          <PresetButton
+            onClick={(): void => {
+              setAllFilters(bestFilters);
+              setFiltersVisible({
+                ...initialFiltersVisible,
+                wins: true,
+                winrate100: true
+              });
+              toggleSortBy("winrate100", true);
+              for (const columnId of toggleableIds) {
+                const isVisible = [
+                  "name",
+                  "format",
+                  "colorSortVal",
+                  "losses",
+                  "winrate100",
+                  "wins"
+                ].includes(columnId);
+                toggleHideColumn(columnId, !isVisible);
+              }
+            }}
+          >
+            Best
+          </PresetButton>
+          <PresetButton
+            onClick={(): void => {
+              setAllFilters(wantedFilters);
+              setFiltersVisible({
+                ...initialFiltersVisible,
+                boosterCost: true
+              });
+              toggleSortBy("boosterCost", true);
+              for (const columnId of toggleableIds) {
+                const isVisible = [
+                  "name",
+                  "format",
+                  "colorSortVal",
+                  "boosterCost",
+                  "timeUpdated"
+                ].includes(columnId);
+                toggleHideColumn(columnId, !isVisible);
+              }
+            }}
+          >
+            Wanted
+          </PresetButton>
+          <MetricText
+            onClick={(): void => setTogglesVisible(!togglesVisible)}
+            className="button_simple"
+            style={{ margin: "0 0 5px 12px" }}
+          >
+            {togglesVisible ? "Hide" : "Show"} Column Toggles
+          </MetricText>
+        </div>
+        <div className="decks_table_toggles">
+          {togglesVisible &&
+            toggleableColumns.map((column: any) => (
+              <StyledCheckboxContainer key={column.id}>
+                {column.render("Header")}
+                <input type="checkbox" {...column.getToggleHiddenProps()} />
+                <span className={"checkmark"} />
+              </StyledCheckboxContainer>
+            ))}
+        </div>
+        <div className="decks_table_search_cont">
+          <WrappedReactSelect
+            current={tableMode}
+            options={TABLE_MODES}
+            callback={setTableMode}
+            className={"decks_table_mode"}
+          />
+          <GlobalFilter
+            preGlobalFilteredRows={preGlobalFilteredRows}
+            globalFilter={globalFilter}
+            setGlobalFilter={setGlobalFilter}
+          />
+          {globalFilter && (
+            <div
+              style={{ marginRight: 0, minWidth: "24px" }}
+              className={"button close"}
+              onClick={(e): void => {
+                e.stopPropagation();
+                setGlobalFilter(undefined);
+              }}
+              title={"clear column filter"}
+            />
+          )}
+          <PagingControls {...pagingProps} />
+        </div>
+      </div>
+      <div
+        className="decks_table_head line_dark"
+        style={{
+          gridTemplateColumns: `200px 150px 150px ${"1fr ".repeat(
+            visibleHeaders.length - 3
+          )}`
+        }}
+        {...getTableProps()}
+      >
+        {visibleHeaders.map((column: any, ii: number) => (
+          <div
+            {...column.getHeaderProps(column.getSortByToggleProps())}
+            className={"hover_label"}
+            style={{
+              height: "64px",
+              gridArea: `1 / ${ii + 1} / 1 / ${ii + 2}`
+            }}
+            key={column.id}
+          >
+            <div className={"decks_table_head_container"}>
+              <div
+                className={
+                  column.isSorted
+                    ? column.isSortedDesc
+                      ? " sort_desc"
+                      : " sort_asc"
+                    : ""
+                }
+                style={{ marginRight: "4px", width: "16px" }}
+              />
+              <div className={"flex_item"}>{column.render("Header")}</div>
+              {column.canFilter && (
+                <div
+                  style={{ marginRight: 0 }}
+                  className={"button settings"}
+                  onClick={(e): void => {
+                    e.stopPropagation();
+                    setFiltersVisible({
+                      ...filtersVisible,
+                      [column.id]: !filtersVisible[column.id]
+                    });
+                  }}
+                  title={
+                    (filtersVisible[column.id] ? "hide" : "show") +
+                    " column filter"
+                  }
+                />
+              )}
+              {column.filterValue && (
+                <div
+                  style={{ marginRight: 0 }}
+                  className={"button close"}
+                  onClick={(e): void => {
+                    e.stopPropagation();
+                    setFilter(column.id, undefined);
+                  }}
+                  title={"clear column filter"}
+                />
+              )}
+            </div>
+            {column.canFilter && filtersVisible[column.id] && (
+              <div
+                onClick={(e): void => e.stopPropagation()}
+                style={{
+                  display: "flex",
+                  justifyContent: "center"
+                }}
+                title={"filter column"}
+              >
+                {column.render("Filter")}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/window_main/components/decks/DecksTableControls.tsx
+++ b/src/window_main/components/decks/DecksTableControls.tsx
@@ -58,7 +58,7 @@ export default function DecksTableControls({
   getTableProps,
   globalFilter,
   gotoPage,
-  headers,
+  gridTemplateColumns,
   nextPage,
   pageCount,
   pageIndex,
@@ -73,12 +73,12 @@ export default function DecksTableControls({
   setTableMode,
   tableMode,
   toggleHideColumn,
-  toggleSortBy
+  toggleSortBy,
+  visibleHeaders
 }: DecksTableControlsProps): JSX.Element {
   const toggleableColumns = flatColumns.filter((column: any) =>
     toggleableIds.includes(column.id)
   );
-  const visibleHeaders = headers.filter((header: any) => header.isVisible);
   const initialFiltersVisible: { [key: string]: boolean } = {};
   for (const column of flatColumns) {
     if (column.canFilter) {
@@ -241,11 +241,7 @@ export default function DecksTableControls({
       </div>
       <div
         className="decks_table_head line_dark"
-        style={{
-          gridTemplateColumns: `200px 150px 150px ${"1fr ".repeat(
-            visibleHeaders.length - 3
-          )}`
-        }}
+        style={{ gridTemplateColumns }}
         {...getTableProps()}
       >
         {visibleHeaders.map((column: any, ii: number) => (

--- a/src/window_main/components/decks/DecksTableControls.tsx
+++ b/src/window_main/components/decks/DecksTableControls.tsx
@@ -9,6 +9,7 @@ import FilterPanel from "../../FilterPanel";
 import { MetricText } from "./cells";
 import { StyledCheckboxContainer, GlobalFilter } from "./filters";
 import PagingControls from "../PagingControls";
+import { DecksTableControlsProps } from "./types";
 
 const PresetButton = styled(MetricText).attrs(props => ({
   className: (props.className ?? "") + " button_simple"
@@ -73,7 +74,7 @@ export default function DecksTableControls({
   tableMode,
   toggleHideColumn,
   toggleSortBy
-}: any): JSX.Element {
+}: DecksTableControlsProps): JSX.Element {
   const toggleableColumns = flatColumns.filter((column: any) =>
     toggleableIds.includes(column.id)
   );

--- a/src/window_main/components/decks/DecksTableControls.tsx
+++ b/src/window_main/components/decks/DecksTableControls.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 
 import { WrappedReactSelect } from "../../../shared/ReactSelect";
-import { TABLE_MODES } from "../../../shared/constants";
+import { DECKS_TABLE_MODES } from "../../../shared/constants";
 
 import FilterPanel from "../../FilterPanel";
 import PagingControls from "../PagingControls";
@@ -204,7 +204,7 @@ export default function DecksTableControls({
         <div className="decks_table_search_cont">
           <WrappedReactSelect
             current={tableMode}
-            options={TABLE_MODES}
+            options={DECKS_TABLE_MODES}
             callback={setTableMode}
             className={"decks_table_mode"}
           />

--- a/src/window_main/components/decks/DecksTableControls.tsx
+++ b/src/window_main/components/decks/DecksTableControls.tsx
@@ -223,6 +223,7 @@ export default function DecksTableControls({
             preGlobalFilteredRows={preGlobalFilteredRows}
             globalFilter={globalFilter}
             setGlobalFilter={setGlobalFilter}
+            promptNoun={"decks"}
           />
           {globalFilter && (
             <div

--- a/src/window_main/components/decks/DecksTableControls.tsx
+++ b/src/window_main/components/decks/DecksTableControls.tsx
@@ -18,24 +18,6 @@ const PresetButton = styled(MetricText).attrs(props => ({
   width: 90px;
 `;
 
-const toggleableIds = [
-  "name",
-  "format",
-  "colorSortVal",
-  "duration",
-  "avgDuration",
-  "boosterCost",
-  "lastEditWinrate",
-  "timePlayed",
-  "timeUpdated",
-  "timeTouched",
-  "losses",
-  "tags",
-  "total",
-  "winrate100",
-  "wins",
-  "archivedCol"
-];
 const recentFilters = (): { id: string; value: any }[] => [
   { id: "archivedCol", value: "hideArchived" }
 ];
@@ -76,15 +58,18 @@ export default function DecksTableControls({
   toggleSortBy,
   visibleHeaders
 }: DecksTableControlsProps): JSX.Element {
-  const toggleableColumns = flatColumns.filter((column: any) =>
-    toggleableIds.includes(column.id)
-  );
-  const initialFiltersVisible: { [key: string]: boolean } = {};
-  for (const column of flatColumns) {
-    if (column.canFilter) {
-      initialFiltersVisible[column.id] = !!column.filterValue;
+  const [toggleableColumns, initialFiltersVisible] = React.useMemo(() => {
+    const toggleableColumns = flatColumns.filter(
+      (column: any) => column.mayToggle
+    );
+    const initialFiltersVisible: { [key: string]: boolean } = {};
+    for (const column of flatColumns) {
+      if (column.canFilter) {
+        initialFiltersVisible[column.id] = !!column.filterValue;
+      }
     }
-  }
+    return [toggleableColumns, initialFiltersVisible];
+  }, [flatColumns]);
   const [filtersVisible, setFiltersVisible] = React.useState(
     initialFiltersVisible
   );
@@ -134,15 +119,15 @@ export default function DecksTableControls({
               setAllFilters(recentFilters);
               setFiltersVisible(initialFiltersVisible);
               toggleSortBy("timeTouched", true);
-              for (const columnId of toggleableIds) {
+              for (const column of toggleableColumns) {
                 const isVisible = [
                   "name",
                   "format",
                   "colorSortVal",
                   "timeTouched",
                   "lastEditWinrate"
-                ].includes(columnId);
-                toggleHideColumn(columnId, !isVisible);
+                ].includes(column.id);
+                toggleHideColumn(column.id, !isVisible);
               }
             }}
           >
@@ -157,7 +142,7 @@ export default function DecksTableControls({
                 winrate100: true
               });
               toggleSortBy("winrate100", true);
-              for (const columnId of toggleableIds) {
+              for (const column of toggleableColumns) {
                 const isVisible = [
                   "name",
                   "format",
@@ -165,8 +150,8 @@ export default function DecksTableControls({
                   "losses",
                   "winrate100",
                   "wins"
-                ].includes(columnId);
-                toggleHideColumn(columnId, !isVisible);
+                ].includes(column.id);
+                toggleHideColumn(column.id, !isVisible);
               }
             }}
           >
@@ -180,15 +165,15 @@ export default function DecksTableControls({
                 boosterCost: true
               });
               toggleSortBy("boosterCost", true);
-              for (const columnId of toggleableIds) {
+              for (const column of toggleableColumns) {
                 const isVisible = [
                   "name",
                   "format",
                   "colorSortVal",
                   "boosterCost",
                   "timeUpdated"
-                ].includes(columnId);
-                toggleHideColumn(columnId, !isVisible);
+                ].includes(column.id);
+                toggleHideColumn(column.id, !isVisible);
               }
             }}
           >

--- a/src/window_main/components/decks/DecksTableControls.tsx
+++ b/src/window_main/components/decks/DecksTableControls.tsx
@@ -126,7 +126,6 @@ export default function DecksTableControls({
               toggleSortBy("timeTouched", true);
               for (const column of toggleableColumns) {
                 const isVisible = [
-                  "name",
                   "format",
                   "colorSortVal",
                   "timeTouched",
@@ -149,7 +148,6 @@ export default function DecksTableControls({
               toggleSortBy("winrate100", true);
               for (const column of toggleableColumns) {
                 const isVisible = [
-                  "name",
                   "format",
                   "colorSortVal",
                   "losses",
@@ -172,7 +170,6 @@ export default function DecksTableControls({
               toggleSortBy("boosterCost", true);
               for (const column of toggleableColumns) {
                 const isVisible = [
-                  "name",
                   "format",
                   "colorSortVal",
                   "boosterCost",

--- a/src/window_main/components/decks/cells.tsx
+++ b/src/window_main/components/decks/cells.tsx
@@ -402,7 +402,13 @@ export function TagsCell({
 
 export function MissingCardsCell({ cell }: CellProps): JSX.Element {
   if (!cell.value) {
-    return <></>;
+    return (
+      <StyledFlexRightCell>
+        <div className={"bo_explore_cost"} style={{ visibility: "hidden" }}>
+          0
+        </div>
+      </StyledFlexRightCell>
+    );
   }
   const data = cell.row.values;
   const ownedWildcards = {
@@ -429,11 +435,7 @@ export function MissingCardsCell({ cell }: CellProps): JSX.Element {
           </div>
         );
       })}
-      <div
-        key={"booster"}
-        className={"bo_explore_cost"}
-        title={"Boosters needed (estimated)"}
-      >
+      <div className={"bo_explore_cost"} title={"Boosters needed (estimated)"}>
         {Math.round(cell.value)}
       </div>
     </StyledFlexRightCell>
@@ -480,7 +482,7 @@ export function ArchivedCell({
   const data = cell.row.values;
   const isArchived = data.archived;
   if (!data.custom) {
-    return <></>;
+    return <StyledArchiveDiv style={{ visibility: "hidden" }} />;
   }
   return (
     <StyledArchivedCell

--- a/src/window_main/components/decks/cells.tsx
+++ b/src/window_main/components/decks/cells.tsx
@@ -25,7 +25,9 @@ import {
   ArchiveSymbol,
   useColorpicker,
   ColoredArchivedSymbol,
-  ManaSymbol
+  ManaSymbol,
+  RaritySymbol,
+  BoosterSymbol
 } from "../display";
 import { DecksTableCellProps } from "./types";
 
@@ -247,10 +249,10 @@ export function TagsCell({
 export function MissingCardsCell({ cell }: DecksTableCellProps): JSX.Element {
   if (!cell.value) {
     return (
-      <FlexLeftContainer>
-        <div className={"bo_explore_cost"} style={{ visibility: "hidden" }}>
-          0
-        </div>
+      <FlexLeftContainer style={{ visibility: "hidden" }}>
+        <MetricText>
+          <BoosterSymbol /> 0
+        </MetricText>
       </FlexLeftContainer>
     );
   }
@@ -268,20 +270,21 @@ export function MissingCardsCell({ cell }: DecksTableCellProps): JSX.Element {
           return;
         }
         return (
-          <div
+          <MetricText
             key={cardRarity}
-            className={"wc_explore_cost wc_" + cardRarity}
             title={_.capitalize(cardRarity) + " wildcards needed."}
+            style={{ marginRight: "4px" }}
           >
+            <RaritySymbol rarity={cardRarity} />{" "}
             {(ownedWildcards[cardRarity] > 0
               ? ownedWildcards[cardRarity] + "/"
               : "") + data[cardRarity]}
-          </div>
+          </MetricText>
         );
       })}
-      <div className={"bo_explore_cost"} title={"Boosters needed (estimated)"}>
-        {Math.round(cell.value)}
-      </div>
+      <MetricText title={"Boosters needed (estimated)"}>
+        <BoosterSymbol /> {Math.round(cell.value)}
+      </MetricText>
     </FlexLeftContainer>
   );
 }
@@ -291,7 +294,6 @@ export function ArchiveHeader(): JSX.Element {
     <ArchiveSymbol
       title={`archive/restore
 (deck must no longer be in Arena)`}
-      style={{ height: "24px", minHeight: "24px" }}
     />
   );
 }

--- a/src/window_main/components/decks/cells.tsx
+++ b/src/window_main/components/decks/cells.tsx
@@ -450,6 +450,7 @@ const StyledArchiveDiv = styled.div`
   margin: auto;
   overflow: hidden;
   background: url(../images/show.png) no-repeat left;
+  background-size: contain;
   -webkit-transition: all 0.25s cubic-bezier(0.2, 0.5, 0.35, 1);
   vertical-align: middle;
   opacity: 0.8;
@@ -463,6 +464,7 @@ export function ArchiveHeader(): JSX.Element {
     <StyledArchiveDiv
       title={`archive/restore
 (deck must no longer be in Arena)`}
+      style={{ height: "24px", minHeight: "24px" }}
     />
   );
 }

--- a/src/window_main/components/decks/cells.tsx
+++ b/src/window_main/components/decks/cells.tsx
@@ -83,7 +83,7 @@ export function StyledArtTileCell({
   );
 }
 
-const StyledFlexLeftCell = styled.div`
+export const StyledFlexLeftCell = styled.div`
   display: flex;
   justify-content: left;
   div {
@@ -93,7 +93,7 @@ const StyledFlexLeftCell = styled.div`
   }
 `;
 
-const StyledFlexRightCell = styled.div`
+export const StyledFlexRightCell = styled.div`
   display: flex;
   justify-content: right;
   div {
@@ -106,18 +106,19 @@ const StyledFlexRightCell = styled.div`
 export function ColorsCell({ cell }: CellProps): JSX.Element {
   const data = cell.row.values;
   return (
-    <StyledFlexRightCell>
+    <StyledFlexLeftCell>
       {data.colors.map((color: number, index: number) => {
         return <div key={index} className={"mana_s16 mana_" + MANA[color]} />;
       })}
-    </StyledFlexRightCell>
+    </StyledFlexLeftCell>
   );
 }
 
-const LabelText = styled.div`
+export const LabelText = styled.div`
   display: inline-block;
   cursor: pointer;
   text-align: left;
+  white-space: nowrap;
 `;
 
 export function NameCell({ cell }: CellProps): JSX.Element {
@@ -319,7 +320,7 @@ export function FormatCell({ cell, editTagCallback }: CellProps): JSX.Element {
     null
   );
   return (
-    <StyledFlexRightCell>
+    <StyledFlexLeftCell>
       <StyledTag
         backgroundColor={backgroundColor}
         fontStyle={"italic"}
@@ -334,7 +335,7 @@ export function FormatCell({ cell, editTagCallback }: CellProps): JSX.Element {
       >
         {cell.value || "unknown"}
       </StyledTag>
-    </StyledFlexRightCell>
+    </StyledFlexLeftCell>
   );
 }
 
@@ -409,11 +410,11 @@ export function TagsCell({
 export function MissingCardsCell({ cell }: CellProps): JSX.Element {
   if (!cell.value) {
     return (
-      <StyledFlexRightCell>
+      <StyledFlexLeftCell>
         <div className={"bo_explore_cost"} style={{ visibility: "hidden" }}>
           0
         </div>
-      </StyledFlexRightCell>
+      </StyledFlexLeftCell>
     );
   }
   const data = cell.row.values;
@@ -424,7 +425,7 @@ export function MissingCardsCell({ cell }: CellProps): JSX.Element {
     mythic: pd.economy.wcMythic
   };
   return (
-    <StyledFlexRightCell>
+    <StyledFlexLeftCell>
       {CARD_RARITIES.map(cardRarity => {
         if (cardRarity === "land" || !data[cardRarity]) {
           return;
@@ -444,7 +445,7 @@ export function MissingCardsCell({ cell }: CellProps): JSX.Element {
       <div className={"bo_explore_cost"} title={"Boosters needed (estimated)"}>
         {Math.round(cell.value)}
       </div>
-    </StyledFlexRightCell>
+    </StyledFlexLeftCell>
   );
 }
 

--- a/src/window_main/components/decks/cells.tsx
+++ b/src/window_main/components/decks/cells.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import format from "date-fns/format";
 import isValid from "date-fns/isValid";
 
-import { MANA, CARD_RARITIES } from "../../../shared/constants";
+import { CARD_RARITIES } from "../../../shared/constants";
 import { toMMSS, toDDHHMMSS } from "../../../shared/util";
 import RelativeTime from "../../../shared/time-components/RelativeTime";
 import pd from "../../../shared/player-data";
@@ -27,7 +27,7 @@ import {
   ColoredArchivedSymbol,
   ManaSymbol
 } from "../display";
-import { CellProps } from "./types";
+import { DecksTableCellProps } from "./types";
 
 interface ArtTileCellProps {
   url: string;
@@ -43,7 +43,7 @@ export function ArtTileCell({
   );
 }
 
-export function ColorsCell({ cell }: CellProps): JSX.Element {
+export function ColorsCell({ cell }: DecksTableCellProps): JSX.Element {
   const data = cell.row.values;
   return (
     <FlexLeftContainer>
@@ -54,7 +54,7 @@ export function ColorsCell({ cell }: CellProps): JSX.Element {
   );
 }
 
-export function NameCell({ cell }: CellProps): JSX.Element {
+export function NameCell({ cell }: DecksTableCellProps): JSX.Element {
   let displayName = cell.value;
   if (displayName.includes("?=?Loc/Decks/Precon/")) {
     displayName = displayName.replace("?=?Loc/Decks/Precon/", "");
@@ -65,11 +65,11 @@ export function NameCell({ cell }: CellProps): JSX.Element {
   return <LabelText>{displayName}</LabelText>;
 }
 
-export function MetricCell({ cell }: CellProps): JSX.Element {
+export function MetricCell({ cell }: DecksTableCellProps): JSX.Element {
   return <MetricText>{cell.value}</MetricText>;
 }
 
-export function DatetimeCell({ cell }: CellProps): JSX.Element {
+export function DatetimeCell({ cell }: DecksTableCellProps): JSX.Element {
   const dateVal = new Date(cell.value);
   if (!isValid(dateVal)) {
     return <MetricText>-</MetricText>;
@@ -81,7 +81,7 @@ export function DatetimeCell({ cell }: CellProps): JSX.Element {
   );
 }
 
-export function WinRateCell({ cell }: CellProps): JSX.Element {
+export function WinRateCell({ cell }: DecksTableCellProps): JSX.Element {
   const { total, interval, winrate, winrateLow, winrateHigh } = cell.row.values;
   if (!total) {
     return <MetricText title={"no data yet"}>-</MetricText>;
@@ -109,7 +109,9 @@ export function WinRateCell({ cell }: CellProps): JSX.Element {
   );
 }
 
-export function LastEditWinRateCell({ cell }: CellProps): JSX.Element {
+export function LastEditWinRateCell({
+  cell
+}: DecksTableCellProps): JSX.Element {
   const data = cell.row.values;
   let value, tooltip;
   if (data.lastEditTotal) {
@@ -133,7 +135,7 @@ export function LastEditWinRateCell({ cell }: CellProps): JSX.Element {
   return <MetricText title={tooltip}>{value}</MetricText>;
 }
 
-export function DurationCell({ cell }: CellProps): JSX.Element {
+export function DurationCell({ cell }: DecksTableCellProps): JSX.Element {
   const data = cell.row.values;
   let value, tooltip;
   if (data.total) {
@@ -146,7 +148,10 @@ export function DurationCell({ cell }: CellProps): JSX.Element {
   return <MetricText title={tooltip}>{value}</MetricText>;
 }
 
-export function FormatCell({ cell, editTagCallback }: CellProps): JSX.Element {
+export function FormatCell({
+  cell,
+  editTagCallback
+}: DecksTableCellProps): JSX.Element {
   const backgroundColor = getTagColor(cell.value);
   const containerRef: React.MutableRefObject<HTMLDivElement | null> = React.useRef(
     null
@@ -176,7 +181,7 @@ export function TagsCell({
   deleteTagCallback,
   editTagCallback,
   tagDeckCallback
-}: CellProps): JSX.Element {
+}: DecksTableCellProps): JSX.Element {
   const backgroundColor = getTagColor();
   const data = cell.row.values;
   const containerRef: React.MutableRefObject<HTMLDivElement | null> = React.useRef(
@@ -239,7 +244,7 @@ export function TagsCell({
   );
 }
 
-export function MissingCardsCell({ cell }: CellProps): JSX.Element {
+export function MissingCardsCell({ cell }: DecksTableCellProps): JSX.Element {
   if (!cell.value) {
     return (
       <FlexLeftContainer>
@@ -294,7 +299,7 @@ export function ArchiveHeader(): JSX.Element {
 export function ArchivedCell({
   cell,
   archiveDeckCallback
-}: CellProps): JSX.Element {
+}: DecksTableCellProps): JSX.Element {
   const data = cell.row.values;
   const isArchived = data.archived;
   if (!data.custom) {

--- a/src/window_main/components/decks/cells.tsx
+++ b/src/window_main/components/decks/cells.tsx
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import React, { useRef } from "react";
+import React from "react";
 import format from "date-fns/format";
 import isValid from "date-fns/isValid";
 import styled from "styled-components";
@@ -251,7 +251,7 @@ const StyledTagWithClose = styled(StyledTag)`
 `;
 
 function useColorpicker(
-  containerRef: React.MutableRefObject<any>,
+  containerRef: React.MutableRefObject<HTMLElement | null>,
   tag: string,
   backgroundColor: string,
   editTagCallback: (tag: string, color: string) => void
@@ -284,7 +284,9 @@ function DeckTag({
   deleteTagCallback
 }: DeckTagProps): JSX.Element {
   const backgroundColor = getTagColor(tag);
-  const containerRef = useRef(null);
+  const containerRef: React.MutableRefObject<HTMLDivElement | null> = React.useRef(
+    null
+  );
   return (
     <StyledTagWithClose
       backgroundColor={backgroundColor}
@@ -313,7 +315,9 @@ function DeckTag({
 
 export function FormatCell({ cell, editTagCallback }: CellProps): JSX.Element {
   const backgroundColor = getTagColor(cell.value);
-  const containerRef = useRef(null);
+  const containerRef: React.MutableRefObject<HTMLDivElement | null> = React.useRef(
+    null
+  );
   return (
     <StyledFlexRightCell>
       <StyledTag
@@ -342,10 +346,12 @@ export function TagsCell({
 }: CellProps): JSX.Element {
   const backgroundColor = getTagColor();
   const data = cell.row.values;
-  const containerRef = useRef(null);
+  const containerRef: React.MutableRefObject<HTMLDivElement | null> = React.useRef(
+    null
+  );
   // TODO translate this into React
   const clickHandler = function(e: React.MouseEvent): void {
-    const container: any = containerRef.current;
+    const container = containerRef.current;
     if (!container) {
       return;
     }

--- a/src/window_main/components/decks/cells.tsx
+++ b/src/window_main/components/decks/cells.tsx
@@ -27,7 +27,7 @@ import {
 
 const StyledArtTileHeader = styled.div`
   width: 200px;
-  margin: 0;
+  margin: 0 8px;
 `;
 
 const StyledArtTile = styled(StyledArtTileHeader)`

--- a/src/window_main/components/decks/cells.tsx
+++ b/src/window_main/components/decks/cells.tsx
@@ -25,6 +25,64 @@ import {
   StyledArchivedCellProps
 } from "./types";
 
+const StyledArtTileHeader = styled.div`
+  width: 200px;
+  margin: 0;
+`;
+
+const StyledArtTile = styled(StyledArtTileHeader)`
+  background-size: 200px;
+  background-position-x: center;
+  background-position-y: -10px;
+  opacity: 0.66;
+  height: 64px;
+  width: 160px;
+  &.deckTileHover-enter {
+    opacity: 0.66;
+    width: 160px;
+  }
+  &.deckTileHover-enter-active {
+    opacity: 1;
+    width: 200px;
+    -webkit-transition: opacity 0.2s ease-in, width 0.2s ease-in;
+    transition: opacity 0.2s ease-in, width 0.2s ease-in;
+  }
+  &.deckTileHover-enter-done {
+    opacity: 1;
+    width: 200px;
+  }
+  &.deckTileHover-exit {
+    opacity: 1;
+    width: 200px;
+  }
+  &.deckTileHover-exit-active {
+    opacity: 0.66;
+    width: 160px;
+    -webkit-transition: opacity 0.2s ease-in, width 0.2s ease-in;
+    transition: opacity 0.2s ease-in, width 0.2s ease-in;
+  }
+  &.deckTileHover-exit-done {
+    opacity: 0.66;
+    width: 160px;
+  }
+`;
+interface StyledArtTileCellProps {
+  url: string;
+  className?: string;
+}
+
+export function StyledArtTileCell({
+  url,
+  ...otherProps
+}: StyledArtTileCellProps): JSX.Element {
+  return (
+    <StyledArtTile
+      style={{ backgroundImage: `url("${url}")` }}
+      {...otherProps}
+    />
+  );
+}
+
 const StyledFlexLeftCell = styled.div`
   display: flex;
   justify-content: left;

--- a/src/window_main/components/decks/filters.tsx
+++ b/src/window_main/components/decks/filters.tsx
@@ -131,10 +131,11 @@ export function uberSearchFilterFn(
 export function GlobalFilter({
   preGlobalFilteredRows,
   globalFilter,
-  setGlobalFilter
+  setGlobalFilter,
+  promptNoun
 }: any): JSX.Element {
   const count = preGlobalFilteredRows.length;
-  const prompt = `Search ${count} decks...`;
+  const prompt = `Search ${count} ${promptNoun}...`;
   return (
     <StyledInputContainer title={prompt}>
       <input

--- a/src/window_main/components/decks/filters.tsx
+++ b/src/window_main/components/decks/filters.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import _ from "lodash";
 import React from "react";
 import styled from "styled-components";
@@ -8,35 +9,7 @@ import ManaFilter, { ColorFilter } from "../../ManaFilter";
 
 import Aggregator from "../../aggregator";
 import { MetricText } from "./cells";
-
-export const StyledInputContainer = styled.div.attrs(props => ({
-  className: (props.className ?? "") + " input_container"
-}))`
-  display: inline-flex;
-  margin: inherit;
-  position: relative;
-  width: 100%;
-  height: 26px;
-  padding-bottom: 4px;
-  input[type="number"]::-webkit-inner-spin-button,
-  input[type="number"]::-webkit-outer-spin-button {
-    -webkit-appearance: none;
-    margin: 0;
-  }
-  &.input_container input {
-    margin: 0;
-    width: calc(100% - 10px);
-    padding: 2px 4px;
-    position: absolute;
-    left: 0;
-    right: 0;
-  }
-  &:hover input {
-    color: rgba(255, 255, 255, 1);
-    background-color: var(--color-mid-50);
-    border: 1px solid var(--color-light);
-  }
-`;
+import { StyledInputContainer } from "../PagingControls";
 
 export const StyledCheckboxContainer = styled.label.attrs(props => ({
   className: (props.className ?? "") + " check_container hover_label"

--- a/src/window_main/components/decks/filters.tsx
+++ b/src/window_main/components/decks/filters.tsx
@@ -1,21 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import _ from "lodash";
 import React from "react";
-import styled from "styled-components";
 import matchSorter from "match-sorter";
 
 import { MANA } from "../../../shared/constants";
 import ManaFilter, { ColorFilter } from "../../ManaFilter";
-
 import Aggregator from "../../aggregator";
-import { MetricText } from "./cells";
-import { StyledInputContainer } from "../PagingControls";
-
-export const StyledCheckboxContainer = styled.label.attrs(props => ({
-  className: (props.className ?? "") + " check_container hover_label"
-}))`
-  display: inline-flex;
-`;
+import { MetricText, InputContainer, CheckboxContainer } from "../display";
 
 export function TextBoxFilter({
   column: { id, filterValue, preFilteredRows, setFilter }
@@ -26,13 +17,13 @@ export function TextBoxFilter({
   const prompt =
     id === "deckTileId" ? `Search ${count} decks...` : `Filter ${id}...`;
   return (
-    <StyledInputContainer title={prompt}>
+    <InputContainer title={prompt}>
       <input
         value={filterValue ?? ""}
         onChange={(e): void => setFilter(e.target.value ?? undefined)}
         placeholder={prompt}
       />
-    </StyledInputContainer>
+    </InputContainer>
   );
 }
 
@@ -52,7 +43,7 @@ export function NumberRangeColumnFilter({
   }, [id, preFilteredRows]);
   return (
     <>
-      <StyledInputContainer
+      <InputContainer
         style={{
           width: "36px",
           marginRight: "4px"
@@ -71,9 +62,9 @@ export function NumberRangeColumnFilter({
           placeholder={"min"}
           title={`inclusive lower bound (min ${min})`}
         />
-      </StyledInputContainer>
+      </InputContainer>
       <MetricText>to</MetricText>
-      <StyledInputContainer
+      <InputContainer
         style={{
           width: "36px",
           marginLeft: "4px"
@@ -92,7 +83,7 @@ export function NumberRangeColumnFilter({
           placeholder={"max"}
           title={`inclusive upper bound (max ${max})`}
         />
-      </StyledInputContainer>
+      </InputContainer>
     </>
   );
 }
@@ -105,7 +96,7 @@ export function fuzzyTextFilterFn(
   return matchSorter(rows, filterValue, { keys: ["values." + id] });
 }
 
-export function uberSearchFilterFn(
+export function deckSearchFilterFn(
   rows: any[],
   id: string,
   filterValue: string
@@ -137,13 +128,13 @@ export function GlobalFilter({
   const count = preGlobalFilteredRows.length;
   const prompt = `Search ${count} ${promptNoun}...`;
   return (
-    <StyledInputContainer title={prompt}>
+    <InputContainer title={prompt}>
       <input
         value={globalFilter ?? ""}
         onChange={(e): void => setGlobalFilter(e.target.value ?? undefined)}
         placeholder={prompt}
       />
-    </StyledInputContainer>
+    </InputContainer>
   );
 }
 
@@ -186,7 +177,7 @@ export function ArchiveColumnFilter({
   column: any;
 }): JSX.Element {
   return (
-    <StyledCheckboxContainer style={{ margin: "4px" }}>
+    <CheckboxContainer style={{ margin: "4px" }}>
       archived
       <input
         type="checkbox"
@@ -197,7 +188,7 @@ export function ArchiveColumnFilter({
         }}
       />
       <span className={"checkmark"} />
-    </StyledCheckboxContainer>
+    </CheckboxContainer>
   );
 }
 

--- a/src/window_main/components/decks/filters.tsx
+++ b/src/window_main/components/decks/filters.tsx
@@ -150,6 +150,7 @@ export function ColorColumnFilter({
       prefixId={"decks_table"}
       filterKey={"colors"}
       filters={{ colors: filterValue }}
+      symbolSize={16}
       onFilterChanged={(colors): void => {
         if (_.isMatch(colors, defaultColors)) {
           setFilter(undefined); // clear filter

--- a/src/window_main/components/decks/filters.tsx
+++ b/src/window_main/components/decks/filters.tsx
@@ -155,6 +155,24 @@ export function uberSearchFilterFn(
   return _.intersection(...matches);
 }
 
+export function GlobalFilter({
+  preGlobalFilteredRows,
+  globalFilter,
+  setGlobalFilter
+}: any): JSX.Element {
+  const count = preGlobalFilteredRows.length;
+  const prompt = `Search ${count} decks...`;
+  return (
+    <StyledInputContainer title={prompt}>
+      <input
+        value={globalFilter ?? ""}
+        onChange={(e): void => setGlobalFilter(e.target.value ?? undefined)}
+        placeholder={prompt}
+      />
+    </StyledInputContainer>
+  );
+}
+
 const defaultColors = Aggregator.getDefaultColorFilter();
 
 export function ColorColumnFilter({

--- a/src/window_main/components/decks/filters.tsx
+++ b/src/window_main/components/decks/filters.tsx
@@ -212,7 +212,7 @@ export function ArchiveColumnFilter({
   column: any;
 }): JSX.Element {
   return (
-    <StyledCheckboxContainer style={{ marginLeft: 0 }}>
+    <StyledCheckboxContainer style={{ margin: "4px" }}>
       archived
       <input
         type="checkbox"

--- a/src/window_main/components/decks/rows.tsx
+++ b/src/window_main/components/decks/rows.tsx
@@ -61,19 +61,6 @@ export function DeckTile({
     openDeckCallback(deckId);
   }, [deckId]);
 
-  const requireLabelIds = [
-    "duration",
-    "avgDuration",
-    "winrate100",
-    "lastEditWinrate",
-    "timePlayed",
-    "timeUpdated",
-    "timeTouched",
-    "losses",
-    "total",
-    "wins"
-  ];
-
   return (
     <div
       className={"decks_table_deck_tile"}
@@ -94,7 +81,7 @@ export function DeckTile({
             {...cell.getCellProps()}
             key={cell.column.id + "_" + row.index}
           >
-            {requireLabelIds.includes(cell.column.id) && (
+            {cell.column.needsTileLabel && (
               <MetricText
                 style={{
                   paddingRight: "8px",

--- a/src/window_main/components/decks/rows.tsx
+++ b/src/window_main/components/decks/rows.tsx
@@ -1,0 +1,127 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React from "react";
+import { CSSTransition } from "react-transition-group";
+
+import { getCardArtCrop } from "../../../shared/util";
+
+import { MetricText, StyledArtTileCell } from "./cells";
+
+export function TableViewRow({
+  row,
+  index,
+  openDeckCallback
+}: {
+  row: any;
+  index: number;
+  openDeckCallback: (id: string) => void;
+}): JSX.Element {
+  const deckId = row.values.deckId;
+  const mouseClick = React.useCallback(() => {
+    openDeckCallback(deckId);
+  }, [deckId]);
+  return (
+    <div
+      className={
+        "decks_table_body_row " + (index % 2 == 0 ? "line_light" : "line_dark")
+      }
+      style={{
+        gridTemplateColumns: `200px 150px 150px ${"1fr ".repeat(
+          row.cells.length - 3
+        )}`
+      }}
+      onClick={mouseClick}
+    >
+      {row.cells.map((cell: any) => {
+        return (
+          <div
+            className="inner_div"
+            {...cell.getCellProps()}
+            key={cell.column.id + "_" + row.index}
+            title={`show ${row.values.name} details`}
+          >
+            {cell.render("Cell")}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function DeckTile({
+  row,
+  index,
+  openDeckCallback
+}: {
+  row: any;
+  index: number;
+  openDeckCallback: (id: string) => void;
+}): JSX.Element {
+  const [hover, setHover] = React.useState(false);
+
+  const mouseEnter = React.useCallback(() => {
+    setHover(true);
+  }, []);
+
+  const mouseLeave = React.useCallback(() => {
+    setHover(false);
+  }, []);
+
+  const deckId = row.values.deckId;
+  const mouseClick = React.useCallback(() => {
+    openDeckCallback(deckId);
+  }, [deckId]);
+
+  const requireLabelIds = [
+    "duration",
+    "avgDuration",
+    "winrate100",
+    "lastEditWinrate",
+    "timePlayed",
+    "timeUpdated",
+    "timeTouched",
+    "losses",
+    "total",
+    "wins"
+  ];
+
+  return (
+    <div
+      className={"decks_table_deck_tile"}
+      title={`show ${row.values.name} details`}
+      onMouseEnter={mouseEnter}
+      onMouseLeave={mouseLeave}
+      onClick={mouseClick}
+    >
+      <CSSTransition classNames="deckTileHover" in={!!hover} timeout={200}>
+        <StyledArtTileCell url={getCardArtCrop(row.values["deckTileId"])} />
+      </CSSTransition>
+      {row.cells.map((cell: any) => {
+        cell.hover = hover;
+        return (
+          <div
+            className="inner_div"
+            style={hover ? { backgroundColor: "rgba(0,0,0,0.4)" } : undefined}
+            {...cell.getCellProps()}
+            key={cell.column.id + "_" + row.index}
+          >
+            {requireLabelIds.includes(cell.column.id) && (
+              <MetricText
+                style={{
+                  paddingRight: "8px",
+                  fontSize: "small",
+                  whiteSpace: "nowrap",
+                  fontWeight: 300,
+                  color: "var(--color-light-50)"
+                }}
+              >
+                {cell.column.render("Header")}:
+              </MetricText>
+            )}
+            {cell.render("Cell")}
+          </div>
+        );
+      })}
+      <div className="inner_div"> </div>
+    </div>
+  );
+}

--- a/src/window_main/components/decks/rows.tsx
+++ b/src/window_main/components/decks/rows.tsx
@@ -8,7 +8,7 @@ import { ArtTileCell } from "./cells";
 import { MetricText } from "../display";
 import { DecksTableRowProps } from "./types";
 
-export function TableViewRow({
+export function DecksTableViewRow({
   row,
   index,
   openDeckCallback,
@@ -42,7 +42,7 @@ export function TableViewRow({
   );
 }
 
-export function DeckTile({
+export function DecksArtViewRow({
   row,
   openDeckCallback
 }: DecksTableRowProps): JSX.Element {

--- a/src/window_main/components/decks/rows.tsx
+++ b/src/window_main/components/decks/rows.tsx
@@ -4,7 +4,8 @@ import { CSSTransition } from "react-transition-group";
 
 import { getCardArtCrop } from "../../../shared/util";
 
-import { MetricText, StyledArtTileCell } from "./cells";
+import { ArtTileCell } from "./cells";
+import { MetricText } from "../display";
 
 export function TableViewRow({
   row,
@@ -93,7 +94,7 @@ export function DeckTile({
       onClick={mouseClick}
     >
       <CSSTransition classNames="deckTileHover" in={!!hover} timeout={200}>
-        <StyledArtTileCell url={getCardArtCrop(row.values["deckTileId"])} />
+        <ArtTileCell url={getCardArtCrop(row.values["deckTileId"])} />
       </CSSTransition>
       {row.cells.map((cell: any) => {
         cell.hover = hover;

--- a/src/window_main/components/decks/rows.tsx
+++ b/src/window_main/components/decks/rows.tsx
@@ -6,18 +6,14 @@ import { getCardArtCrop } from "../../../shared/util";
 
 import { ArtTileCell } from "./cells";
 import { MetricText } from "../display";
+import { DecksTableRowProps } from "./types";
 
 export function TableViewRow({
   row,
   index,
   openDeckCallback,
   gridTemplateColumns
-}: {
-  row: any;
-  index: number;
-  openDeckCallback: (id: string) => void;
-  gridTemplateColumns: string;
-}): JSX.Element {
+}: DecksTableRowProps): JSX.Element {
   const deckId = row.values.deckId;
   const mouseClick = React.useCallback(() => {
     openDeckCallback(deckId);
@@ -48,15 +44,8 @@ export function TableViewRow({
 
 export function DeckTile({
   row,
-  index,
-  openDeckCallback,
-  gridTemplateColumns
-}: {
-  row: any;
-  index: number;
-  openDeckCallback: (id: string) => void;
-  gridTemplateColumns: string;
-}): JSX.Element {
+  openDeckCallback
+}: DecksTableRowProps): JSX.Element {
   const [hover, setHover] = React.useState(false);
 
   const mouseEnter = React.useCallback(() => {

--- a/src/window_main/components/decks/rows.tsx
+++ b/src/window_main/components/decks/rows.tsx
@@ -9,11 +9,13 @@ import { MetricText, StyledArtTileCell } from "./cells";
 export function TableViewRow({
   row,
   index,
-  openDeckCallback
+  openDeckCallback,
+  gridTemplateColumns
 }: {
   row: any;
   index: number;
   openDeckCallback: (id: string) => void;
+  gridTemplateColumns: string;
 }): JSX.Element {
   const deckId = row.values.deckId;
   const mouseClick = React.useCallback(() => {
@@ -24,11 +26,7 @@ export function TableViewRow({
       className={
         "decks_table_body_row " + (index % 2 == 0 ? "line_light" : "line_dark")
       }
-      style={{
-        gridTemplateColumns: `200px 150px 150px ${"1fr ".repeat(
-          row.cells.length - 3
-        )}`
-      }}
+      style={{ gridTemplateColumns }}
       onClick={mouseClick}
     >
       {row.cells.map((cell: any) => {
@@ -50,11 +48,13 @@ export function TableViewRow({
 export function DeckTile({
   row,
   index,
-  openDeckCallback
+  openDeckCallback,
+  gridTemplateColumns
 }: {
   row: any;
   index: number;
   openDeckCallback: (id: string) => void;
+  gridTemplateColumns: string;
 }): JSX.Element {
   const [hover, setHover] = React.useState(false);
 

--- a/src/window_main/components/decks/types.ts
+++ b/src/window_main/components/decks/types.ts
@@ -43,6 +43,7 @@ export interface DecksTableState {
   hiddenColumns: string[];
   filters: { [key: string]: any };
   sortBy: [{ id: string; desc: boolean }];
+  decksTableMode: string;
 }
 
 export interface DecksTableProps {

--- a/src/window_main/components/decks/types.ts
+++ b/src/window_main/components/decks/types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { SerializedDeck } from "../../../shared/types/Deck";
 
 export interface DeckStats {
@@ -88,7 +89,14 @@ export interface DecksTableControlsProps {
   visibleHeaders: any[];
 }
 
-export interface CellProps {
+export interface DecksTableRowProps {
+  row: any;
+  index: number;
+  openDeckCallback: (id: string) => void;
+  gridTemplateColumns: string;
+}
+
+export interface DecksTableCellProps {
   cell: any;
   archiveDeckCallback: (id: string) => void;
   tagDeckCallback: (deckid: string, tag: string) => void;

--- a/src/window_main/components/decks/types.ts
+++ b/src/window_main/components/decks/types.ts
@@ -60,6 +60,33 @@ export interface DecksTableProps {
   cachedTableMode: string;
 }
 
+export interface DecksTableControlsProps {
+  canNextPage: boolean;
+  canPreviousPage: boolean;
+  filterMatchesCallback: (filters: AggregatorFilters) => void;
+  filters: AggregatorFilters;
+  flatColumns: any[];
+  getTableProps: any;
+  globalFilter: any;
+  gotoPage: any;
+  headers: any[];
+  nextPage: any;
+  pageCount: number;
+  pageIndex: number;
+  pageOptions: any;
+  pageSize: number;
+  preGlobalFilteredRows: any[];
+  previousPage: any;
+  setAllFilters: any;
+  setFilter: any;
+  setGlobalFilter: any;
+  setPageSize: any;
+  setTableMode: any;
+  tableMode: string;
+  toggleHideColumn: any;
+  toggleSortBy: any;
+}
+
 export interface CellProps {
   cell: any;
   archiveDeckCallback: (id: string) => void;

--- a/src/window_main/components/decks/types.ts
+++ b/src/window_main/components/decks/types.ts
@@ -95,19 +95,3 @@ export interface CellProps {
   editTagCallback: (tag: string, color: string) => void;
   deleteTagCallback: (deckid: string, tag: string) => void;
 }
-
-export interface StyledTagProps {
-  backgroundColor: string;
-  fontStyle: string;
-}
-
-export interface DeckTagProps {
-  deckid: string;
-  tag: string;
-  editTagCallback: (tag: string, color: string) => void;
-  deleteTagCallback: (deckid: string, tag: string) => void;
-}
-
-export interface StyledArchivedCellProps {
-  archived: boolean;
-}

--- a/src/window_main/components/decks/types.ts
+++ b/src/window_main/components/decks/types.ts
@@ -69,7 +69,7 @@ export interface DecksTableControlsProps {
   getTableProps: any;
   globalFilter: any;
   gotoPage: any;
-  headers: any[];
+  gridTemplateColumns: string;
   nextPage: any;
   pageCount: number;
   pageIndex: number;
@@ -85,6 +85,7 @@ export interface DecksTableControlsProps {
   tableMode: string;
   toggleHideColumn: any;
   toggleSortBy: any;
+  visibleHeaders: any[];
 }
 
 export interface CellProps {

--- a/src/window_main/components/decks/types.ts
+++ b/src/window_main/components/decks/types.ts
@@ -34,7 +34,6 @@ export interface DecksData extends SerializedDeck, DeckStats, MissingWildcards {
 }
 
 export interface AggregatorFilters {
-  onlyCurrentDecks?: boolean;
   date?: Date;
   showArchived?: boolean;
 }
@@ -51,6 +50,7 @@ export interface DecksTableProps {
   filters: AggregatorFilters;
   filterMatchesCallback: (filters: AggregatorFilters) => void;
   openDeckCallback: (id: string) => void;
+  filterDecksCallback: (deckId?: string | string[]) => void;
   archiveDeckCallback: (id: string) => void;
   tagDeckCallback: (deckid: string, tag: string) => void;
   editTagCallback: (tag: string, color: string) => void;

--- a/src/window_main/components/decks/types.ts
+++ b/src/window_main/components/decks/types.ts
@@ -56,6 +56,7 @@ export interface DecksTableProps {
   deleteTagCallback: (deckid: string, tag: string) => void;
   tableStateCallback: (state: DecksTableState) => void;
   cachedState: DecksTableState;
+  cachedTableMode: string;
 }
 
 export interface CellProps {

--- a/src/window_main/components/display.tsx
+++ b/src/window_main/components/display.tsx
@@ -1,0 +1,290 @@
+import React from "react";
+import styled from "styled-components";
+
+import { MANA } from "../../shared/constants";
+
+import { getTagColor, showColorpicker } from "../renderer-util";
+
+export const ArtTileHeader = styled.div`
+  width: 200px;
+  margin: 0 8px;
+`;
+
+export const ArtTile = styled(ArtTileHeader)`
+  background-size: 200px;
+  background-position-x: center;
+  background-position-y: -10px;
+  opacity: 0.66;
+  height: 64px;
+  width: 160px;
+  &.deckTileHover-enter {
+    opacity: 0.66;
+    width: 160px;
+  }
+  &.deckTileHover-enter-active {
+    opacity: 1;
+    width: 200px;
+    -webkit-transition: opacity 0.2s ease-in, width 0.2s ease-in;
+    transition: opacity 0.2s ease-in, width 0.2s ease-in;
+  }
+  &.deckTileHover-enter-done {
+    opacity: 1;
+    width: 200px;
+  }
+  &.deckTileHover-exit {
+    opacity: 1;
+    width: 200px;
+  }
+  &.deckTileHover-exit-active {
+    opacity: 0.66;
+    width: 160px;
+    -webkit-transition: opacity 0.2s ease-in, width 0.2s ease-in;
+    transition: opacity 0.2s ease-in, width 0.2s ease-in;
+  }
+  &.deckTileHover-exit-done {
+    opacity: 0.66;
+    width: 160px;
+  }
+`;
+
+export const FlexLeftContainer = styled.div`
+  display: flex;
+  justify-content: left;
+  div {
+    :last-child:not(.deck_tag_close) {
+      margin-right: auto;
+    }
+  }
+`;
+
+export const FlexRightContainer = styled.div`
+  display: flex;
+  justify-content: right;
+  div {
+    :first-child {
+      margin-left: auto;
+    }
+  }
+`;
+
+export const LabelText = styled.div`
+  display: inline-block;
+  cursor: pointer;
+  text-align: left;
+  white-space: nowrap;
+`;
+
+export const MetricText = styled.div`
+  display: inline-block;
+  line-height: 32px;
+  font-family: var(--sub-font-name);
+  color: var(--color-light);
+  font-weight: 300;
+`;
+
+interface TagBubbleProps {
+  backgroundColor: string;
+  fontStyle: string;
+}
+
+export const TagBubble = styled.div<TagBubbleProps>`
+  font-family: var(--sub-font-name);
+  cursor: pointer;
+  color: black;
+  font-size: 13px;
+  opacity: 0.8;
+  margin-right: 12px;
+  margin-bottom: 4px;
+  height: 20px;
+  line-height: 20px;
+  text-indent: 8px;
+  padding-right: 12px;
+  border-radius: 16px;
+  display: flex;
+  justify-content: space-between;
+  -webkit-transition: all 0.2s ease-in-out;
+  background-color: ${({ backgroundColor }): string => backgroundColor};
+  font-style: ${({ fontStyle }): string => fontStyle};
+  :last-child {
+    margin-right: 0;
+  }
+  &:hover {
+    opacity: 1;
+  }
+`;
+
+const TagBubbleWithCloseContainer = styled(TagBubble)`
+  padding-right: 0;
+`;
+
+export function useColorpicker(
+  containerRef: React.MutableRefObject<HTMLElement | null>,
+  tag: string,
+  backgroundColor: string,
+  editTagCallback: (tag: string, color: string) => void
+): (e: React.MouseEvent) => void {
+  return (e): void => {
+    e.stopPropagation();
+    showColorpicker(
+      backgroundColor,
+      (color: { rgbString: string }) => {
+        const container = containerRef.current;
+        if (container) {
+          container.style.backgroundColor = color.rgbString;
+        }
+      },
+      (color: { rgbString: string }) => editTagCallback(tag, color.rgbString),
+      () => {
+        const container = containerRef.current;
+        if (container) {
+          container.style.backgroundColor = backgroundColor;
+        }
+      }
+    );
+  };
+}
+
+interface TagBubbleWithCloseProps {
+  deckid: string;
+  tag: string;
+  editTagCallback: (tag: string, color: string) => void;
+  deleteTagCallback: (deckid: string, tag: string) => void;
+}
+
+export function TagBubbleWithClose({
+  deckid,
+  tag,
+  editTagCallback,
+  deleteTagCallback
+}: TagBubbleWithCloseProps): JSX.Element {
+  const backgroundColor = getTagColor(tag);
+  const containerRef: React.MutableRefObject<HTMLDivElement | null> = React.useRef(
+    null
+  );
+  return (
+    <TagBubbleWithCloseContainer
+      backgroundColor={backgroundColor}
+      fontStyle={"normal"}
+      ref={containerRef}
+      title={"change tag color"}
+      onClick={useColorpicker(
+        containerRef,
+        tag,
+        backgroundColor,
+        editTagCallback
+      )}
+    >
+      {tag}
+      <div
+        className={"deck_tag_close"}
+        title={"delete tag"}
+        onClick={(e): void => {
+          e.stopPropagation();
+          deleteTagCallback(deckid, tag);
+        }}
+      />
+    </TagBubbleWithCloseContainer>
+  );
+}
+
+const ManaSymbolBase = styled.div.attrs<ManaSymbolProps>(props => ({
+  className: `mana_s16 mana_${MANA[props.colorIndex]} ${props.className ?? ""}`
+}))``;
+
+interface ManaSymbolProps {
+  colorIndex: number;
+}
+
+export const ManaSymbol = styled(ManaSymbolBase)<ManaSymbolProps>``;
+
+export const ArchiveSymbol = styled.div`
+  border-radius: 50%;
+  cursor: pointer;
+  width: 32px;
+  min-height: 32px;
+  margin: auto;
+  overflow: hidden;
+  background: url(../images/show.png) no-repeat left;
+  background-size: contain;
+  -webkit-transition: all 0.25s cubic-bezier(0.2, 0.5, 0.35, 1);
+  vertical-align: middle;
+  opacity: 0.8;
+  &:hover {
+    opacity: 1;
+  }
+`;
+
+interface ColoredArchivedSymbolProps {
+  archived: boolean;
+}
+
+export const ColoredArchivedSymbol = styled(ArchiveSymbol)<
+  ColoredArchivedSymbolProps
+>`
+  background: var(
+      ${(props): string => (props.archived ? "--color-g" : "--color-r")}
+    )
+    url(../images/${(props): string => (props.archived ? "show.png" : "hide.png")})
+    no-repeat left;
+`;
+
+export const InputContainer = styled.div.attrs(props => ({
+  className: (props.className ?? "") + " input_container"
+}))`
+  display: inline-flex;
+  margin: inherit;
+  position: relative;
+  width: 100%;
+  height: 26px;
+  padding-bottom: 4px;
+  input[type="number"]::-webkit-inner-spin-button,
+  input[type="number"]::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+  &.input_container input {
+    margin: 0;
+    width: calc(100% - 10px);
+    padding: 2px 4px;
+    position: absolute;
+    left: 0;
+    right: 0;
+  }
+  &:hover input {
+    color: rgba(255, 255, 255, 1);
+    background-color: var(--color-mid-50);
+    border: 1px solid var(--color-light);
+  }
+`;
+
+export const CheckboxContainer = styled.label.attrs(props => ({
+  className: (props.className ?? "") + " check_container hover_label"
+}))`
+  display: inline-flex;
+`;
+
+export const SmallTextButton = styled(MetricText).attrs(props => ({
+  className: (props.className ?? "") + " button_simple"
+}))`
+  margin: 0 4px 5px 4px;
+  width: 90px;
+`;
+
+interface PagingButtonProps {
+  selected?: boolean;
+}
+
+export const PagingButtonBase = styled.button.attrs<PagingButtonProps>(
+  props => ({
+    className:
+      (props.className ?? "") +
+      (props.disabled ? " paging_button_disabled" : " paging_button") +
+      (props.selected ? " paging_active" : "")
+  })
+)`
+  width: initial;
+  height: initial;
+  minwidth: 30px;
+`;
+
+export const PagingButton = styled(PagingButtonBase)<PagingButtonProps>``;

--- a/src/window_main/components/display.tsx
+++ b/src/window_main/components/display.tsx
@@ -17,8 +17,8 @@ export const ArtTile = styled(ArtTileHeader)`
   opacity: 0.7;
   height: 64px;
   width: 200px;
-  -webkit-transition: all 0.2s cubic-bezier(0.35, 0.12, 0.5, 1.0);
-  transition: all 0.2s cubic-bezier(0.35, 0.12, 0.5, 1.0);
+  -webkit-transition: all 0.2s cubic-bezier(0.35, 0.12, 0.5, 1);
+  transition: all 0.2s cubic-bezier(0.35, 0.12, 0.5, 1);
   &.deckTileHover-enter {
     opacity: 0.7;
     background-size: 110%;

--- a/src/window_main/components/display.tsx
+++ b/src/window_main/components/display.tsx
@@ -201,14 +201,39 @@ interface ManaSymbolProps {
 
 export const ManaSymbol = styled(ManaSymbolBase)<ManaSymbolProps>``;
 
+const SymbolBase = styled.div`
+  line-height: initial;
+  height: 20px;
+  width: 20px;
+  display: inline-block;
+  background-size: contain;
+  background-position: center;
+  margin: auto 2px;
+  vertical-align: middle;
+`;
+
+const RaritySymbolBase = styled(SymbolBase).attrs<RaritySymbolProps>(props => ({
+  className: `wc_explore_cost wc_${props.rarity} ${props.className ?? ""}`
+}))``;
+
+interface RaritySymbolProps {
+  rarity: string;
+}
+
+export const RaritySymbol = styled(RaritySymbolBase)<RaritySymbolProps>``;
+
+export const BoosterSymbol = styled(SymbolBase).attrs(props => ({
+  className: `bo_explore_cost ${props.className ?? ""}`
+}))``;
+
 export const ArchiveSymbol = styled.div`
   border-radius: 50%;
   cursor: pointer;
-  width: 32px;
-  min-height: 32px;
+  width: 30px;
+  min-height: 24px;
   margin: auto;
   overflow: hidden;
-  background: url(../images/show.png) no-repeat left;
+  background: url(../images/show.png) no-repeat center;
   background-size: contain;
   -webkit-transition: all 0.25s cubic-bezier(0.2, 0.5, 0.35, 1);
   vertical-align: middle;
@@ -229,7 +254,7 @@ export const ColoredArchivedSymbol = styled(ArchiveSymbol)<
       ${(props): string => (props.archived ? "--color-g" : "--color-r")}
     )
     url(../images/${(props): string => (props.archived ? "show.png" : "hide.png")})
-    no-repeat left;
+    no-repeat center;
 `;
 
 export const InputContainer = styled.div.attrs(props => ({

--- a/src/window_main/components/display.tsx
+++ b/src/window_main/components/display.tsx
@@ -11,39 +11,43 @@ export const ArtTileHeader = styled.div`
 `;
 
 export const ArtTile = styled(ArtTileHeader)`
-  background-size: 200px;
+  background-size: 100%;
   background-position-x: center;
-  background-position-y: -10px;
-  opacity: 0.66;
+  background-position-y: 10%;
+  opacity: 0.7;
   height: 64px;
-  width: 160px;
+  width: 200px;
+  -webkit-transition: all 0.2s cubic-bezier(0.35, 0.12, 0.5, 1.0);
+  transition: all 0.2s cubic-bezier(0.35, 0.12, 0.5, 1.0);
   &.deckTileHover-enter {
-    opacity: 0.66;
-    width: 160px;
+    opacity: 0.7;
+    background-size: 110%;
+    background-position-y: 16%;
   }
   &.deckTileHover-enter-active {
     opacity: 1;
-    width: 200px;
-    -webkit-transition: opacity 0.2s ease-in, width 0.2s ease-in;
-    transition: opacity 0.2s ease-in, width 0.2s ease-in;
+    background-size: 110%;
+    background-position-y: 16%;
   }
   &.deckTileHover-enter-done {
     opacity: 1;
-    width: 200px;
+    background-size: 110%;
+    background-position-y: 16%;
   }
   &.deckTileHover-exit {
     opacity: 1;
-    width: 200px;
+    background-size: 110%;
+    background-position-y: 16%;
   }
   &.deckTileHover-exit-active {
-    opacity: 0.66;
-    width: 160px;
-    -webkit-transition: opacity 0.2s ease-in, width 0.2s ease-in;
-    transition: opacity 0.2s ease-in, width 0.2s ease-in;
+    opacity: 0.7;
+    background-size: 100%;
+    background-position-y: 10%;
   }
   &.deckTileHover-exit-done {
-    opacity: 0.66;
-    width: 160px;
+    opacity: 0.75;
+    background-size: 100%;
+    background-position-y: 10%;
   }
 `;
 

--- a/src/window_main/components/display.tsx
+++ b/src/window_main/components/display.tsx
@@ -270,6 +270,10 @@ export const SmallTextButton = styled(MetricText).attrs(props => ({
   width: 90px;
 `;
 
+export const MediumTextButton = styled(SmallTextButton)`
+  width: 180px;
+`;
+
 interface PagingButtonProps {
   selected?: boolean;
 }

--- a/src/window_main/index.css
+++ b/src/window_main/index.css
@@ -1527,6 +1527,7 @@ a:hover {
     text-align: center;
     line-height: 24px;
     border-radius: 4px;
+    border: none;
     color: var(--color-light-20);
     background-color: var(--color-mid-40);
 }

--- a/src/window_main/index.css
+++ b/src/window_main/index.css
@@ -1478,10 +1478,11 @@ a:hover {
 
 .icon_search_inclusive {
     display: -webkit-inline-box;
-    width: 20px;
-    margin-right: 16px;
-    height: 20px;
     background: center no-repeat url('../images/create.png');
+    background-size: contain;
+    margin: auto 2px auto 2px;
+    background-repeat: no-repeat;
+    filter: drop-shadow(-1px 1px black);
 }
 
 .wc_search_icon {
@@ -1883,9 +1884,7 @@ a:hover {
     align-self: center;
     opacity: 1;
     background-repeat: no-repeat;
-    width: 40px;
-    margin: 0 auto;
-    height: 20px;
+    margin: 0 2px;
     cursor: pointer;
     background-position: center;
     background-size: contain;

--- a/src/window_main/index.css
+++ b/src/window_main/index.css
@@ -3905,6 +3905,7 @@ a:hover {
 .decks_table_deck_tile .inner_div {
     display: flex;
     padding: 2px;
+    padding-left: 10px;
     margin-left: 8px;
     justify-content: flex-start;
     align-items: center;

--- a/src/window_main/index.css
+++ b/src/window_main/index.css
@@ -1483,6 +1483,7 @@ a:hover {
     margin: auto 2px auto 2px;
     background-repeat: no-repeat;
     filter: drop-shadow(-1px 1px black);
+    vertical-align: middle;
 }
 
 .wc_search_icon {

--- a/src/window_main/index.css
+++ b/src/window_main/index.css
@@ -3859,12 +3859,17 @@ a:hover {
     display: grid;
     color: var(--color-light);
     border-bottom: 1px solid var(--color-light);
+    background-color: var(--color-mid-20);
 }
 
 .decks_table_head_container {
     margin-top: 8px;
     display: flex;
     justify-content: center;   
+}
+
+.decks_table_body {
+    background-color: var(--color-mid-20);
 }
 
 .decks_table_body_row {
@@ -3891,12 +3896,9 @@ a:hover {
 .decks_table_deck_tile {
     display: inline-block;
     height: 32px;
+    width: 208px;
     color: var(--color-light);
     -webkit-transition: all .1s ease-out;
-}
-
-.decks_table_deck_tile:hover {
-    background-color: rgba(0,0,0,0.4);
     cursor: pointer;
 }
 

--- a/src/window_main/index.css
+++ b/src/window_main/index.css
@@ -3888,6 +3888,27 @@ a:hover {
     overflow: hidden;
 }
 
+.decks_table_deck_tile {
+    display: inline-block;
+    height: 32px;
+    color: var(--color-light);
+    -webkit-transition: all .1s ease-out;
+}
+
+.decks_table_deck_tile:hover {
+    background-color: rgba(0,0,0,0.4);
+    cursor: pointer;
+}
+
+.decks_table_deck_tile .inner_div {
+    display: flex;
+    padding: 2px;
+    margin-left: 8px;
+    justify-content: flex-start;
+    align-items: center;
+    overflow: hidden;
+}
+
 .hover_label:hover {
     background-color: rgba(0,0,0,0.4);
     cursor: pointer;

--- a/src/window_main/index.css
+++ b/src/window_main/index.css
@@ -3850,7 +3850,8 @@ a:hover {
     display: flex;
     flex-wrap: wrap;
     width: -webkit-fill-available;
-    justify-content: space-between;
+    justify-content: center;
+    align-items: center;
 }
 
 .decks_table_search_cont {

--- a/src/window_main/index.css
+++ b/src/window_main/index.css
@@ -1493,11 +1493,17 @@ a:hover {
 }
 
 .paging_container {
-    margin: 16px 24px;
+    margin: 8px;
     display: flex;
     width: 100%;
     height: 24px;
     justify-content: center;
+    align-items: center;
+}
+
+.paging_text {
+    color: var(--color-light);
+    white-space: nowrap;
 }
 
 .paging_button {
@@ -3851,8 +3857,8 @@ a:hover {
     display: flex;
     margin: 4px auto;
     width: -webkit-fill-available;
-    justify-content: center;
-    max-width: 600px;
+    justify-content: space-between;
+    align-items: center;
 }
 
 .decks_table_head {

--- a/src/window_main/tournaments.js
+++ b/src/window_main/tournaments.js
@@ -203,7 +203,7 @@ function showTournamentRegister(mainDiv, tou) {
       .filter(deck => !deck.custom)
       .filter(deck => getBoosterCountEstimate(get_deck_missing(deck)) === 0);
 
-    validDecks.sort(new Aggregator({ onlyCurrentDecks: true }).compareDecks);
+    validDecks.sort(new Aggregator().compareDecks);
     const deckSelect = createSelect(
       deckSelectContainer,
       validDecks.map(deck => deck.id),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
       "isolatedModules": true,
       // Import non-ES modules as default imports.
       "esModuleInterop": true,
-      "jsx": "react"
+      "jsx": "react",
+      "downlevelIteration": true
     },
     "include": [
       "src"


### PR DESCRIPTION
### Motivation
This PR upgrades the Decks Table with a bunch of goodies:
- Moves the last chunk of state management logic on the decks tab into React
- `DecksTab` is now a proper React Component
- several performance optimizations (memoization and cleaner React hooks)
- connects the stats panel to the currently filtered decks in the table
- adds pagination controls to the decks table
- New dual view modes, "Table View" and "Deck Art View"

![react-decks-tab](https://user-images.githubusercontent.com/14894693/71647349-6217a280-2caa-11ea-8e37-a5c27735561c.gif)
