### PR TITLE
bugfix gracefully handle missing card metadata

### DIFF
--- a/src/window_background/getOpponentDeck.ts
+++ b/src/window_background/getOpponentDeck.ts
@@ -34,10 +34,11 @@ function getBestArchetype(deck: Deck): string {
       .getMainboard()
       .get()
       .forEach(card => {
+        const cardData = db.card(card.id);
+        if (!cardData) return;
         //let q = card.quantity;
-        const name = (db.card(card.id) as DbCardData).name;
+        const name = cardData.name;
         const archMain = arch.average.mainDeck;
-
         const deviation = 1 - (archMain[name] ? 1 : 0); // archMain[name] ? archMain[name] : 0 // for full data
         mainDeviations.push(deviation * deviation);
         //console.log(name, deviation, archMain[name]);

--- a/src/window_main/renderer-util.js
+++ b/src/window_main/renderer-util.js
@@ -193,7 +193,9 @@ function drawDeck(div, deck, showWildcards = false) {
           deck,
           false
         );
-        div.appendChild(tile);
+        if (tile) {
+          div.appendChild(tile);
+        }
       }
     });
   }


### PR DESCRIPTION
This PR fixes 2 more locations that would throw JS errors when they hit a card that does not yet exist in the metadata database.
- bugfix `getOpponentDeck`
- bugfix `renderer-util.drawDeck`

https://discordapp.com/channels/463844727654187020/467737642306371584/679788336671490099
![image](https://user-images.githubusercontent.com/14894693/74971632-450f6e00-53d5-11ea-8a3f-2a7aeed3b136.png)
