### PR TITLE
add boosters filter preset to collection page

### DIFF
--- a/src/window_main/components/collection/CollectionTableControls.tsx
+++ b/src/window_main/components/collection/CollectionTableControls.tsx
@@ -14,6 +14,9 @@ import PagingControls from "../tables/PagingControls";
 import { defaultRarity } from "./filters";
 import { CollectionTableControlsProps } from "./types";
 
+const boostersFilters = (): FilterValue[] => [
+  { id: "booster", value: { true: true, false: false } }
+];
 const standardSetsFilter: FilterValue = {};
 db.standardSetCodes.forEach(code => (standardSetsFilter[code] = true));
 const standardFilters = (): FilterValue[] => [
@@ -67,6 +70,23 @@ export default function CollectionTableControls(
         <span style={{ paddingBottom: "8px", marginLeft: "12px" }}>
           Presets:
         </span>
+        <SmallTextButton
+          onClick={(): void => {
+            setAllFilters(boostersFilters);
+            setFiltersVisible({
+              ...initialFiltersVisible,
+              booster: true
+            });
+            toggleSortBy("grpId", true, false);
+            for (const column of toggleableColumns) {
+              toggleHideColumn(column.id, !column.defaultVisible);
+            }
+            toggleHideColumn("booster", false);
+            toggleHideColumn("cmc", true);
+          }}
+        >
+          Boosters
+        </SmallTextButton>
         <SmallTextButton
           onClick={(): void => {
             setAllFilters(standardFilters);


### PR DESCRIPTION
### Motivation
Adds a super-useful and often requested single-click solution to the Collection page.