### PR TITLE
Bugfix remember previous scroll position

### DIFF
--- a/src/window_main/DecksTab.tsx
+++ b/src/window_main/DecksTab.tsx
@@ -18,7 +18,10 @@ import Aggregator, {
 } from "./aggregator";
 import DecksTable from "./components/decks/DecksTable";
 import { DecksData } from "./components/decks/types";
-import { useAggregatorAndSidePanel } from "./components/tables/hooks";
+import {
+  useAggregatorAndSidePanel,
+  useLastScrollTop
+} from "./components/tables/hooks";
 import { openDeck } from "./deck-details";
 import mountReactComponent from "./mountReactComponent";
 import {
@@ -173,10 +176,11 @@ export function DecksTab({
     [aggFilters]
   );
   const events = React.useMemo(getTotalAggEvents, []);
+  const [containerRef, onScroll] = useLastScrollTop();
 
   return (
     <>
-      <div className={"wrapper_column"}>
+      <div className={"wrapper_column"} ref={containerRef} onScroll={onScroll}>
         <DecksTable
           data={data}
           aggFilters={aggFilters}

--- a/src/window_main/EventsTab.tsx
+++ b/src/window_main/EventsTab.tsx
@@ -14,7 +14,10 @@ import {
   EventTableData,
   SerializedEvent
 } from "./components/events/types";
-import { useAggregatorAndSidePanel } from "./components/tables/hooks";
+import {
+  useAggregatorAndSidePanel,
+  useLastScrollTop
+} from "./components/tables/hooks";
 import mountReactComponent from "./mountReactComponent";
 import {
   hideLoadingBars,
@@ -206,10 +209,11 @@ export function EventsTab({
     updateSidebarCallback: updateStatsPanel
   });
   const events = React.useMemo(getTotalAggEvents, []);
+  const [containerRef, onScroll] = useLastScrollTop();
 
   return (
     <>
-      <div className={"wrapper_column"}>
+      <div className={"wrapper_column"} ref={containerRef} onScroll={onScroll}>
         <EventsTable
           data={data}
           aggFilters={aggFilters}

--- a/src/window_main/MatchesTab.tsx
+++ b/src/window_main/MatchesTab.tsx
@@ -10,7 +10,10 @@ import { getReadableEvent } from "../shared/util";
 import Aggregator, { AggregatorFilters } from "./aggregator";
 import MatchesTable from "./components/matches/MatchesTable";
 import { MatchTableData, SerializedMatch } from "./components/matches/types";
-import { useAggregatorAndSidePanel } from "./components/tables/hooks";
+import {
+  useAggregatorAndSidePanel,
+  useLastScrollTop
+} from "./components/tables/hooks";
 import { TagCounts } from "./components/tables/types";
 import { openMatch } from "./match-details";
 import mountReactComponent from "./mountReactComponent";
@@ -304,10 +307,11 @@ export function MatchesTab({
     updateSidebarCallback: updateStatsPanel
   });
   const [events, tags] = React.useMemo(getTotalAggData, []);
+  const [containerRef, onScroll] = useLastScrollTop();
 
   return (
     <>
-      <div className={"wrapper_column"}>
+      <div className={"wrapper_column"} ref={containerRef} onScroll={onScroll}>
         <MatchesTable
           data={data}
           aggFilters={aggFilters}

--- a/src/window_main/components/economy/EconomyTable.tsx
+++ b/src/window_main/components/economy/EconomyTable.tsx
@@ -18,7 +18,7 @@ import {
   NumberRangeColumnFilter,
   TextBoxFilter
 } from "../tables/filters";
-import { useBaseReactTable } from "../tables/hooks";
+import { useBaseReactTable, useLastScrollTop } from "../tables/hooks";
 import PagingControls from "../tables/PagingControls";
 import TableHeaders from "../tables/TableHeaders";
 import { BaseTableProps } from "../tables/types";
@@ -335,8 +335,9 @@ export default function EconomyTable({
     ...tableControlsProps
   };
   const isTableMode = tableMode === EVENTS_TABLE_MODE;
+  const [containerRef, onScroll] = useLastScrollTop();
   return (
-    <div className="react_table_wrap">
+    <div className="react_table_wrap" ref={containerRef} onScroll={onScroll}>
       <EconomyTableControls {...economyTableControlsProps} />
       <div
         className="med_scroll"

--- a/src/window_main/components/tables/hooks.ts
+++ b/src/window_main/components/tables/hooks.ts
@@ -11,6 +11,7 @@ import {
 } from "react-table";
 import pd from "../../../shared/player-data";
 import Aggregator, { AggregatorFilters } from "../../aggregator";
+import { getLocalState, setLocalState } from "../../renderer-util";
 import {
   archivedFilterFn,
   colorsFilterFn,
@@ -61,6 +62,27 @@ export function useLegacyRenderer(
     }
   }, [containerRef, renderEventRow, rendererArgs]);
   return containerRef;
+}
+
+export function useLastScrollTop(): [
+  React.RefObject<HTMLDivElement>,
+  () => void
+] {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  React.useEffect(() => {
+    if (containerRef?.current) {
+      const { lastScrollTop } = getLocalState();
+      if (lastScrollTop) {
+        containerRef.current.scrollTop = lastScrollTop;
+      }
+    }
+  }, [containerRef]);
+  const onScroll = React.useCallback(() => {
+    if (containerRef?.current) {
+      setLocalState({ lastScrollTop: containerRef.current.scrollTop });
+    }
+  }, []);
+  return [containerRef, onScroll];
 }
 
 export function useAggregatorAndSidePanel<D extends TableData>({


### PR DESCRIPTION
### Motivation
In our legacy code (still includes the Explore page), we used `DataScroller` and `lastScrollTop` in `localState` to remember the user's current scroll position. If they chose to edit a row (add tag, delete tag, archive, etc), the round-trip to the background process would trigger a screen "refresh". At that point, `DataScroller` handled automatically restoring the user to their previous scroll position.

In the post-react-table world, we still have to do a round-trip in some cases, but we no longer have `DataScroller`. Hence this regression:
https://discordapp.com/channels/463844727654187020/467737642306371584/671912594558287872
![image](https://user-images.githubusercontent.com/14894693/73338701-077f5100-422c-11ea-9daa-8fc3f86780d8.png)
^ this problem is broader than described here; it also affects the Decks page, Events page, and Economy page; it also affects archiving actions.

### Approach
This PR creates a new common hook that imitates the old approach in `DataScroller`, then adds the hook to the new react-table pages.
