### PR TITLE
Bugfix hidden columns memory leak

### DIFF
--- a/src/window_main/components/tables/hooks.ts
+++ b/src/window_main/components/tables/hooks.ts
@@ -165,21 +165,19 @@ export function useBaseReactTable<D extends TableData>({
     [customFilterTypes]
   );
   const initialState: TableState<D> = React.useMemo(() => {
-    // default hidden columns
-    const hiddenColumns = columns
-      .filter(column => !column.defaultVisible)
-      .map(column => column.id ?? column.accessor);
     const state = _.defaultsDeep(cachedState, {
       pageSize: 25,
-      ...defaultState,
-      hiddenColumns
+      hiddenColumns: [],
+      ...defaultState
     });
     // ensure data-only columns are all invisible
+    const hiddenColumns = new Set(state.hiddenColumns);
     for (const column of columns) {
       if (!column.defaultVisible && !column.mayToggle) {
-        state.hiddenColumns.push(column.id ?? column.accessor);
+        hiddenColumns.add(column.id ?? column.accessor);
       }
     }
+    state.hiddenColumns = [...hiddenColumns];
     return state;
   }, [cachedState, columns, defaultState]);
 

--- a/src/window_main/components/tables/hooks.ts
+++ b/src/window_main/components/tables/hooks.ts
@@ -165,19 +165,23 @@ export function useBaseReactTable<D extends TableData>({
     [customFilterTypes]
   );
   const initialState: TableState<D> = React.useMemo(() => {
+    // default hidden columns
+    const hiddenColumns = columns
+      .filter(column => !column.defaultVisible)
+      .map(column => column.id ?? column.accessor);
     const state = _.defaultsDeep(cachedState, {
       pageSize: 25,
-      hiddenColumns: [],
-      ...defaultState
+      ...defaultState,
+      hiddenColumns
     });
     // ensure data-only columns are all invisible
-    const hiddenColumns = new Set(state.hiddenColumns);
+    const hiddenSet = new Set(state.hiddenColumns);
     for (const column of columns) {
       if (!column.defaultVisible && !column.mayToggle) {
-        hiddenColumns.add(column.id ?? column.accessor);
+        hiddenSet.add(column.id ?? column.accessor);
       }
     }
-    state.hiddenColumns = [...hiddenColumns];
+    state.hiddenColumns = [...hiddenSet];
     return state;
   }, [cachedState, columns, defaultState]);
 


### PR DESCRIPTION
### Motivation
The current common table logic that saves and loads previous user state for the tables has some custom logic to ensure that any newly added columns are hidden by default unless specified as `defaultVisible` or `mayToggle`. The problem is that it currently does this by simply appending the list of hidden columns to the end of the list in the state, which causes it to slowly grow over time.

This PR fixes the memory leak by using a `Set`.