### PR TITLE
Revert "attempt to fix multi account merges (#840)"

### DIFF
--- a/src/window_background/background.js
+++ b/src/window_background/background.js
@@ -504,7 +504,7 @@ async function logLoop() {
 
     // Get player Id
     strCheck = '\\"playerId\\": \\"';
-    if (value.includes(strCheck) && parsedData.arenaId == undefined) {
+    if (value.includes(strCheck)) {
       parsedData.arenaId = debugArenaID
         ? debugArenaID
         : unleakString(dataChop(value, strCheck, '\\"'));
@@ -512,13 +512,13 @@ async function logLoop() {
 
     // Get User name
     strCheck = '\\"screenName\\": \\"';
-    if (value.includes(strCheck) && parsedData.name == undefined) {
+    if (value.includes(strCheck)) {
       parsedData.name = unleakString(dataChop(value, strCheck, '\\"'));
     }
 
     // Get Client Version
     strCheck = '\\"clientVersion\\": "\\';
-    if (value.includes(strCheck) && parsedData.arenaVersion == undefined) {
+    if (value.includes(strCheck)) {
       parsedData.arenaVersion = unleakString(dataChop(value, strCheck, '\\"'));
     }
     /*

--- a/src/window_background/labels.js
+++ b/src/window_background/labels.js
@@ -26,7 +26,6 @@ import {
 import actionLog from "./actionLog";
 import addCustomDeck from "./addCustomDeck";
 import { createDraft, createMatch, completeMatch } from "./data";
-import { loadPlayerConfig } from "../loadPlayerConfig";
 
 let logLanguage = "English";
 
@@ -298,12 +297,6 @@ export function onLabelOutLogInfo(entry) {
 
   if (json.params.messageName == "Client.Connected") {
     logLanguage = json.params.payloadObject.settings.language.language;
-    const parsedData = {};
-    parsedData.arenaId = json.params.payloadObject.playerId;
-    parsedData.name = json.params.payloadObject.screenName;
-    parsedData.arenaVersion = json.params.payloadObject.clientVersion;
-    setData(parsedData, false);
-    loadPlayerConfig(json.params.payloadObject.playerId);
   }
   if (skipMatch) return;
   if (json.params.messageName == "DuelScene.GameStop") {

--- a/src/window_background/loadPlayerConfig.js
+++ b/src/window_background/loadPlayerConfig.js
@@ -52,14 +52,10 @@ export async function loadPlayerConfig(playerId) {
   ipcLog("...found all documents in player database.");
   ipcPop({ text: "Player history loaded.", time: 3000, progress: -1 });
 
-  // Only if watcher is not initialized
-  // Could happen when using multi accounts
-  if (globals.watchingLog == false) {
-    globals.watchingLog = true;
-    ipcLog("Starting Arena Log Watcher: " + settings.logUri);
-    globals.stopWatchingLog = arenaLogWatcher.startWatchingLog(settings.logUri);
-    ipcLog("Calling back to http-api...");
-  }
+  globals.watchingLog = true;
+  ipcLog("Starting Arena Log Watcher: " + settings.logUri);
+  globals.stopWatchingLog = arenaLogWatcher.startWatchingLog(settings.logUri);
+  ipcLog("Calling back to http-api...");
 }
 
 function ipcUpgradeProgress(progress) {


### PR DESCRIPTION
Currently `develop` has a broken build caused by #840. This simply reverts that commit.

(most likely the root problem is a circular dependency issue like `labels --> loadPlayerConfig --> arena-log-watcher --> labels --> loadPlayerConfig ...`)

This reverts commit 32e709597d309fb5722abc158def478f5785a5e8.