### PR TITLE
No file extensions

### DIFF
--- a/src/shared/cardsList.ts
+++ b/src/shared/cardsList.ts
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import db from "./database.js";
+import db from "./database";
 import Colors from "./colors";
 import { CardObject, v2cardsList, isV2CardsList } from "./types/Deck";
 import { DbCardData } from "./types/Metadata";

--- a/src/window_background/actionLog.ts
+++ b/src/window_background/actionLog.ts
@@ -1,7 +1,7 @@
 import { ipc_send } from "./backgroundUtil";
 import fs from "fs";
 import path from "path";
-import { IPC_OVERLAY } from "../shared/constants.js";
+import { IPC_OVERLAY } from "../shared/constants";
 import globals from "./globals";
 import format from "date-fns/format";
 

--- a/src/window_background/backgroundUtil.ts
+++ b/src/window_background/backgroundUtil.ts
@@ -6,7 +6,7 @@ import _ from "lodash";
 import parse from "date-fns/parse";
 import isValid from "date-fns/isValid";
 import { IPC_BACKGROUND, IPC_MAIN, IPC_OVERLAY } from "../shared/constants";
-import playerData from "../shared/player-data.js";
+import playerData from "../shared/player-data";
 import globals from "./globals";
 
 // Begin of IPC messages recievers

--- a/src/window_background/data.ts
+++ b/src/window_background/data.ts
@@ -3,7 +3,7 @@ import database from "../shared/database";
 import electron from "electron";
 import getOpponentDeck from "./getOpponentDeck";
 import globals from "./globals";
-import playerData from "../shared/player-data.js";
+import playerData from "../shared/player-data";
 import { DEFAULT_TILE } from "../shared/constants";
 import { MatchCreatedEvent } from "../shared/types/MatchCreatedEvent";
 import { objectClone } from "../shared/util";

--- a/src/window_background/greToClientInterpreter.ts
+++ b/src/window_background/greToClientInterpreter.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 /* eslint-disable @typescript-eslint/camelcase */
-import { IPC_OVERLAY } from "../shared/constants.js";
+import { IPC_OVERLAY } from "../shared/constants";
 import { objectClone } from "../shared/util";
 import { ipc_send } from "./backgroundUtil";
 import Deck from "../shared/deck";

--- a/src/window_background/updateDeck.js
+++ b/src/window_background/updateDeck.js
@@ -1,5 +1,5 @@
 import globals from "./globals";
-import { IPC_OVERLAY } from "../shared/constants.js";
+import { IPC_OVERLAY } from "../shared/constants";
 import { ipc_send } from "./backgroundUtil";
 import forceDeckUpdate from "./forceDeckUpdate";
 import getOpponentDeck from "./getOpponentDeck";

--- a/src/window_main/collection/completionHeatMap.ts
+++ b/src/window_main/collection/completionHeatMap.ts
@@ -10,7 +10,7 @@ import {
   BLACK,
   GREEN,
   RED
-} from "../../shared/constants.js";
+} from "../../shared/constants";
 
 import { CardStats } from "./collectionStats";
 

--- a/src/window_main/tournaments.js
+++ b/src/window_main/tournaments.js
@@ -2,7 +2,7 @@ import anime from "animejs";
 import { queryElements as $$, createDiv } from "../shared/dom-fns";
 import createSelect from "./createSelect";
 import * as deckDrawer from "./DeckDrawer";
-import { EASING_DEFAULT } from "../shared/constants.js";
+import { EASING_DEFAULT } from "../shared/constants";
 import {
   compare_cards,
   get_deck_export,


### PR DESCRIPTION
### Motivation
This PR completes a minor code chore to remove the few remaining explicit filename extensions from `import` statements. It is a pre-requisite for the long-delayed conversion of the build to Webpack (#737) and original came from that PR.