### PR TITLE
bugfix old Deck data may be Arena Deck v3

### DIFF
--- a/src/shared/DeckTypesStats.tsx
+++ b/src/shared/DeckTypesStats.tsx
@@ -17,7 +17,7 @@ function getDeckTypesAmount(deck: Deck): { [key: string]: number } {
       // develop merge conflict 23/11/19
       //if (card.id && card.id.id && card.id.id == 100) {
       //  types.lan += card.quantity;
-      if (card.id.id && card.id.id == 100) {
+      if (card?.id?.id === 100) {
         return;
       }
       const c = db.card(card.id);

--- a/src/shared/DeckTypesStats.tsx
+++ b/src/shared/DeckTypesStats.tsx
@@ -14,9 +14,6 @@ function getDeckTypesAmount(deck: Deck): { [key: string]: number } {
     .get()
     .forEach(function(card: CardObject | any) {
       // TODO remove group lands hack
-      // develop merge conflict 23/11/19
-      //if (card.id && card.id.id && card.id.id == 100) {
-      //  types.lan += card.quantity;
       if (card?.id?.id === 100) {
         return;
       }

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -320,10 +320,7 @@ export function get_wc_missing(deck, grpid, isSideboard) {
   // cap at 4 copies to handle petitioners, rat colony, etc
   needed = Math.min(4, needed);
 
-  const card = db.card(grpid);
-  if (!card) {
-    return 0;
-  }
+  let card = db.card(grpid);
   let arr = card.reprints;
   if (!arr) arr = [grpid];
   else arr.push(grpid);

--- a/src/shared/util.js
+++ b/src/shared/util.js
@@ -320,7 +320,10 @@ export function get_wc_missing(deck, grpid, isSideboard) {
   // cap at 4 copies to handle petitioners, rat colony, etc
   needed = Math.min(4, needed);
 
-  let card = db.card(grpid);
+  const card = db.card(grpid);
+  if (!card) {
+    return 0;
+  }
   let arr = card.reprints;
   if (!arr) arr = [grpid];
   else arr.push(grpid);

--- a/src/window_background/labels.js
+++ b/src/window_background/labels.js
@@ -264,7 +264,7 @@ function convertV3ToV2(v3List) {
   return ret;
 }
 
-function convertDeckFromV3(deck) {
+export function convertDeckFromV3(deck) {
   if (deck.CourseDeck) {
     if (deck.CourseDeck.mainDeck)
       deck.CourseDeck.mainDeck = convertV3ToV2(deck.CourseDeck.mainDeck);

--- a/src/window_background/loadPlayerConfig.js
+++ b/src/window_background/loadPlayerConfig.js
@@ -1,13 +1,13 @@
-import _ from "lodash";
 import { shell } from "electron";
-
+import _ from "lodash";
 import { IPC_BACKGROUND, IPC_OVERLAY } from "../shared/constants";
-
-import { ipc_send as ipcSend, setData } from "./backgroundUtil";
-import globals from "./globals";
 import { playerDb, playerDbLegacy } from "../shared/db/LocalDatabase";
 import playerData from "../shared/player-data";
+import { isV2CardsList } from "../shared/types/Deck";
 import arenaLogWatcher from "./arena-log-watcher";
+import { ipc_send as ipcSend, setData } from "./backgroundUtil";
+import globals from "./globals";
+import { convertDeckFromV3 } from "./labels";
 
 const ipcLog = message => ipcSend("ipc_log", message);
 const ipcPop = args => ipcSend("popup", args);
@@ -22,6 +22,16 @@ export function syncSettings(
   const settings = { ...playerData.settings, ...dirtySettings };
   setData({ settings }, refresh);
   if (refresh) ipcSend("set_settings", JSON.stringify(settings));
+}
+
+function fixBadPlayerData() {
+  // 2020-01-17 discovered with @Thaoden that some old draft decks might be v3
+  // probably caused by a bad label handler that was temporarily on stable
+  for (const deck of playerData.deckList) {
+    if (!isV2CardsList(deck.mainDeck)) {
+      convertDeckFromV3(deck);
+    }
+  }
 }
 
 // Loads this player's configuration file
@@ -40,6 +50,7 @@ export async function loadPlayerConfig(playerId) {
   const __playerData = _.defaultsDeep(savedData, playerData);
   const { settings } = __playerData;
   setData(__playerData, true);
+  fixBadPlayerData();
   ipcSend("renderer_set_bounds", __playerData.windowBounds);
   syncSettings(settings, true);
 

--- a/src/window_background/loadPlayerConfig.js
+++ b/src/window_background/loadPlayerConfig.js
@@ -30,6 +30,7 @@ function fixBadPlayerData() {
   for (const deck of playerData.deckList) {
     if (!isV2CardsList(deck.mainDeck)) {
       convertDeckFromV3(deck);
+      setData({ [deck.id]: deck }, false);
     }
   }
 }

--- a/src/window_background/loadPlayerConfig.js
+++ b/src/window_background/loadPlayerConfig.js
@@ -27,12 +27,14 @@ export function syncSettings(
 function fixBadPlayerData() {
   // 2020-01-17 discovered with @Thaoden that some old draft decks might be v3
   // probably caused by a bad label handler that was temporarily on stable
+  const decks = { ...playerData.decks };
   for (const deck of playerData.deckList) {
     if (!isV2CardsList(deck.mainDeck)) {
-      convertDeckFromV3(deck);
-      setData({ [deck.id]: deck }, false);
+      ipcLog("Converting v3 deck: " + deck.id);
+      decks[deck.id] = convertDeckFromV3(deck);
     }
   }
+  setData({ decks }, false);
 }
 
 // Loads this player's configuration file


### PR DESCRIPTION
### Motivation
Some time ago, there existed some released Beta or stable release that allowed users to save invalid draft decks. This was likely immediately after the log format changed to Arena V3, but before we correctly updated our label handlers. As a result, @Thaoden had several draft decks with an invalid format that were causing bugs on the Decks page and the Collection page.

This PR adds a step to our initial tool startup to automatically detect and convert those Arena V3 decks into the correct mtgatool internal format.