### PR TITLE
persist player data fixes

### DIFF
--- a/src/window_background/loadPlayerConfig.js
+++ b/src/window_background/loadPlayerConfig.js
@@ -32,7 +32,7 @@ async function fixBadPlayerData() {
     if (!isV2CardsList(deck.mainDeck)) {
       ipcLog("Converting v3 deck: " + deck.id);
       decks[deck.id] = convertDeckFromV3(deck);
-      playerDb.upsert("decks", deck.id, deck);
+      await playerDb.upsert("decks", deck.id, deck);
     }
   }
   setData({ decks }, false);

--- a/src/window_background/loadPlayerConfig.js
+++ b/src/window_background/loadPlayerConfig.js
@@ -24,7 +24,7 @@ export function syncSettings(
   if (refresh) ipcSend("set_settings", JSON.stringify(settings));
 }
 
-function fixBadPlayerData() {
+async function fixBadPlayerData() {
   // 2020-01-17 discovered with @Thaoden that some old draft decks might be v3
   // probably caused by a bad label handler that was temporarily on stable
   const decks = { ...playerData.decks };
@@ -32,6 +32,7 @@ function fixBadPlayerData() {
     if (!isV2CardsList(deck.mainDeck)) {
       ipcLog("Converting v3 deck: " + deck.id);
       decks[deck.id] = convertDeckFromV3(deck);
+      playerDb.upsert("decks", deck.id, deck);
     }
   }
   setData({ decks }, false);
@@ -53,7 +54,7 @@ export async function loadPlayerConfig(playerId) {
   const __playerData = _.defaultsDeep(savedData, playerData);
   const { settings } = __playerData;
   setData(__playerData, true);
-  fixBadPlayerData();
+  await fixBadPlayerData();
   ipcSend("renderer_set_bounds", __playerData.windowBounds);
   syncSettings(settings, true);
 

--- a/src/window_background/loadPlayerConfig.js
+++ b/src/window_background/loadPlayerConfig.js
@@ -31,8 +31,9 @@ async function fixBadPlayerData() {
   for (const deck of playerData.deckList) {
     if (!isV2CardsList(deck.mainDeck)) {
       ipcLog("Converting v3 deck: " + deck.id);
-      decks[deck.id] = convertDeckFromV3(deck);
-      await playerDb.upsert("decks", deck.id, deck);
+      const fixedDeck = convertDeckFromV3(deck);
+      decks[deck.id] = fixedDeck;
+      await playerDb.upsert("decks", deck.id, fixedDeck);
     }
   }
   setData({ decks }, false);


### PR DESCRIPTION
Responding to feedback from @Thaoden that we should only convert these once, then persist the results.

@Thaoden can you confirm that running this permanently converts your problem decks?