### PR TITLE
Misc table tweaks

### DIFF
--- a/src/window_main/DecksTab.tsx
+++ b/src/window_main/DecksTab.tsx
@@ -33,7 +33,7 @@ function openDeckDetails(
   id: string | number,
   filters: AggregatorFilters
 ): void {
-  const deck = pd.deck(id);
+  const deck = pd.deck(id + "");
   if (!deck) return;
   openDeck(deck, { ...filters, deckId: id });
   anime({
@@ -102,6 +102,7 @@ function getDecksData(aggregator: Aggregator): DecksData[] {
   return pd.deckList.map(
     (deck: SerializedDeck): DecksData => {
       const id = deck.id ?? "";
+      const name = (deck.name ?? "").replace("?=?Loc/Decks/Precon/", "");
       const archivedSortVal = deck.archived ? 1 : deck.custom ? 0.5 : 0;
       const colorSortVal = deck.colors?.join("") ?? "";
       // compute winrate metrics
@@ -119,6 +120,7 @@ function getDecksData(aggregator: Aggregator): DecksData[] {
       const lastTouched = dateMaxValid(lastUpdated, lastPlayed);
       return {
         ...deck,
+        name,
         format: getReadableFormat(deck.format),
         ...deckStats,
         winrate100,

--- a/src/window_main/MatchesTab.tsx
+++ b/src/window_main/MatchesTab.tsx
@@ -39,7 +39,7 @@ function openMatchDetails(id: string | number): void {
 
 function addTag(matchid: string, tag: string): void {
   const match = pd.match(matchid);
-  if ([tagPrompt, NO_ARCH, DEFAULT_ARCH].includes(tag)) return;
+  if (!match || [tagPrompt, NO_ARCH].includes(tag)) return;
   if (match.tags?.includes(tag)) return;
   ipcSend("add_matches_tag", { matchid, tag });
 }
@@ -50,7 +50,7 @@ function editTag(tag: string, color: string): void {
 
 function deleteTag(matchid: string, tag: string): void {
   const match = pd.match(matchid);
-  if (!match.tags?.includes(tag)) return;
+  if (!match || !match.tags?.includes(tag)) return;
   ipcSend("delete_matches_tag", { matchid, tag });
 }
 
@@ -224,6 +224,8 @@ function getMatchesData(aggregator: Aggregator): MatchTableData[] {
         const timestamp = new Date(match.date ?? NaN);
         const colors = match.playerDeck.colors ?? [];
         const oppColors = match.oppDeck.colors ?? [];
+        const oppArenaId = match.opponent.name ?? "-#000000";
+        const oppName = oppArenaId.slice(0, -6);
         return {
           ...match,
           archivedSortVal: match.archived ? 1 : 0,
@@ -242,7 +244,8 @@ function getMatchesData(aggregator: Aggregator): MatchTableData[] {
           oppColors,
           oppColorSortVal: oppColors.join(""),
           oppLeaderboardPlace: match.opponent.leaderboardPlace,
-          oppName: match.opponent.name ?? "",
+          oppArenaId,
+          oppName,
           oppPercentile: match.opponent.percentile
             ? match.opponent.percentile / 100
             : undefined,

--- a/src/window_main/collection/CollectionTab.tsx
+++ b/src/window_main/collection/CollectionTab.tsx
@@ -67,7 +67,7 @@ function getExportString(cardIds: string[]): string {
       const code = db.sets[card.set]?.code ?? "???";
       add = add
         .replace("$Name", '"' + name + '"')
-        .replace("$Count", count)
+        .replace("$Count", count + "")
         .replace("$SetName", card.set)
         .replace("$SetCode", code)
         .replace("$Collector", card.cid)

--- a/src/window_main/components/collection/types.ts
+++ b/src/window_main/components/collection/types.ts
@@ -12,7 +12,7 @@ export interface CardsData extends DbCardData {
 }
 
 export interface CollectionTableProps {
-  cachedState: TableState<CardsData>;
+  cachedState?: TableState<CardsData>;
   cachedTableMode: string;
   cardHoverCallback: (cardDiv: HTMLElement, card: DbCardData) => void;
   contextMenuCallback: (cardDiv: HTMLElement, card: DbCardData) => void;

--- a/src/window_main/components/decks/DecksArtViewRow.tsx
+++ b/src/window_main/components/decks/DecksArtViewRow.tsx
@@ -3,7 +3,6 @@ import { Cell } from "react-table";
 import { CSSTransition } from "react-transition-group";
 import { getCardArtCrop } from "../../../shared/util";
 import { ArtTile, MetricText } from "../display";
-import { TableViewRowProps } from "../tables/types";
 import { DecksData, DecksTableRowProps } from "./types";
 
 function DeckArt({ url }: { url: string }): JSX.Element {
@@ -43,8 +42,7 @@ function DecksArtViewCell({
 
 export default function DecksArtViewRow({
   row,
-  openDeckCallback,
-  ...otherProps
+  openDeckCallback
 }: DecksTableRowProps): JSX.Element {
   const deck = row.original;
   const parentId = deck.id ?? "";
@@ -58,9 +56,6 @@ export default function DecksArtViewRow({
   const mouseLeave = React.useCallback(() => {
     setHover(false);
   }, []);
-  const divProps = { ...otherProps };
-  delete divProps.index;
-  delete divProps.gridTemplateColumns;
   return (
     <div
       className={"decks_table_deck_tile"}
@@ -68,7 +63,6 @@ export default function DecksArtViewRow({
       title={"show deck details"}
       onMouseEnter={mouseEnter}
       onMouseLeave={mouseLeave}
-      {...divProps}
     >
       <CSSTransition classNames="deckTileHover" in={!!hover} timeout={200}>
         <DeckArt url={getCardArtCrop(row.values["deckTileId"])} />

--- a/src/window_main/components/decks/types.ts
+++ b/src/window_main/components/decks/types.ts
@@ -3,6 +3,7 @@ import { SerializedDeck } from "../../../shared/types/Deck";
 import { AggregatorFilters, AggregatorStats } from "../../aggregator";
 import {
   TableControlsProps,
+  TableData,
   TableViewRowProps,
   TagCounts
 } from "../tables/types";
@@ -17,7 +18,8 @@ export interface MissingWildcards {
 export interface DecksData
   extends SerializedDeck,
     AggregatorStats,
-    MissingWildcards {
+    MissingWildcards,
+    TableData {
   winrate100: number;
   archivedSortVal: number;
   avgDuration: number;
@@ -36,7 +38,7 @@ export interface DecksTableProps {
   addTagCallback: (id: string, tag: string) => void;
   archiveCallback: (id: string | number) => void;
   aggFilters: AggregatorFilters;
-  cachedState: TableState<DecksData>;
+  cachedState?: TableState<DecksData>;
   cachedTableMode: string;
   data: DecksData[];
   events: string[];

--- a/src/window_main/components/display.tsx
+++ b/src/window_main/components/display.tsx
@@ -55,21 +55,46 @@ export const ArtTile = styled(ArtTileHeader)`
   }
 `;
 
-export const FlexLeftContainer = styled.div`
+export const FlexContainer = styled.div`
   display: flex;
-  justify-content: left;
+  align-items: center;
   div {
+    margin: auto 4px;
+  }
+`;
+
+export const FlexLeftContainer = styled(FlexContainer)`
+  justify-content: flex-start;
+  margin-right: auto;
+  div {
+    :first-child:not(.deck_tag_close) {
+      margin-left: 0;
+    }
     :last-child:not(.deck_tag_close) {
       margin-right: auto;
     }
   }
 `;
 
-export const FlexRightContainer = styled.div`
-  display: flex;
-  justify-content: right;
+export const FlexCenterContainer = styled(FlexContainer)`
+  justify-content: center;
+  margin-left: auto;
+  margin-right: auto;
   div {
-    :first-child {
+    :first-child:not(.deck_tag_close) {
+      margin-left: auto;
+    }
+    :last-child:not(.deck_tag_close) {
+      margin-right: auto;
+    }
+  }
+`;
+
+export const FlexRightContainer = styled(FlexContainer)`
+  justify-content: flex-end;
+  margin-left: auto;
+  div {
+    :first-child:not(.deck_tag_close) {
       margin-left: auto;
     }
   }
@@ -79,21 +104,29 @@ export const LabelText = styled.div`
   display: inline-block;
   text-align: left;
   white-space: nowrap;
+  color: var(--color-light);
 `;
+
+export interface BriefTextProps extends React.HTMLAttributes<HTMLDivElement> {
+  value?: string;
+  maxLength?: number;
+}
 
 export function BriefText({
   value,
-  maxLength
-}: {
-  value?: string;
-  maxLength?: number;
-}): JSX.Element {
+  maxLength,
+  ...otherProps
+}: BriefTextProps): JSX.Element {
   let displayName = value ?? "";
   const cutoff = maxLength ?? 25;
   if (displayName.length > cutoff) {
     displayName = displayName.slice(0, cutoff - 3) + "...";
   }
-  return <LabelText title={value}>{displayName}</LabelText>;
+  return (
+    <LabelText title={value} {...otherProps}>
+      {displayName}
+    </LabelText>
+  );
 }
 
 export const MetricText = styled.div`

--- a/src/window_main/components/economy/EconomyHeader.tsx
+++ b/src/window_main/components/economy/EconomyHeader.tsx
@@ -23,7 +23,7 @@ export function EconomyHeader(): JSX.Element {
       <EconomyValueRecord
         title={"Boosters"}
         iconClassName={"economy_wc_med wc_booster economyIconMargin"}
-        deltaContent={total}
+        deltaContent={formatNumber(total)}
       />
       <EconomyValueRecord
         title={"Vault"}
@@ -68,7 +68,7 @@ export function EconomyHeader(): JSX.Element {
       <EconomyValueRecord
         title={"Experience"}
         iconClassName={"economy_exp economyIconMargin"}
-        deltaContent={pd.economy.currentExp || 0}
+        deltaContent={formatNumber(pd.economy.currentExp || 0)}
       />
     </>
   );

--- a/src/window_main/components/economy/types.ts
+++ b/src/window_main/components/economy/types.ts
@@ -62,7 +62,7 @@ export interface TransactionData extends SerializedTransaction {
 
 export interface EconomyTableProps {
   archiveCallback: (id: string) => void;
-  cachedState: TableState<TransactionData>;
+  cachedState?: TableState<TransactionData>;
   cachedTableMode: string;
   data: TransactionData[];
   tableModeCallback: (tableMode: string) => void;

--- a/src/window_main/components/events/EventsTable.tsx
+++ b/src/window_main/components/events/EventsTable.tsx
@@ -10,6 +10,7 @@ import {
   MetricCell,
   RelativeTimeCell,
   ShortTextCell,
+  SubTextCell,
   TextCell
 } from "../tables/cells";
 import {
@@ -20,6 +21,7 @@ import {
 } from "../tables/filters";
 import { useBaseReactTable } from "../tables/hooks";
 import PagingControls from "../tables/PagingControls";
+import TableHeaders from "../tables/TableHeaders";
 import { TableViewRow } from "../tables/TableViewRow";
 import { BaseTableProps } from "../tables/types";
 import EventsListViewRow from "./EventsListViewRow";
@@ -30,7 +32,6 @@ import {
   EventsTableProps,
   EventTableData
 } from "./types";
-import TableHeaders from "../tables/TableHeaders";
 
 const columns: Column<EventTableData>[] = [
   { accessor: "id" },
@@ -49,8 +50,8 @@ const columns: Column<EventTableData>[] = [
     disableFilters: false,
     filter: "fuzzyText",
     Filter: TextBoxFilter,
-    Cell: ShortTextCell,
-    gridWidth: "200px",
+    Cell: SubTextCell,
+    gridWidth: "210px",
     mayToggle: true
   },
   {
@@ -60,7 +61,7 @@ const columns: Column<EventTableData>[] = [
     filter: "fuzzyText",
     Filter: TextBoxFilter,
     Cell: ShortTextCell,
-    gridWidth: "200px",
+    gridWidth: "210px",
     mayToggle: true,
     defaultVisible: true
   },
@@ -82,8 +83,8 @@ const columns: Column<EventTableData>[] = [
     disableFilters: false,
     filter: "fuzzyText",
     Filter: TextBoxFilter,
-    Cell: ShortTextCell,
-    gridWidth: "200px",
+    Cell: SubTextCell,
+    gridWidth: "210px",
     mayToggle: true,
     defaultVisible: true
   },

--- a/src/window_main/components/events/types.ts
+++ b/src/window_main/components/events/types.ts
@@ -60,7 +60,7 @@ export interface EventTableData extends TableData, SerializedEvent, EventStats {
 export interface EventsTableProps {
   archiveCallback: (id: string | number) => void;
   aggFilters: AggregatorFilters;
-  cachedState: TableState<EventTableData>;
+  cachedState?: TableState<EventTableData>;
   cachedTableMode: string;
   data: EventTableData[];
   editTagCallback: (tag: string, color: string) => void;

--- a/src/window_main/components/matches/MatchesTable.tsx
+++ b/src/window_main/components/matches/MatchesTable.tsx
@@ -10,7 +10,8 @@ import {
   MetricCell,
   PercentCell,
   RelativeTimeCell,
-  ShortTextCell
+  ShortTextCell,
+  SubTextCell
 } from "../tables/cells";
 import {
   ArchiveColumnFilter,
@@ -68,8 +69,8 @@ const columns: Column<MatchTableData>[] = [
     disableFilters: false,
     filter: "fuzzyText",
     Filter: TextBoxFilter,
-    Cell: ShortTextCell,
-    gridWidth: "200px",
+    Cell: SubTextCell,
+    gridWidth: "210px",
     mayToggle: true,
     defaultVisible: true
   },
@@ -141,7 +142,7 @@ const columns: Column<MatchTableData>[] = [
     filter: "fuzzyText",
     Filter: TextBoxFilter,
     Cell: ShortTextCell,
-    gridWidth: "200px",
+    gridWidth: "210px",
     mayToggle: true,
     defaultVisible: true
   },
@@ -165,9 +166,19 @@ const columns: Column<MatchTableData>[] = [
     filter: "fuzzyText",
     Filter: TextBoxFilter,
     Cell: ShortTextCell,
-    gridWidth: "200px",
+    gridWidth: "210px",
     mayToggle: true,
     defaultVisible: true
+  },
+  {
+    Header: "Op. ID",
+    accessor: "oppArenaId",
+    disableFilters: false,
+    filter: "fuzzyText",
+    Filter: TextBoxFilter,
+    Cell: SubTextCell,
+    gridWidth: "210px",
+    mayToggle: true
   },
   {
     Header: "Op. Rank",
@@ -226,7 +237,7 @@ const columns: Column<MatchTableData>[] = [
     filter: "fuzzyText",
     disableSortBy: true,
     Cell: ArchetypeCell,
-    gridWidth: "200px",
+    gridWidth: "210px",
     mayToggle: true,
     defaultVisible: true
   },

--- a/src/window_main/components/matches/cells.tsx
+++ b/src/window_main/components/matches/cells.tsx
@@ -1,6 +1,11 @@
 import React from "react";
 import { Cell } from "react-table";
-import { BinarySymbol, FlexLeftContainer, RankSymbol } from "../display";
+import {
+  BinarySymbol,
+  BriefText,
+  FlexLeftContainer,
+  RankSymbol
+} from "../display";
 import { TagsCell } from "../tables/cells";
 import { TagCounts } from "../tables/types";
 import { MatchTableData } from "./types";
@@ -38,7 +43,10 @@ export function RankCell({
   return (
     <FlexLeftContainer>
       <RankSymbol rank={cell.value} />
-      {cell.value}
+      <BriefText
+        value={cell.value}
+        style={{ fontFamily: "var(--main-font-name-it)", opacity: 0.5 }}
+      />
     </FlexLeftContainer>
   );
 }

--- a/src/window_main/components/matches/types.ts
+++ b/src/window_main/components/matches/types.ts
@@ -27,6 +27,7 @@ export interface MatchTableData extends SerializedMatch, TableData {
   isOnPlay: boolean;
   leaderboardPlace?: number;
   losses: number;
+  oppArenaId: string;
   oppArchetype: string;
   oppColors: number[];
   oppColorSortVal: string;
@@ -47,7 +48,7 @@ export interface MatchesTableProps {
   addTagCallback: (id: string, tag: string) => void;
   aggFilters: AggregatorFilters;
   archiveCallback: (id: string | number) => void;
-  cachedState: TableState<MatchTableData>;
+  cachedState?: TableState<MatchTableData>;
   cachedTableMode: string;
   data: MatchTableData[];
   deleteTagCallback: (id: string, tag: string) => void;

--- a/src/window_main/components/tables/cells.tsx
+++ b/src/window_main/components/tables/cells.tsx
@@ -37,8 +37,7 @@ export function ColorsCell<D extends TableData>({
 export function ShortTextCell<D extends TableData>({
   cell
 }: CellProps<D>): JSX.Element {
-  const displayName = (cell.value ?? "").replace("?=?Loc/Decks/Precon/", "");
-  return <BriefText value={displayName} />;
+  return <BriefText value={cell.value} />;
 }
 
 export function TextCell<D extends TableData>({
@@ -47,6 +46,17 @@ export function TextCell<D extends TableData>({
   return <BriefText value={cell.value} maxLength={50} />;
 }
 
+export function SubTextCell<D extends TableData>({
+  cell
+}: CellProps<D>): JSX.Element {
+  return (
+    <BriefText
+      value={cell.value}
+      maxLength={50}
+      style={{ fontFamily: "var(--main-font-name-it)", opacity: 0.5 }}
+    />
+  );
+}
 export function MetricCell<D extends TableData>({
   cell
 }: CellProps<D>): JSX.Element {

--- a/src/window_main/components/tables/hooks.ts
+++ b/src/window_main/components/tables/hooks.ts
@@ -170,8 +170,12 @@ export function useBaseReactTable<D extends TableData>({
     const hiddenColumns = columns
       .filter(column => !column.defaultVisible)
       .map(column => column.id ?? column.accessor);
-    const state =
-      cachedState ?? _.defaults(defaultState, { pageSize: 25, hiddenColumns });
+    const mergedDefault = _.defaults(defaultState, {
+      pageSize: 25,
+      hiddenColumns
+    }) as TableState<D>;
+    const state = cachedState ?? mergedDefault;
+
     // ensure data-only columns are all invisible
     const hiddenSet = new Set(state.hiddenColumns ?? []);
     for (const column of columns) {

--- a/src/window_main/components/tables/types.ts
+++ b/src/window_main/components/tables/types.ts
@@ -27,7 +27,7 @@ export interface MultiSelectFilterProps<D> {
 }
 
 export interface BaseTableProps<D extends TableData> {
-  cachedState: TableState<D>;
+  cachedState?: TableState<D>;
   columns: Column<D>[];
   customDefaultColumn?: Partial<Column<D>>;
   customFilterTypes?: { [key: string]: any };


### PR DESCRIPTION
This PR has a handful of low-risk tweaks to the table displays and types that were originally part of #860:
- cleans up some random code cruft
- breaks apart opponent Arena ID and name on matches page
- adds a new `SubTextCell` (italic) and uses it for some columns to match list items
- slightly more precise types