### PR TITLE
deescalate offline or non-sharing modes to a warning

### DIFF
--- a/src/window_background/httpApi.ts
+++ b/src/window_background/httpApi.ts
@@ -195,7 +195,7 @@ function handleAuthResponse(
   results?: string,
   parsedResult?: any
 ): void {
-  if (error) {
+  if (error || !parsedResult) {
     syncSettings({ token: "" }, false);
     appDb.upsert("", "email", "");
     appDb.upsert("", "token", "");
@@ -203,7 +203,7 @@ function handleAuthResponse(
     ipcSend("toggle_login", true);
     ipcSend("clear_pwd", 1);
     ipcPop({
-      text: error.message,
+      text: error?.message,
       time: 3000,
       progress: -1
     });

--- a/src/window_background/httpWorker.ts
+++ b/src/window_background/httpWorker.ts
@@ -117,8 +117,10 @@ export function asyncWorker(task: HttpTask, callback: HttpTaskCallback): void {
     if (!playerData.offline) {
       setData({ offline: true });
     }
-    const text = `Settings dont allow sending data! > (${task.method})`;
-    callback(new Error(text), task);
+    const text = `WARNING >> currently offline or settings prohibit sharing > (${task.method})`;
+    ipcLog(text);
+    callback(undefined, task, undefined, undefined);
+    return;
   }
   const _headers: any = { ...task };
   _headers.token = playerData.settings.token;


### PR DESCRIPTION
### Motivation
When a user runs in offline mode or disables sharing, the tool "overreacts" a tiny bit.

https://discordapp.com/channels/463844727654187020/467737642306371584/668475031184998402
![image](https://user-images.githubusercontent.com/14894693/72691195-5c0e2800-3ad8-11ea-98f6-981bcde9e785.png)


#### Before
![image](https://user-images.githubusercontent.com/14894693/72691110-b6f34f80-3ad7-11ea-9ca8-a1d0378dd5c5.png)
![image](https://user-images.githubusercontent.com/14894693/72691116-c5da0200-3ad7-11ea-8caf-678ca57e3ad2.png)


#### After
![image](https://user-images.githubusercontent.com/14894693/72691130-f5890a00-3ad7-11ea-96b1-704834aad435.png)
