### PR TITLE
fix multi account merges

### DIFF
--- a/src/window_background/background.js
+++ b/src/window_background/background.js
@@ -504,7 +504,7 @@ async function logLoop() {
 
     // Get player Id
     strCheck = '\\"playerId\\": \\"';
-    if (value.includes(strCheck)) {
+    if (value.includes(strCheck) && parsedData.arenaId == undefined) {
       parsedData.arenaId = debugArenaID
         ? debugArenaID
         : unleakString(dataChop(value, strCheck, '\\"'));
@@ -512,13 +512,13 @@ async function logLoop() {
 
     // Get User name
     strCheck = '\\"screenName\\": \\"';
-    if (value.includes(strCheck)) {
+    if (value.includes(strCheck) && parsedData.name == undefined) {
       parsedData.name = unleakString(dataChop(value, strCheck, '\\"'));
     }
 
     // Get Client Version
     strCheck = '\\"clientVersion\\": "\\';
-    if (value.includes(strCheck)) {
+    if (value.includes(strCheck) && parsedData.arenaVersion == undefined) {
       parsedData.arenaVersion = unleakString(dataChop(value, strCheck, '\\"'));
     }
     /*

--- a/src/window_background/labels.js
+++ b/src/window_background/labels.js
@@ -26,6 +26,7 @@ import {
 import actionLog from "./actionLog";
 import addCustomDeck from "./addCustomDeck";
 import { createDraft, createMatch, completeMatch } from "./data";
+import { loadPlayerConfig } from "../loadPlayerConfig";
 
 let logLanguage = "English";
 
@@ -297,6 +298,12 @@ export function onLabelOutLogInfo(entry) {
 
   if (json.params.messageName == "Client.Connected") {
     logLanguage = json.params.payloadObject.settings.language.language;
+    const parsedData = {};
+    parsedData.arenaId = json.params.payloadObject.playerId;
+    parsedData.name = json.params.payloadObject.screenName;
+    parsedData.arenaVersion = json.params.payloadObject.clientVersion;
+    setData(parsedData, false);
+    loadPlayerConfig(json.params.payloadObject.playerId);
   }
   if (skipMatch) return;
   if (json.params.messageName == "DuelScene.GameStop") {

--- a/src/window_background/loadPlayerConfig.js
+++ b/src/window_background/loadPlayerConfig.js
@@ -52,10 +52,14 @@ export async function loadPlayerConfig(playerId) {
   ipcLog("...found all documents in player database.");
   ipcPop({ text: "Player history loaded.", time: 3000, progress: -1 });
 
-  globals.watchingLog = true;
-  ipcLog("Starting Arena Log Watcher: " + settings.logUri);
-  globals.stopWatchingLog = arenaLogWatcher.startWatchingLog(settings.logUri);
-  ipcLog("Calling back to http-api...");
+  // Only if watcher is not initialized
+  // Could happen when using multi accounts
+  if (globals.watchingLog == false) {
+    globals.watchingLog = true;
+    ipcLog("Starting Arena Log Watcher: " + settings.logUri);
+    globals.stopWatchingLog = arenaLogWatcher.startWatchingLog(settings.logUri);
+    ipcLog("Calling back to http-api...");
+  }
 }
 
 function ipcUpgradeProgress(progress) {


### PR DESCRIPTION
Smoothly switch between players data based on the connection events from the logs.

Still havent enabled any way to force load a player's data (@AnnanFay suggested this at some point), and while its possible I believe it may be better to only allow that if the login in MTG Arena actually happened, by reading the connected event (like this PR does), that is to only allow local users looking at the data from the account only if they actually logged into it.
Also doing this kind of unexpected "switch" while another user is playing might cause the merging issues we want to avoid so badly in the first place unless we implement some complex logic of "this user is being used but data displayed if from this other user".