### PR TITLE
[feature] draft set-completion estimation stats

### DIFF
--- a/src/window_main/collection/CollectionTab.tsx
+++ b/src/window_main/collection/CollectionTab.tsx
@@ -92,9 +92,12 @@ function isBoosterMathValid(filters: Filters<CardsData>): boolean {
   for (const filter of filters) {
     if (filter.id === "booster") {
       hasCorrectBoosterFilter = filter.value?.true && !filter.value?.false;
-    }
-    if (filter.id === "rarity") {
+    } else if (filter.id === "rarity") {
       hasCorrectRarityFilter = filter.value?.mythic && filter.value?.rare;
+    } else if (filter.id === "set") {
+      continue; // this is fine
+    } else {
+      return false; // no other filters allowed
     }
   }
   return hasCorrectBoosterFilter && hasCorrectRarityFilter;

--- a/src/window_main/collection/CollectionTab.tsx
+++ b/src/window_main/collection/CollectionTab.tsx
@@ -20,7 +20,8 @@ import {
   hideLoadingBars,
   ipcSend,
   makeResizable,
-  resetMainContainer
+  resetMainContainer,
+  setLocalState
 } from "../renderer-util";
 import {
   CollectionStats,
@@ -91,6 +92,7 @@ function saveTableState(collectionTableState: TableState<CardsData>): void {
 
 function saveTableMode(collectionTableMode: string): void {
   ipcSend("save_user_settings", { collectionTableMode, skipRefresh: true });
+  setLocalState({ collectionTableMode });
 }
 
 function getCollectionData(): CardsData[] {

--- a/src/window_main/collection/collectionStats.ts
+++ b/src/window_main/collection/collectionStats.ts
@@ -1,16 +1,20 @@
 import Colors from "../../shared/colors";
 import { CARD_RARITIES } from "../../shared/constants";
 import db from "../../shared/database";
-import { createDiv } from "../../shared/dom-fns";
+import { createDiv, createLabel, createInput } from "../../shared/dom-fns";
 import pd from "../../shared/player-data";
 import { getMissingCardCounts } from "../../shared/util";
 import createSelect from "../createSelect";
 import { formatNumber } from "../renderer-util";
+import database from "../../shared/database";
 
 const ALL_CARDS = "All cards";
 const SINGLETONS = "Singletons (at least one)";
 const FULL_SETS = "Full sets (all 4 copies)";
 let countMode = ALL_CARDS;
+let rareDraftFactor = 3;
+let mythicDraftFactor = 0.14;
+let boosterWinFactor = 1.2;
 
 class CountStats {
   public owned: number;
@@ -55,6 +59,9 @@ export class SetStats {
   public uncommon: CountStats;
   public rare: CountStats;
   public mythic: CountStats;
+  public boosters: number;
+  public boosterRares: number;
+  public boosterMythics: number;
 
   constructor(set: string) {
     this.set = set;
@@ -63,6 +70,9 @@ export class SetStats {
     this.uncommon = new CountStats();
     this.rare = new CountStats();
     this.mythic = new CountStats();
+    this.boosters = 0;
+    this.boosterRares = 0;
+    this.boosterMythics = 0;
   }
 
   get all(): CountStats {
@@ -94,6 +104,17 @@ export interface CollectionStats {
   [set: string]: SetStats;
 }
 
+const chanceBoosterHasMythic = 0.125; // assume 1/8 of packs have a mythic
+const chanceBoosterHasRare = 1 - chanceBoosterHasMythic;
+const chanceNotWildCard = 11 / 12; // TODO this is wrong, should be 23/24
+export function estimateBoosterRares(boosterCount: number): number {
+  return boosterCount * chanceBoosterHasRare * chanceNotWildCard;
+}
+export function estimateBoosterMythics(boosterCount: number): number {
+  return boosterCount * chanceBoosterHasMythic * chanceNotWildCard;
+}
+const byId = (id: string): HTMLElement | null => document.getElementById(id);
+
 export function getCollectionStats(
   cardIds: (string | number)[]
 ): CollectionStats {
@@ -110,9 +131,22 @@ export function getCollectionStats(
   const stats: { [key: string]: SetStats } = {
     complete: new SetStats("complete")
   };
-  Object.keys(db.sets).forEach(
-    setName => (stats[setName] = new SetStats(setName))
-  );
+  Object.keys(db.sets).forEach(setName => {
+    const setStats = new SetStats(setName);
+    setStats.boosters = pd.economy.boosters
+      .filter(
+        ({ collationId }: { collationId: number }) =>
+          database.sets[setName]?.collation === collationId
+      )
+      .reduce(
+        (accumulator: number, booster: { count: number }) =>
+          accumulator + booster.count,
+        0
+      );
+    setStats.boosterRares = estimateBoosterRares(setStats.boosters);
+    setStats.boosterMythics = estimateBoosterMythics(setStats.boosters);
+    stats[setName] = setStats;
+  });
   cardIds.forEach(cardId => {
     const card = db.card(cardId);
     if (!card) return;
@@ -227,6 +261,14 @@ function renderCompletionDiv(
   return completionDiv;
 }
 
+function blurIfEnterKey(element: HTMLInputElement) {
+  return (e: KeyboardEvent): void => {
+    if (e.keyCode === 13) {
+      element.blur();
+    }
+  };
+}
+
 export function createInventoryStats(
   container: HTMLElement,
   setStats: SetStats,
@@ -250,11 +292,10 @@ export function createInventoryStats(
   const flex = createDiv(["flex_item"]);
   const mainstats = createDiv(["main_stats"]);
 
+  // Counting Mode Selector
   const completionLabel = document.createElement("label");
   completionLabel.innerHTML = "count:";
   mainstats.appendChild(completionLabel);
-
-  // Counting Mode Selector
   const countModeDiv = createDiv(["stats_count_div"]);
   const countModeSelect = createSelect(
     countModeDiv,
@@ -296,6 +337,79 @@ export function createInventoryStats(
     missing[rarity] = countStats.total - countStats.owned;
   });
 
+  const constantsLabel = createDiv(["deck_name"], "Draft Estimator:");
+  constantsLabel.style.width = "100%";
+  mainstats.appendChild(constantsLabel);
+
+  // Rares-per-draft Factor
+  const rareLabel = createLabel(["but_container_label"], "rares/draft:");
+  const rareInputCont = createDiv(["input_container"]);
+  const rareInput = createInput([], "", {
+    type: "text",
+    id: "collection_rares_per_draft",
+    autocomplete: "off",
+    placeholder: "3",
+    value: rareDraftFactor
+  });
+  rareInput.addEventListener("keyup", blurIfEnterKey(rareInput));
+  rareInput.addEventListener("focusout", () => {
+    const inputEl = byId("collection_rares_per_draft");
+    if (inputEl) {
+      const inputValue = (inputEl as HTMLInputElement).value;
+      rareDraftFactor = parseFloat(inputValue);
+      updateCallback();
+    }
+  });
+  rareInputCont.appendChild(rareInput);
+  rareLabel.appendChild(rareInputCont);
+  mainstats.appendChild(rareLabel);
+
+  // Mythics-per-draft Factor
+  const mythicLabel = createLabel(["but_container_label"], "mythics/draft:");
+  const mythicInputCont = createDiv(["input_container"]);
+  const mythicInput = createInput([], "", {
+    type: "text",
+    id: "collection_mythics_per_draft",
+    autocomplete: "off",
+    placeholder: "3",
+    value: mythicDraftFactor
+  });
+  mythicInput.addEventListener("keyup", blurIfEnterKey(mythicInput));
+  mythicInput.addEventListener("focusout", () => {
+    const inputEl = byId("collection_mythics_per_draft");
+    if (inputEl) {
+      const inputValue = (inputEl as HTMLInputElement).value;
+      mythicDraftFactor = parseFloat(inputValue);
+      updateCallback();
+    }
+  });
+  mythicInputCont.appendChild(mythicInput);
+  mythicLabel.appendChild(mythicInputCont);
+  mainstats.appendChild(mythicLabel);
+
+  // Boosters-per-draft Factor
+  const boosterLabel = createLabel(["but_container_label"], "boosters/draft:");
+  const boosterInputCont = createDiv(["input_container"]);
+  const boosterInput = createInput([], "", {
+    type: "text",
+    id: "collection_boosters_per_draft",
+    autocomplete: "off",
+    placeholder: "3",
+    value: boosterWinFactor
+  });
+  boosterInput.addEventListener("keyup", blurIfEnterKey(boosterInput));
+  boosterInput.addEventListener("focusout", () => {
+    const inputEl = byId("collection_boosters_per_draft");
+    if (inputEl) {
+      const inputValue = (inputEl as HTMLInputElement).value;
+      boosterWinFactor = parseFloat(inputValue);
+      updateCallback();
+    }
+  });
+  boosterInputCont.appendChild(boosterInput);
+  boosterLabel.appendChild(boosterInputCont);
+  mainstats.appendChild(boosterLabel);
+
   flex.appendChild(mainstats);
   container.appendChild(top);
   container.appendChild(flex);
@@ -322,51 +436,130 @@ export function createWantedStats(
   container: HTMLElement,
   setStats: SetStats
 ): void {
-  const chanceBoosterHasMythic = 0.125; // assume 1/8 of packs have a mythic
-  const chanceBoosterHasRare = 1 - chanceBoosterHasMythic;
-  const wantedText =
-    "<abbr title='missing copy of a card in a current deck'>wanted</abbr>";
+  const unownedUniqueRares =
+    setStats["rare"].unique - setStats["rare"].complete;
+  const unownedUniqueMythics =
+    setStats["mythic"].unique - setStats["mythic"].complete;
 
-  // chance that the next booster opened contains a rare missing from one of our decks
-  const possibleRares = setStats["rare"].unique - setStats["rare"].complete;
-  if (possibleRares && setStats["rare"].uniqueWanted) {
-    const chanceBoosterRareWanted = (
-      (chanceBoosterHasRare * setStats["rare"].uniqueWanted) /
-      possibleRares
-    ).toLocaleString([], {
-      style: "percent",
-      maximumSignificantDigits: 2
-    });
-    const rareWantedDiv = createDiv(["stats_set_completion"]);
-    const rareWantedIcon = createDiv(["stats_set_icon", "bo_explore_cost"]);
-    rareWantedIcon.style.height = "30px";
-    const rareWantedSpan = document.createElement("span");
-    rareWantedSpan.innerHTML = `<i>~${chanceBoosterRareWanted} chance next booster has ${wantedText} rare.</i>`;
-    rareWantedSpan.style.fontSize = "13px";
-    rareWantedIcon.appendChild(rareWantedSpan);
-    rareWantedDiv.appendChild(rareWantedIcon);
-    container.appendChild(rareWantedDiv);
+  if (unownedUniqueRares || unownedUniqueMythics) {
+    // estimate stockpiled unowned rares and mythics
+    if (setStats.boosters) {
+      const boostersDiv = createDiv(["stats_set_completion"]);
+      const boostersIcon = createDiv(["stats_set_icon", "bo_explore_cost"]);
+      boostersIcon.style.height = "30px";
+      const boostersSpan = document.createElement("span");
+      boostersSpan.innerHTML = `<i>${
+        setStats.boosters
+      } current boosters: ~${setStats.boosterRares.toFixed(
+        2
+      )} new rares, ~${setStats.boosterMythics.toFixed(2)} new mythics</i>`;
+      boostersSpan.style.fontSize = "13px";
+      boostersIcon.appendChild(boostersSpan);
+      boostersDiv.appendChild(boostersIcon);
+      container.appendChild(boostersDiv);
+    }
+
+    // estimate unowned rares and mythics in next draft pool (P1P1, P2P1, P3P1)
+    const newRares = (
+      (chanceBoosterHasRare * unownedUniqueRares * 3) /
+      setStats["rare"].unique
+    ).toFixed(2);
+    const newMythics = (
+      (chanceBoosterHasMythic * unownedUniqueMythics * 3) /
+      setStats["mythic"].unique
+    ).toFixed(2);
+    const draftNewDiv = createDiv(["stats_set_completion"]);
+    const draftNewIcon = createDiv(["stats_set_icon", "economy_ticket"]);
+    draftNewIcon.style.height = "30px";
+    const draftNewSpan = document.createElement("span");
+    draftNewSpan.innerHTML = `<i>next draft pool: ~${newRares} new rares, ~${newMythics} new mythics</i>`;
+    draftNewSpan.style.fontSize = "13px";
+    draftNewIcon.appendChild(draftNewSpan);
+    draftNewDiv.appendChild(draftNewIcon);
+    container.appendChild(draftNewDiv);
   }
 
-  // chance that the next booster opened contains a mythic missing from one of our decks
-  const possibleMythics =
-    setStats["mythic"].unique - setStats["mythic"].complete;
-  if (possibleMythics && setStats["mythic"].uniqueWanted) {
-    const chanceBoosterMythicWanted = (
-      (chanceBoosterHasMythic * setStats["mythic"].uniqueWanted) /
-      possibleMythics
+  if (setStats["rare"].uniqueWanted || setStats["mythic"].uniqueWanted) {
+    const wantedText =
+      "<abbr title='missing copy of a card in a current deck'>wanted</abbr>";
+
+    // chance that the next booster opened contains a wanted card
+    const chanceRareWanted = (
+      (chanceBoosterHasRare * setStats["rare"].uniqueWanted) /
+      unownedUniqueRares
     ).toLocaleString([], {
       style: "percent",
       maximumSignificantDigits: 2
     });
-    const mythicWantedDiv = createDiv(["stats_set_completion"]);
-    const mythicWantedIcon = createDiv(["stats_set_icon", "bo_explore_cost"]);
-    mythicWantedIcon.style.height = "30px";
-    const mythicWantedSpan = document.createElement("span");
-    mythicWantedSpan.innerHTML = `<i>~${chanceBoosterMythicWanted} chance next booster has ${wantedText} mythic.</i>`;
-    mythicWantedSpan.style.fontSize = "13px";
-    mythicWantedIcon.appendChild(mythicWantedSpan);
-    mythicWantedDiv.appendChild(mythicWantedIcon);
-    container.appendChild(mythicWantedDiv);
+    const chanceMythicWanted = (
+      (chanceBoosterHasMythic * setStats["mythic"].uniqueWanted) /
+      unownedUniqueMythics
+    ).toLocaleString([], {
+      style: "percent",
+      maximumSignificantDigits: 2
+    });
+    const wantedDiv = createDiv(["stats_set_completion"]);
+    const wantedIcon = createDiv(["stats_set_icon", "bo_explore_cost"]);
+    wantedIcon.style.height = "30px";
+    const wantedSpan = document.createElement("span");
+    wantedSpan.innerHTML = `<i>next booster: ~${chanceRareWanted} ${wantedText} rare, ~${chanceMythicWanted} ${wantedText} mythic</i>`;
+    wantedSpan.style.fontSize = "13px";
+    wantedIcon.appendChild(wantedSpan);
+    wantedDiv.appendChild(wantedIcon);
+    container.appendChild(wantedDiv);
+
+    // chance that the next draft pool (P1P1, P2P1, P3P1) contains a wanted card
+    const chanceBoosterRareWanted = (
+      (chanceBoosterHasRare * setStats["rare"].uniqueWanted * 3) /
+      setStats["rare"].unique
+    ).toLocaleString([], {
+      style: "percent",
+      maximumSignificantDigits: 2
+    });
+    const chanceBoosterMythicWanted = (
+      (chanceBoosterHasMythic * setStats["mythic"].uniqueWanted * 3) /
+      setStats["mythic"].unique
+    ).toLocaleString([], {
+      style: "percent",
+      maximumSignificantDigits: 2
+    });
+    const draftWantedDiv = createDiv(["stats_set_completion"]);
+    const draftWantedIcon = createDiv(["stats_set_icon", "economy_ticket"]);
+    draftWantedIcon.style.height = "30px";
+    const draftWantedSpan = document.createElement("span");
+    draftWantedSpan.innerHTML = `<i>next draft pool: ~${chanceBoosterRareWanted} ${wantedText} rare, ~${chanceBoosterMythicWanted} ${wantedText} mythic</i>`;
+    draftWantedSpan.style.fontSize = "13px";
+    draftWantedIcon.appendChild(draftWantedSpan);
+    draftWantedDiv.appendChild(draftWantedIcon);
+    container.appendChild(draftWantedDiv);
+  }
+
+  // estimate remaining drafts to collect entire set
+  // https://www.mtggoldfish.com/articles/collecting-mtg-arena-part-1-of-2
+  // D = (T - P*7/8*11/12 - R)/(N+W*7/8*11/12)
+  if (unownedUniqueRares || unownedUniqueMythics) {
+    const remainingRares =
+      setStats["rare"].total - setStats["rare"].owned - setStats.boosterRares;
+    const rareEstimate = Math.ceil(
+      remainingRares /
+        (rareDraftFactor + estimateBoosterRares(boosterWinFactor))
+    );
+    const remainingMythics =
+      setStats["mythic"].total -
+      setStats["mythic"].owned -
+      setStats.boosterMythics;
+    const mythicEstimate = Math.ceil(
+      remainingMythics /
+        (mythicDraftFactor + estimateBoosterMythics(boosterWinFactor))
+    );
+    const draftCompleteDiv = createDiv(["stats_set_completion"]);
+    const draftCompleteIcon = createDiv(["stats_set_icon", "icon_2"]);
+    draftCompleteIcon.style.height = "30px";
+    const draftCompleteSpan = document.createElement("span");
+    draftCompleteSpan.innerHTML = `<i>drafts to complete set: ~${rareEstimate} for rares, ~${mythicEstimate} for mythics</i>`;
+    draftCompleteSpan.style.fontSize = "13px";
+    draftCompleteIcon.appendChild(draftCompleteSpan);
+    draftCompleteDiv.appendChild(draftCompleteIcon);
+    container.appendChild(draftCompleteDiv);
   }
 }

--- a/src/window_main/collection/collectionStats.ts
+++ b/src/window_main/collection/collectionStats.ts
@@ -1,3 +1,4 @@
+import { shell } from "electron";
 import Colors from "../../shared/colors";
 import { CARD_RARITIES } from "../../shared/constants";
 import db from "../../shared/database";
@@ -106,7 +107,7 @@ export interface CollectionStats {
 
 const chanceBoosterHasMythic = 0.125; // assume 1/8 of packs have a mythic
 const chanceBoosterHasRare = 1 - chanceBoosterHasMythic;
-const chanceNotWildCard = 11 / 12; // TODO this is wrong, should be 23/24
+const chanceNotWildCard = 11 / 12; // assume (1/24 mythic + 1/24 rare) WC instead of card
 export function estimateBoosterRares(boosterCount: number): number {
   return boosterCount * chanceBoosterHasRare * chanceNotWildCard;
 }
@@ -337,7 +338,7 @@ export function createInventoryStats(
     missing[rarity] = countStats.total - countStats.owned;
   });
 
-  const constantsLabel = createDiv(["deck_name"], "Draft Estimator:");
+  const constantsLabel = createDiv(["deck_name"], "Draft Estimator*:");
   constantsLabel.style.width = "100%";
   mainstats.appendChild(constantsLabel);
 
@@ -409,6 +410,18 @@ export function createInventoryStats(
   boosterInputCont.appendChild(boosterInput);
   boosterLabel.appendChild(boosterInputCont);
   mainstats.appendChild(boosterLabel);
+
+  const creditLink = createDiv(
+    ["settings_note"],
+    "<i><a>*[original by caliban on mtggoldfish]</a></i>"
+  );
+  creditLink.style.opacity = "0.6";
+  creditLink.addEventListener("click", () =>
+    shell.openExternal(
+      "https://www.mtggoldfish.com/articles/collecting-mtg-arena-part-1-of-2"
+    )
+  );
+  mainstats.appendChild(creditLink);
 
   flex.appendChild(mainstats);
   container.appendChild(top);

--- a/src/window_main/collection/collectionStats.ts
+++ b/src/window_main/collection/collectionStats.ts
@@ -1,12 +1,13 @@
+/* eslint-disable @typescript-eslint/no-use-before-define */
 import { shell } from "electron";
 import Colors from "../../shared/colors";
-import { CARD_RARITIES } from "../../shared/constants";
+import { CARD_RARITIES, COLLECTION_SETS_MODE } from "../../shared/constants";
 import db from "../../shared/database";
 import { createDiv, createLabel, createInput } from "../../shared/dom-fns";
 import pd from "../../shared/player-data";
 import { getMissingCardCounts } from "../../shared/util";
 import createSelect from "../createSelect";
-import { formatNumber } from "../renderer-util";
+import { formatNumber, getLocalState } from "../renderer-util";
 import database from "../../shared/database";
 
 const ALL_CARDS = "All cards";
@@ -338,90 +339,96 @@ export function createInventoryStats(
     missing[rarity] = countStats.total - countStats.owned;
   });
 
-  const constantsLabel = createDiv(["deck_name"], "Draft Estimator*:");
-  constantsLabel.style.width = "100%";
-  mainstats.appendChild(constantsLabel);
+  const { collectionTableMode } = getLocalState();
+  if (collectionTableMode === COLLECTION_SETS_MODE) {
+    const constantsLabel = createDiv(["deck_name"], "Draft Estimator*:");
+    constantsLabel.style.width = "100%";
+    mainstats.appendChild(constantsLabel);
 
-  // Rares-per-draft Factor
-  const rareLabel = createLabel(["but_container_label"], "rares/draft:");
-  const rareInputCont = createDiv(["input_container"]);
-  const rareInput = createInput([], "", {
-    type: "text",
-    id: "collection_rares_per_draft",
-    autocomplete: "off",
-    placeholder: "3",
-    value: rareDraftFactor
-  });
-  rareInput.addEventListener("keyup", blurIfEnterKey(rareInput));
-  rareInput.addEventListener("focusout", () => {
-    const inputEl = byId("collection_rares_per_draft");
-    if (inputEl) {
-      const inputValue = (inputEl as HTMLInputElement).value;
-      rareDraftFactor = parseFloat(inputValue);
-      updateCallback();
-    }
-  });
-  rareInputCont.appendChild(rareInput);
-  rareLabel.appendChild(rareInputCont);
-  mainstats.appendChild(rareLabel);
+    // Rares-per-draft Factor
+    const rareLabel = createLabel(["but_container_label"], "rares/draft:");
+    const rareInputCont = createDiv(["input_container"]);
+    const rareInput = createInput([], "", {
+      type: "text",
+      id: "collection_rares_per_draft",
+      autocomplete: "off",
+      placeholder: "3",
+      value: rareDraftFactor
+    });
+    rareInput.addEventListener("keyup", blurIfEnterKey(rareInput));
+    rareInput.addEventListener("focusout", () => {
+      const inputEl = byId("collection_rares_per_draft");
+      if (inputEl) {
+        const inputValue = (inputEl as HTMLInputElement).value;
+        rareDraftFactor = parseFloat(inputValue);
+        updateCallback();
+      }
+    });
+    rareInputCont.appendChild(rareInput);
+    rareLabel.appendChild(rareInputCont);
+    mainstats.appendChild(rareLabel);
 
-  // Mythics-per-draft Factor
-  const mythicLabel = createLabel(["but_container_label"], "mythics/draft:");
-  const mythicInputCont = createDiv(["input_container"]);
-  const mythicInput = createInput([], "", {
-    type: "text",
-    id: "collection_mythics_per_draft",
-    autocomplete: "off",
-    placeholder: "3",
-    value: mythicDraftFactor
-  });
-  mythicInput.addEventListener("keyup", blurIfEnterKey(mythicInput));
-  mythicInput.addEventListener("focusout", () => {
-    const inputEl = byId("collection_mythics_per_draft");
-    if (inputEl) {
-      const inputValue = (inputEl as HTMLInputElement).value;
-      mythicDraftFactor = parseFloat(inputValue);
-      updateCallback();
-    }
-  });
-  mythicInputCont.appendChild(mythicInput);
-  mythicLabel.appendChild(mythicInputCont);
-  mainstats.appendChild(mythicLabel);
+    // Mythics-per-draft Factor
+    const mythicLabel = createLabel(["but_container_label"], "mythics/draft:");
+    const mythicInputCont = createDiv(["input_container"]);
+    const mythicInput = createInput([], "", {
+      type: "text",
+      id: "collection_mythics_per_draft",
+      autocomplete: "off",
+      placeholder: "3",
+      value: mythicDraftFactor
+    });
+    mythicInput.addEventListener("keyup", blurIfEnterKey(mythicInput));
+    mythicInput.addEventListener("focusout", () => {
+      const inputEl = byId("collection_mythics_per_draft");
+      if (inputEl) {
+        const inputValue = (inputEl as HTMLInputElement).value;
+        mythicDraftFactor = parseFloat(inputValue);
+        updateCallback();
+      }
+    });
+    mythicInputCont.appendChild(mythicInput);
+    mythicLabel.appendChild(mythicInputCont);
+    mainstats.appendChild(mythicLabel);
 
-  // Boosters-per-draft Factor
-  const boosterLabel = createLabel(["but_container_label"], "boosters/draft:");
-  const boosterInputCont = createDiv(["input_container"]);
-  const boosterInput = createInput([], "", {
-    type: "text",
-    id: "collection_boosters_per_draft",
-    autocomplete: "off",
-    placeholder: "3",
-    value: boosterWinFactor
-  });
-  boosterInput.addEventListener("keyup", blurIfEnterKey(boosterInput));
-  boosterInput.addEventListener("focusout", () => {
-    const inputEl = byId("collection_boosters_per_draft");
-    if (inputEl) {
-      const inputValue = (inputEl as HTMLInputElement).value;
-      boosterWinFactor = parseFloat(inputValue);
-      updateCallback();
-    }
-  });
-  boosterInputCont.appendChild(boosterInput);
-  boosterLabel.appendChild(boosterInputCont);
-  mainstats.appendChild(boosterLabel);
+    // Boosters-per-draft Factor
+    const boosterLabel = createLabel(
+      ["but_container_label"],
+      "boosters/draft:"
+    );
+    const boosterInputCont = createDiv(["input_container"]);
+    const boosterInput = createInput([], "", {
+      type: "text",
+      id: "collection_boosters_per_draft",
+      autocomplete: "off",
+      placeholder: "3",
+      value: boosterWinFactor
+    });
+    boosterInput.addEventListener("keyup", blurIfEnterKey(boosterInput));
+    boosterInput.addEventListener("focusout", () => {
+      const inputEl = byId("collection_boosters_per_draft");
+      if (inputEl) {
+        const inputValue = (inputEl as HTMLInputElement).value;
+        boosterWinFactor = parseFloat(inputValue);
+        updateCallback();
+      }
+    });
+    boosterInputCont.appendChild(boosterInput);
+    boosterLabel.appendChild(boosterInputCont);
+    mainstats.appendChild(boosterLabel);
 
-  const creditLink = createDiv(
-    ["settings_note"],
-    "<i><a>*[original by caliban on mtggoldfish]</a></i>"
-  );
-  creditLink.style.opacity = "0.6";
-  creditLink.addEventListener("click", () =>
-    shell.openExternal(
-      "https://www.mtggoldfish.com/articles/collecting-mtg-arena-part-1-of-2"
-    )
-  );
-  mainstats.appendChild(creditLink);
+    const creditLink = createDiv(
+      ["settings_note"],
+      "<i><a>*[original by caliban on mtggoldfish]</a></i>"
+    );
+    creditLink.style.opacity = "0.6";
+    creditLink.addEventListener("click", () =>
+      shell.openExternal(
+        "https://www.mtggoldfish.com/articles/collecting-mtg-arena-part-1-of-2"
+      )
+    );
+    mainstats.appendChild(creditLink);
+  }
 
   flex.appendChild(mainstats);
   container.appendChild(top);
@@ -569,7 +576,7 @@ export function createWantedStats(
     const draftCompleteIcon = createDiv(["stats_set_icon", "icon_2"]);
     draftCompleteIcon.style.height = "30px";
     const draftCompleteSpan = document.createElement("span");
-    draftCompleteSpan.innerHTML = `<i>drafts to complete set: ~${rareEstimate} for rares, ~${mythicEstimate} for mythics</i>`;
+    draftCompleteSpan.innerHTML = `<i>drafts to complete set*: ~${rareEstimate} for rares, ~${mythicEstimate} for mythics</i>`;
     draftCompleteSpan.style.fontSize = "13px";
     draftCompleteIcon.appendChild(draftCompleteSpan);
     draftCompleteDiv.appendChild(draftCompleteIcon);

--- a/src/window_main/components/collection/CollectionTableControls.tsx
+++ b/src/window_main/components/collection/CollectionTableControls.tsx
@@ -24,6 +24,10 @@ const ownedFilters = (): FilterValue[] => [
 const wantedFilters = (): FilterValue[] => [
   { id: "wanted", value: [1, undefined] }
 ];
+const draftFilters = (): FilterValue[] => [
+  { id: "set", value: standardSetsFilter },
+  { id: "booster", value: { true: true, false: false } }
+];
 
 const legacyModes = [COLLECTION_CHART_MODE, COLLECTION_SETS_MODE];
 
@@ -111,6 +115,24 @@ export default function CollectionTableControls(
           }}
         >
           Wanted
+        </SmallTextButton>
+        <SmallTextButton
+          onClick={(): void => {
+            setAllFilters(draftFilters);
+            setFiltersVisible({
+              ...initialFiltersVisible,
+              booster: true
+            });
+            toggleSortBy("grpId", true, false);
+            for (const column of toggleableColumns) {
+              toggleHideColumn(column.id, !column.defaultVisible);
+            }
+            toggleHideColumn("booster", false);
+            toggleHideColumn("cmc", true);
+            setTableMode(COLLECTION_SETS_MODE);
+          }}
+        >
+          Draft
         </SmallTextButton>
         <MediumTextButton
           onClick={(): void => setTogglesVisible(!togglesVisible)}

--- a/src/window_main/components/collection/CollectionTableControls.tsx
+++ b/src/window_main/components/collection/CollectionTableControls.tsx
@@ -13,6 +13,9 @@ import { GlobalFilter } from "../tables/filters";
 import PagingControls from "../tables/PagingControls";
 import { CollectionTableControlsProps } from "./types";
 
+const boostersFilters = (): FilterValue[] => [
+  { id: "booster", value: { true: true, false: false } }
+];
 const standardSetsFilter: FilterValue = {};
 db.standardSetCodes.forEach(code => (standardSetsFilter[code] = true));
 const standardFilters = (): FilterValue[] => [
@@ -23,10 +26,6 @@ const ownedFilters = (): FilterValue[] => [
 ];
 const wantedFilters = (): FilterValue[] => [
   { id: "wanted", value: [1, undefined] }
-];
-const draftFilters = (): FilterValue[] => [
-  { id: "set", value: standardSetsFilter },
-  { id: "booster", value: { true: true, false: false } }
 ];
 
 const legacyModes = [COLLECTION_CHART_MODE, COLLECTION_SETS_MODE];
@@ -69,6 +68,23 @@ export default function CollectionTableControls(
         <span style={{ paddingBottom: "8px", marginLeft: "12px" }}>
           Presets:
         </span>
+        <SmallTextButton
+          onClick={(): void => {
+            setAllFilters(boostersFilters);
+            setFiltersVisible({
+              ...initialFiltersVisible,
+              booster: true
+            });
+            toggleSortBy("grpId", true, false);
+            for (const column of toggleableColumns) {
+              toggleHideColumn(column.id, !column.defaultVisible);
+            }
+            toggleHideColumn("booster", false);
+            toggleHideColumn("cmc", true);
+          }}
+        >
+          Boosters
+        </SmallTextButton>
         <SmallTextButton
           onClick={(): void => {
             setAllFilters(standardFilters);
@@ -115,24 +131,6 @@ export default function CollectionTableControls(
           }}
         >
           Wanted
-        </SmallTextButton>
-        <SmallTextButton
-          onClick={(): void => {
-            setAllFilters(draftFilters);
-            setFiltersVisible({
-              ...initialFiltersVisible,
-              booster: true
-            });
-            toggleSortBy("grpId", true, false);
-            for (const column of toggleableColumns) {
-              toggleHideColumn(column.id, !column.defaultVisible);
-            }
-            toggleHideColumn("booster", false);
-            toggleHideColumn("cmc", true);
-            setTableMode(COLLECTION_SETS_MODE);
-          }}
-        >
-          Draft
         </SmallTextButton>
         <MediumTextButton
           onClick={(): void => setTogglesVisible(!togglesVisible)}

--- a/src/window_main/renderer-util.js
+++ b/src/window_main/renderer-util.js
@@ -62,6 +62,7 @@ const localState = {
   authToken: "",
   collectionTableMode: pd.settings.collectionTableMode,
   discordTag: null,
+  isBoosterMathValid: true,
   lastDataIndex: 0,
   lastScrollHandler: null,
   lastScrollTop: 0,

--- a/src/window_main/renderer-util.js
+++ b/src/window_main/renderer-util.js
@@ -60,6 +60,7 @@ let unmountPoints = [];
 // (for state shared across processes, use database or player-data)
 const localState = {
   authToken: "",
+  collectionTableMode: pd.settings.collectionTableMode,
   discordTag: null,
   lastDataIndex: 0,
   lastScrollHandler: null,


### PR DESCRIPTION
### Motivation
F2P and frugal players have frequently requested a metric to help them estimate "How many drafts will it take to get to the center of a Tootsie Pop?" The most popular approach so far was written up here: https://www.mtggoldfish.com/articles/collecting-mtg-arena-part-1-of-2 and has been exactly reproduced here: https://mtgahelper.com/draftsBeforeBoosters

As a quick rehash, I still think the currently accepted approach is wrong for these reasons:
  1. Major: ignores opportunity cost of hoarding boosters (assumes user does not play constructred events)
  2. Major: ignores law of diminishing marginal returns (draft estimation numbers are bad ceilings)
  3. ~~Minor: gets the probability of wildcard upgrade incorrect (uses 11/12 instead of 23/24)~~

Nevertheless, I want to build that approach exactly as a first iteration, then improve upon it after we can validate the numbers

### Initial Demo
![image](https://user-images.githubusercontent.com/14894693/73616337-ee2d2a80-45c6-11ea-82f9-99b02c55fe87.png)
