### PR TITLE
use svg mana icons on explore

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -660,6 +660,7 @@ export const STANDARD_CUTOFF_DATE = "2018-10-04"; // day before GRN release
 
 export const COLORS_ALL = ["w", "u", "b", "r", "g", "c"] as const;
 export const COLORS_BRIEF = ["w", "u", "b", "r", "g"] as const;
+export const COLORS_LONG = ["white", "blue", "black", "red", "green"] as const;
 export const RANKS = [
   "Bronze",
   "Silver",

--- a/src/window_main/explore.js
+++ b/src/window_main/explore.js
@@ -3,7 +3,7 @@ import anime from "animejs";
 import {
   CARD_RARITIES,
   MANA,
-  COLORS_BRIEF,
+  COLORS_LONG,
   DEFAULT_TILE,
   RANKS,
   RANKS_SORT,
@@ -295,14 +295,14 @@ function drawFilters() {
    *  Mana filter
    **/
   const manas = createDiv(["mana_filters_explore"]);
-  COLORS_BRIEF.forEach(function(s, i) {
+  COLORS_LONG.forEach(function(s, i) {
     const mi = [1, 2, 3, 4, 5];
     let classes = ["mana_filter"];
     if (!inputMana.includes(mi[i])) {
       classes.push("mana_filter_on");
     }
     const manabutton = createDiv(classes);
-    manabutton.style.backgroundImage = "url(../images/" + s + "20.png)";
+    manabutton.classList.add("mana_" + s);
     manabutton.style.height = "20px";
     manabutton.style.width = "40px";
     manabutton.addEventListener("click", function() {


### PR DESCRIPTION
### Motivation
This PR completes a minor code chore (and UX upgrade) to use explicit svg class names instead of png resources for the Explore page mana filter. It is a pre-requisite for the long-delayed conversion of the build to Webpack (#737) and originally came from that PR.