### PR TITLE
bugfix restore lands to collection page

### DIFF
--- a/src/window_main/collection/CollectionTab.tsx
+++ b/src/window_main/collection/CollectionTab.tsx
@@ -104,7 +104,7 @@ function getCollectionData(): CardsData[] {
       });
     });
   return db.cardList
-    .filter(card => card.collectible && card.rarity !== "land")
+    .filter(card => card.collectible)
     .map(
       (card): CardsData => {
         const owned = pd.cards.cards[card.id] ?? 0;


### PR DESCRIPTION
This PR restores the land cards to the collection page, which I had accidentally filtered out when I combined the various views together.