### PR TITLE
support wed brawl weekly events

### DIFF
--- a/src/shared/database.ts
+++ b/src/shared/database.ts
@@ -12,6 +12,7 @@ import {
 import { Season, Rank, RankClassInfo } from "./types/Season";
 import { ArenaV3Deck } from "./types/Deck";
 import { STANDARD_CUTOFF_DATE } from "./constants";
+import format from "date-fns/format";
 
 const cachePath: string | null =
   app || (remote && remote.app)
@@ -110,6 +111,11 @@ class Database {
   handleSetDb(_event: Event | null, arg: string) {
     try {
       this.metadata = JSON.parse(arg) as Metadata;
+      for (const event of this.playBrawlEvents) {
+        this.metadata.events[event] = "Play Brawl";
+        this.metadata.events_format[event] = "Brawl";
+        this.metadata.single_match_events.push(event);
+      }
     } catch (e) {
       console.log("Error parsing metadata", e);
     }
@@ -200,6 +206,18 @@ class Database {
 
   get single_match_events(): string[] {
     return this.metadata ? this.metadata.single_match_events : [];
+  }
+
+  get playBrawlEvents(): string[] {
+    const prefix = "Play_Brawl_";
+    const endDate = new Date();
+    const currentDate = new Date("2019-11-06T16:00:00Z"); // first Wednesday brawl
+    const events = [];
+    while (currentDate < endDate) {
+      events.push(prefix + format(currentDate, "yyyyMMdd"));
+      currentDate.setDate(currentDate.getDate() + 7); // repeat every Wednesday
+    }
+    return events;
   }
 
   get season_starts(): Date {

--- a/src/window_main/aggregator.ts
+++ b/src/window_main/aggregator.ts
@@ -61,6 +61,7 @@ export default class Aggregator {
   // Event-related filter values
   public static ALL_EVENT_TRACKS = "All Event Tracks";
   public static ALL_DRAFTS = "All Drafts";
+  public static PLAY_BRAWL = "Play Brawl";
   // Archetype filter values
   public static NO_ARCH = "No Archetype";
 
@@ -205,6 +206,8 @@ export default class Aggregator {
         db.standard_ranked_events.includes(eventId)) ||
       (filterValue === Aggregator.RANKED_DRAFT &&
         db.limited_ranked_events.includes(eventId)) ||
+      (filterValue === Aggregator.PLAY_BRAWL &&
+        getReadableEvent(eventId) === Aggregator.PLAY_BRAWL) ||
       filterValue === eventId
     );
   }
@@ -448,23 +451,24 @@ export default class Aggregator {
   }
 
   get events(): string[] {
+    const brawlEvents = new Set(db.playBrawlEvents);
     return [
       Aggregator.DEFAULT_EVENT,
       Aggregator.ALL_DRAFTS,
       Aggregator.RANKED_CONST,
       Aggregator.RANKED_DRAFT,
-      ...this._eventIds
+      Aggregator.PLAY_BRAWL,
+      ...this._eventIds.filter(eventId => !brawlEvents.has(eventId))
     ];
   }
 
   get trackEvents(): string[] {
+    const bo1Events = new Set(db.single_match_events);
     return [
       Aggregator.ALL_EVENT_TRACKS,
       Aggregator.ALL_DRAFTS,
       Aggregator.RANKED_DRAFT,
-      ...this._eventIds.filter(
-        eventId => !db.single_match_events.includes(eventId)
-      )
+      ...this._eventIds.filter(eventId => !bo1Events.has(eventId))
     ];
   }
 


### PR DESCRIPTION
### Motivation
Every Wednesday, WotC celebrates its most controversial Arena event format by letting folks play Brawl for 24 hours. They implement these "Play Brawl" queues with a separate individual event each week. As a result, our event metadata repo struggles to keep up with adding new codes and mappings. This PR supports Wednesday Play Brawl queues by encapsulating the pattern WotC uses to generate the event code each week and then autogenerating the metadata. There is also some minor logic in the Aggregator to make sure the many events are grouped all pretty-like.