### PR TITLE
Fix archetype detection tags

### DIFF
--- a/src/shared/database.ts
+++ b/src/shared/database.ts
@@ -153,8 +153,8 @@ class Database {
     return this.metadata ? this.metadata.abilities : {};
   }
 
-  get archetypes(): { [id: number]: Archetype } {
-    return this.metadata ? this.metadata.archetypes : {};
+  get archetypes(): Archetype[] {
+    return this.metadata ? this.metadata.archetypes : [];
   }
 
   get cards(): { [id: number]: DbCardData } {

--- a/src/shared/types/Metadata.ts
+++ b/src/shared/types/Metadata.ts
@@ -13,7 +13,7 @@ export interface Metadata {
   limited_ranked_events: string[];
   standard_ranked_events: string[];
   single_match_events: string[];
-  archetypes: { [id: number]: Archetype };
+  archetypes: Archetype[];
 }
 
 export interface DbCardData {
@@ -62,7 +62,7 @@ export interface CardSet {
 export interface Archetype {
   average: ArchetypeAverage;
   name: string;
-  format: string;
+  format?: string;
 }
 
 interface ArchetypeAverage {

--- a/src/window_background/getOpponentDeck.ts
+++ b/src/window_background/getOpponentDeck.ts
@@ -2,10 +2,10 @@ import globals from "./globals";
 import db from "../shared/database";
 import Deck from "../shared/deck";
 import { SerializedDeck } from "../shared/types/Deck";
-import { DbCardData } from "../shared/types/Metadata";
+import { DbCardData, Archetype } from "../shared/types/Metadata";
 
 function calculateDeviation(values: number[]): number {
-  return Math.sqrt(values.reduce((a, b) => a + b) / values.length - 1);
+  return Math.sqrt(values.reduce((a, b) => a + b) / (values.length - 1));
 }
 
 function getBestArchetype(deck: Deck): string {
@@ -26,7 +26,8 @@ function getBestArchetype(deck: Deck): string {
   const highest = lowestDeviation; //err..
 
   // Test for each archetype
-  Object.entries(db.archetypes).forEach(([key, arch]) => {
+  //console.log("highest", highest);
+  db.archetypes.forEach((arch: Archetype) => {
     //console.log(arch.name);
     mainDeviations = [];
     deck
@@ -39,7 +40,7 @@ function getBestArchetype(deck: Deck): string {
 
         const deviation = 1 - (archMain[name] ? 1 : 0); // archMain[name] ? archMain[name] : 0 // for full data
         mainDeviations.push(deviation * deviation);
-        //console.log(name, deviation, q, archMain[name]);
+        //console.log(name, deviation, archMain[name]);
       });
     const finalDeviation = calculateDeviation(mainDeviations);
 
@@ -47,7 +48,7 @@ function getBestArchetype(deck: Deck): string {
       lowestDeviation = finalDeviation;
       bestMatch = arch.name;
     }
-    //console.log(">>", averageDeviation, Math.sqrt(averageDeviation));
+    //console.log(">>", finalDeviation, lowestDeviation, bestMatch);
   });
 
   if (lowestDeviation > highest * 0.5) {


### PR DESCRIPTION
It appears to have been a simple convertion issue when moving to .ts, a parenthesis was missing in `calculateDeviation()`

Also fixed the types for the database archetypes (its probably the same, technically?)