### PR TITLE
Add negative handling for Vault

### DIFF
--- a/src/window_main/components/economy/EconomyDayHeader.tsx
+++ b/src/window_main/components/economy/EconomyDayHeader.tsx
@@ -73,10 +73,14 @@ export function EconomyDayHeader(props: EconomyDayHeaderProps): JSX.Element {
         containerDiv
         iconClassName={"economy_vault"}
         className={"gridVault"}
-        deltaUpContent={formatPercent(
+        deltaUpContent={vaultProgressDelta >= 0 ? formatPercent(
           vaultProgressDelta,
           vaultPercentFormat as any
-        )}
+        ) : undefined}
+        deltaDownContent={vaultProgressDelta < 0 ? formatPercent(
+          vaultProgressDelta,
+          vaultPercentFormat as any
+        ) : undefined}
         title={"Vault"}
       />
       <EconomyValueRecord


### PR DESCRIPTION
Previously, the Vault progress indicator in the Economy screen would show the upward delta arrow even if the user cashed in the Vault causing the percentage progress to be negative:

![image](https://user-images.githubusercontent.com/4501321/74655075-5ba59300-5151-11ea-9f70-9015f06e5f5a.png)

Now, the Vault economy record includes `deltaDownContent` instead of `deltaUpContent` when appropriate, like the other headings.