### PR TITLE
rename skip_refresh to skipRefresh

### DIFF
--- a/src/overlay/OverlayController.tsx
+++ b/src/overlay/OverlayController.tsx
@@ -141,7 +141,7 @@ export default function OverlayController(): JSX.Element {
       ipcSend("save_user_settings", {
         overlays: newOverlays,
         overlayHover: newOverlayHover,
-        skip_refresh: true
+        skipRefresh: true
       });
     }
     setEditMode(_editMode);

--- a/src/window_background/background.js
+++ b/src/window_background/background.js
@@ -237,8 +237,7 @@ ipc.on("save_user_settings", function(event, settings) {
   // console.log("save_user_settings");
   ipc_send("show_loading");
   let refresh = true;
-  if (settings.skip_refresh || settings.skipRefresh) {
-    delete settings.skip_refresh;
+  if (settings.skipRefresh) {
     delete settings.skipRefresh;
     refresh = false;
   }

--- a/src/window_background/loadPlayerConfig.js
+++ b/src/window_background/loadPlayerConfig.js
@@ -107,7 +107,7 @@ async function migrateIfNecessary() {
     // ensure blended user settings migrate
     setData(__playerData, false);
     syncSettings(settings, false);
-    ipcSend("save_user_settings", { skip_refresh: true }, IPC_BACKGROUND);
+    ipcSend("save_user_settings", { skipRefresh: true }, IPC_BACKGROUND);
     const dataToMigrate = playerData.data;
     const totalDocs = Object.values(dataToMigrate).length;
     ipcUpgradeProgress(0);

--- a/src/window_main/DateFilter.tsx
+++ b/src/window_main/DateFilter.tsx
@@ -50,7 +50,7 @@ export default function DateFilter({
         callback(filter);
         ipcSend("save_user_settings", {
           last_date_filter: filter,
-          skip_refresh: true
+          skipRefresh: true
         });
       }
     },

--- a/src/window_main/renderer-util.js
+++ b/src/window_main/renderer-util.js
@@ -136,7 +136,7 @@ function makeResizable(div, resizeCallback, finalCallback) {
   const saveWidth = function(width) {
     ipcSend("save_user_settings", {
       right_panel_width: width,
-      skip_refresh: true
+      skipRefresh: true
     });
   };
 

--- a/src/window_main/renderer.js
+++ b/src/window_main/renderer.js
@@ -281,7 +281,7 @@ ipc.on("force_open_tab", function(event, arg) {
   setLocalState({ lastDataIndex: 0, lastScrollTop: 0 });
   openTab(arg);
   ipcSend("save_user_settings", {
-    skip_refresh: true
+    skipRefresh: true
   });
   updateTopBar();
 });

--- a/src/window_main/tabControl.ts
+++ b/src/window_main/tabControl.ts
@@ -131,7 +131,7 @@ export function clickNav(id: number): void {
   ipcSend("save_user_settings", {
     last_open_tab: sidebarActive,
     last_date_filter: filters.date,
-    skip_refresh: true
+    skipRefresh: true
   });
 }
 


### PR DESCRIPTION
This is a code chore that was discussed in the review of #835. It should have no functional effect.