### PR TITLE
bugfix archived data filter logic across tabs

### DIFF
--- a/src/window_main/DecksTab.tsx
+++ b/src/window_main/DecksTab.tsx
@@ -18,6 +18,7 @@ import Aggregator, {
 } from "./aggregator";
 import DecksTable from "./components/decks/DecksTable";
 import { DecksData } from "./components/decks/types";
+import { isHidingArchived } from "./components/tables/filters";
 import { useAggregatorAndSidePanel } from "./components/tables/hooks";
 import { openDeck } from "./deck-details";
 import mountReactComponent from "./mountReactComponent";
@@ -149,7 +150,7 @@ export function DecksTab({
   aggFiltersArg: AggregatorFilters;
 }): JSX.Element {
   const { decksTableMode, decksTableState } = pd.settings;
-  const showArchived = decksTableState?.filters?.archivedCol !== "hideArchived";
+  const showArchived = !isHidingArchived(decksTableState);
   const getDataAggFilters = (data: DecksData[]): AggregatorFilters => {
     const deckId = data.map(deck => deck.id).filter(id => id) as string[];
     return { deckId };

--- a/src/window_main/EventsTab.tsx
+++ b/src/window_main/EventsTab.tsx
@@ -14,6 +14,7 @@ import {
   EventTableData,
   SerializedEvent
 } from "./components/events/types";
+import { isHidingArchived } from "./components/tables/filters";
 import { useAggregatorAndSidePanel } from "./components/tables/hooks";
 import mountReactComponent from "./mountReactComponent";
 import {
@@ -185,8 +186,7 @@ export function EventsTab({
   aggFiltersArg: AggregatorFilters;
 }): JSX.Element {
   const { eventsTableMode, eventsTableState } = pd.settings;
-  const showArchived =
-    eventsTableState?.filters?.archivedCol !== "hideArchived";
+  const showArchived = !isHidingArchived(eventsTableState);
   const getDataAggFilters = (data: EventTableData[]): AggregatorFilters => {
     const matchIds = _.flatten(data.map(event => event.stats.matchIds));
     return { matchIds };

--- a/src/window_main/MatchesTab.tsx
+++ b/src/window_main/MatchesTab.tsx
@@ -10,6 +10,7 @@ import { getReadableEvent } from "../shared/util";
 import Aggregator, { AggregatorFilters } from "./aggregator";
 import MatchesTable from "./components/matches/MatchesTable";
 import { MatchTableData, SerializedMatch } from "./components/matches/types";
+import { isHidingArchived } from "./components/tables/filters";
 import { useAggregatorAndSidePanel } from "./components/tables/hooks";
 import { TagCounts } from "./components/tables/types";
 import { openMatch } from "./match-details";
@@ -283,8 +284,7 @@ export function MatchesTab({
   aggFiltersArg: AggregatorFilters;
 }): JSX.Element {
   const { matchesTableMode, matchesTableState } = pd.settings;
-  const showArchived =
-    matchesTableState?.filters?.archivedCol !== "hideArchived";
+  const showArchived = !isHidingArchived(matchesTableState);
   const getDataAggFilters = (data: MatchTableData[]): AggregatorFilters => {
     const matchIds = data.map(match => match.id);
     return { matchIds };

--- a/src/window_main/components/decks/DecksTable.tsx
+++ b/src/window_main/components/decks/DecksTable.tsx
@@ -18,7 +18,7 @@ import {
   NumberRangeColumnFilter,
   TextBoxFilter
 } from "../tables/filters";
-import { useBaseReactTable } from "../tables/hooks";
+import { useAggregatorArchiveFilter, useBaseReactTable } from "../tables/hooks";
 import PagingControls from "../tables/PagingControls";
 import TableHeaders from "../tables/TableHeaders";
 import { TableViewRow } from "../tables/TableViewRow";
@@ -296,6 +296,7 @@ export default function DecksTable({
     pagingProps,
     tableControlsProps
   } = useBaseReactTable(tableProps);
+  useAggregatorArchiveFilter(table, aggFilters, setAggFiltersCallback);
   const { getTableBodyProps, page, prepareRow } = table;
   const decksTableControlsProps: DecksTableControlsProps = {
     aggFilters,

--- a/src/window_main/components/events/EventsTable.tsx
+++ b/src/window_main/components/events/EventsTable.tsx
@@ -18,8 +18,9 @@ import {
   NumberRangeColumnFilter,
   TextBoxFilter
 } from "../tables/filters";
-import { useBaseReactTable } from "../tables/hooks";
+import { useAggregatorArchiveFilter, useBaseReactTable } from "../tables/hooks";
 import PagingControls from "../tables/PagingControls";
+import TableHeaders from "../tables/TableHeaders";
 import { TableViewRow } from "../tables/TableViewRow";
 import { BaseTableProps } from "../tables/types";
 import EventsListViewRow from "./EventsListViewRow";
@@ -30,7 +31,6 @@ import {
   EventsTableProps,
   EventTableData
 } from "./types";
-import TableHeaders from "../tables/TableHeaders";
 
 const columns: Column<EventTableData>[] = [
   { accessor: "id" },
@@ -210,6 +210,7 @@ export default function EventsTable({
     pagingProps,
     tableControlsProps
   } = useBaseReactTable(tableProps);
+  useAggregatorArchiveFilter(table, aggFilters, setAggFiltersCallback);
   const { getTableBodyProps, page, prepareRow } = table;
   const eventsTableControlsProps: EventsTableControlsProps = {
     aggFilters,

--- a/src/window_main/components/matches/MatchesTable.tsx
+++ b/src/window_main/components/matches/MatchesTable.tsx
@@ -18,7 +18,7 @@ import {
   NumberRangeColumnFilter,
   TextBoxFilter
 } from "../tables/filters";
-import { useBaseReactTable } from "../tables/hooks";
+import { useAggregatorArchiveFilter, useBaseReactTable } from "../tables/hooks";
 import PagingControls from "../tables/PagingControls";
 import TableHeaders from "../tables/TableHeaders";
 import { TableViewRow } from "../tables/TableViewRow";
@@ -324,6 +324,7 @@ export default function MatchesTable({
     pagingProps,
     tableControlsProps
   } = useBaseReactTable(tableProps);
+  useAggregatorArchiveFilter(table, aggFilters, setAggFiltersCallback);
   const { getTableBodyProps, page, prepareRow } = table;
   const matchesTableControlsProps: MatchesTableControlsProps = {
     aggFilters,

--- a/src/window_main/components/tables/filters.tsx
+++ b/src/window_main/components/tables/filters.tsx
@@ -1,18 +1,18 @@
 import _ from "lodash";
 import matchSorter from "match-sorter";
 import React from "react";
-import { ColumnInstance, FilterValue, Row } from "react-table";
+import { ColumnInstance, FilterValue, Row, TableState } from "react-table";
 import { COLORS_ALL, COLORS_BRIEF } from "../../../shared/constants";
 import { SerializedDeck } from "../../../shared/types/Deck";
 import ManaFilter, { ColorFilter, ManaFilterKeys } from "../../ManaFilter";
 import {
+  BinarySymbol,
   CheckboxContainer,
   InputContainer,
-  MetricText,
-  BinarySymbol
+  MetricText
 } from "../display";
-import { TableData, MultiSelectFilterProps } from "./types";
 import { useMultiSelectFilter } from "./hooks";
+import { MultiSelectFilterProps, TableData } from "./types";
 
 export function TextBoxFilter<D extends TableData>({
   column: { id, filterValue, preFilteredRows, setFilter }
@@ -283,4 +283,14 @@ export function archivedFilterFn<D extends TableData>(
     return rows.filter(row => !row.values.archived);
   }
   return rows;
+}
+
+export function isHidingArchived<D extends TableData>(
+  state?: Partial<TableState<D>>
+): boolean {
+  return (
+    state?.filters?.some(
+      filter => filter.id === "archivedCol" && filter.value === "hideArchived"
+    ) ?? false
+  );
 }


### PR DESCRIPTION
### Motivation
The archived data filters do not work exactly as expected for results data. (e.g. Decks may be correctly filtered to non-archived, but the deck statistics may show archived _matches_)
https://discordapp.com/channels/463844727654187020/467737642306371584/668915494841090098
![image](https://user-images.githubusercontent.com/14894693/73312544-ceb88b00-41dd-11ea-9f68-da348867aebb.png)

This PR fixes all similar problems by creating a new common hook to sync the `AggregatorFilters` with the table filters, and then uses the new hook on the 3 pages that depend on `Aggregator`.