### PR TITLE
Fix loadPlayerConfig path

### DIFF
--- a/src/window_background/labels.js
+++ b/src/window_background/labels.js
@@ -26,7 +26,7 @@ import {
 import actionLog from "./actionLog";
 import addCustomDeck from "./addCustomDeck";
 import { createDraft, createMatch, completeMatch } from "./data";
-import { loadPlayerConfig } from "../loadPlayerConfig";
+import { loadPlayerConfig } from "./loadPlayerConfig";
 
 let logLanguage = "English";
 


### PR DESCRIPTION
`loadPlayerConfig` is in the same folder as `labels`, so only a single dot necessary.