### PR TITLE
bugfix overlay card hover logic

### DIFF
--- a/src/overlay/CardDetailsWindowlet.tsx
+++ b/src/overlay/CardDetailsWindowlet.tsx
@@ -1,11 +1,13 @@
 import React, { useRef } from "react";
+import { useSelector } from "react-redux";
 import { CSSTransition } from "react-transition-group";
 import { ARENA_MODE_DRAFT } from "../shared/constants";
+import db from "../shared/database";
 import DraftRatings from "../shared/DraftRatings";
 import { getCardImage } from "../shared/util";
 import { Chances } from "../types/Chances";
-import { DbCardData } from "../types/Metadata";
 import { SettingsData } from "../types/settings";
+import { AppState } from "../window_main/app/appState";
 import { getEditModeClass, useEditModeOnRef } from "./overlayUtil";
 
 function GroupedLandsDetails(props: { odds: Chances }): JSX.Element {
@@ -33,8 +35,6 @@ const SCALAR = 0.71808510638; // ???
 
 export interface CardDetailsWindowletProps {
   arenaState: number;
-  card?: DbCardData;
-  cardsSizeHoverCard: number;
   editMode: boolean;
   handleToggleEditMode: () => void;
   odds?: Chances;
@@ -54,8 +54,6 @@ export default function CardDetailsWindowlet(
 ): JSX.Element {
   const {
     arenaState,
-    card,
-    cardsSizeHoverCard,
     handleToggleEditMode,
     editMode,
     odds,
@@ -63,6 +61,10 @@ export default function CardDetailsWindowlet(
     overlayScale,
     settings
   } = props;
+  const grpId = useSelector((state: AppState) => state.hover.grpId);
+  const opacity = useSelector((state: AppState) => state.hover.opacity);
+  const cardsSizeHoverCard = useSelector((state: AppState) => state.hover.size);
+  const card = db.card(grpId);
 
   // TODO remove group lands hack
   const isCardGroupedLands = card?.id === 100 && odds;
@@ -73,7 +75,8 @@ export default function CardDetailsWindowlet(
     src: getCardImage(card),
     style: {
       width: cardsSizeHoverCard + "px",
-      height: cardsSizeHoverCard / SCALAR + "px"
+      height: cardsSizeHoverCard / SCALAR + "px",
+      opacity
     }
   };
   const containerRef = useRef(null);

--- a/src/overlay/DeckList.tsx
+++ b/src/overlay/DeckList.tsx
@@ -100,7 +100,6 @@ export interface DeckListProps {
   settings: OverlaySettingsData;
   tileStyle: number;
   cardOdds?: Chances;
-  setHoverCardCallback: (card?: DbCardData) => void;
   setOddsCallback?: (sampleSize: number) => void;
 }
 
@@ -112,7 +111,6 @@ export default function DeckList(props: DeckListProps): JSX.Element {
     tileStyle,
     highlightCardId,
     cardOdds,
-    setHoverCardCallback,
     setOddsCallback
   } = props;
   if (!deck) return <></>;

--- a/src/overlay/DraftElements.tsx
+++ b/src/overlay/DraftElements.tsx
@@ -7,7 +7,6 @@ import {
 } from "../shared/constants";
 import Deck from "../shared/deck";
 import { DraftData, DraftState } from "../types/draft";
-import { DbCardData } from "../types/Metadata";
 import { OverlaySettingsData } from "../types/settings";
 import DeckList from "./DeckList";
 
@@ -19,7 +18,6 @@ export interface DraftElementsProps {
   index: number;
   settings: OverlaySettingsData;
   setDraftStateCallback: (state: DraftState) => void;
-  setHoverCardCallback: (card?: DbCardData) => void;
   tileStyle: number;
 }
 
@@ -33,7 +31,6 @@ export default function DraftElements(props: DraftElementsProps): JSX.Element {
     draftState,
     index,
     setDraftStateCallback,
-    setHoverCardCallback,
     settings,
     tileStyle
   } = props;
@@ -51,7 +48,7 @@ export default function DraftElements(props: DraftElementsProps): JSX.Element {
       packN = draft.packNumber;
     }
     setDraftStateCallback({ packN, pickN });
-  }, [draftState, draft]);
+  }, [draftState, draft, packSize, setDraftStateCallback]);
 
   const handleDraftNext = useCallback((): void => {
     let { packN, pickN } = draftState;
@@ -72,7 +69,7 @@ export default function DraftElements(props: DraftElementsProps): JSX.Element {
       pickN = draft.pickNumber;
     }
     setDraftStateCallback({ packN, pickN });
-  }, [draftState, draft]);
+  }, [draftState, draft, packSize, setDraftStateCallback]);
 
   const { packN, pickN } = draftState;
   const isCurrent = packN === draft.packNumber && pickN === draft.pickNumber;
@@ -138,7 +135,6 @@ export default function DraftElements(props: DraftElementsProps): JSX.Element {
           deck={visibleDeck}
           subTitle={subTitle}
           highlightCardId={pick}
-          setHoverCardCallback={setHoverCardCallback}
           settings={settings}
           tileStyle={tileStyle}
         />

--- a/src/overlay/MatchElements.tsx
+++ b/src/overlay/MatchElements.tsx
@@ -10,7 +10,6 @@ import {
 } from "../shared/constants";
 import { MatchData } from "../types/currentMatch";
 import { InternalActionLog } from "../types/log";
-import { DbCardData } from "../types/Metadata";
 import { OverlaySettingsData } from "../types/settings";
 import ActionLog from "./ActionLog";
 import Clock from "./Clock";
@@ -20,7 +19,6 @@ export interface MatchElementsProps {
   actionLog: InternalActionLog[];
   index: number;
   match: MatchData;
-  setHoverCardCallback: (card?: DbCardData) => void;
   setOddsCallback: (sampleSize: number) => void;
   settings: OverlaySettingsData;
   tileStyle: number;
@@ -36,7 +34,6 @@ export default function MatchElements(props: MatchElementsProps): JSX.Element {
     actionLog,
     index,
     match,
-    setHoverCardCallback,
     setOddsCallback,
     settings,
     tileStyle,
@@ -103,19 +100,13 @@ export default function MatchElements(props: MatchElementsProps): JSX.Element {
           ))}
         </div>
       )}
-      {settings.mode === OVERLAY_LOG && (
-        <ActionLog
-          actionLog={actionLog}
-          setHoverCardCallback={setHoverCardCallback}
-        />
-      )}
+      {settings.mode === OVERLAY_LOG && <ActionLog actionLog={actionLog} />}
       {!!visibleDeck && (
         <DeckList
           deck={visibleDeck}
           subTitle={subTitle}
           settings={settings}
           tileStyle={tileStyle}
-          setHoverCardCallback={setHoverCardCallback}
           setOddsCallback={setOddsCallback}
         />
       )}

--- a/src/overlay/OverlayController.tsx
+++ b/src/overlay/OverlayController.tsx
@@ -17,6 +17,8 @@ import { DbCardData } from "../types/Metadata";
 import { OverlaySettingsData, SettingsData } from "../types/settings";
 import CardDetailsWindowlet from "./CardDetailsWindowlet";
 import OverlayWindowlet from "./OverlayWindowlet";
+import { dispatchAction, SET_HOVER_SIZE } from "../window_main/app/reducers";
+import { useDispatch } from "react-redux";
 
 const sound = new Howl({ src: ["../sounds/blip.mp3"] });
 
@@ -61,18 +63,16 @@ function setOddsCallback(sampleSize: number): void {
  *       - Clock
  */
 export default function OverlayController(): JSX.Element {
-  const [actionLog, setActionLog] = useState([] as InternalActionLog[]);
+  const [actionLog, setActionLog] = useState<InternalActionLog[]>([]);
   const [arenaState, setArenaState] = useState(ARENA_MODE_IDLE);
   const [editMode, setEditMode] = useState(false);
-  const [match, setMatch] = useState(undefined as undefined | MatchData);
-  const [draft, setDraft] = useState(undefined as undefined | DraftData);
+  const [match, setMatch] = useState<undefined | MatchData>(undefined);
+  const [draft, setDraft] = useState<undefined | DraftData>(undefined);
   const [draftState, setDraftState] = useState({ packN: 0, pickN: 0 });
   const [turnPriority, setTurnPriority] = useState(1);
-  const [settings, setSettings] = useState(playerData.settings as SettingsData);
+  const [settings, setSettings] = useState(playerData.settings);
   const [lastBeep, setLastBeep] = useState(Date.now());
-  const [hoverCard, setHoverCard] = useState(
-    undefined as undefined | DbCardData
-  );
+  const dispatcher = useDispatch();
 
   const {
     overlay_scale: overlayScale,
@@ -191,6 +191,7 @@ export default function OverlayController(): JSX.Element {
   );
 
   const handleSettingsUpdated = useCallback((): void => {
+    dispatchAction(dispatcher, SET_HOVER_SIZE, playerData.cardsSizeHoverCard);
     setSettings({ ...playerData.settings });
   }, []);
 
@@ -251,16 +252,12 @@ export default function OverlayController(): JSX.Element {
     match,
     settings,
     setDraftStateCallback: setDraftState,
-    setHoverCardCallback: (card?: DbCardData): void => setHoverCard(card),
     setOddsCallback,
     turnPriority
   };
 
-  const { cardsSizeHoverCard } = playerData;
   const cardDetailsProps = {
     arenaState,
-    card: hoverCard,
-    cardsSizeHoverCard,
     editMode,
     handleToggleEditMode,
     odds: match ? match.playerCardsOdds : undefined,

--- a/src/overlay/OverlayWindowlet.tsx
+++ b/src/overlay/OverlayWindowlet.tsx
@@ -9,7 +9,6 @@ import {
 import { MatchData } from "../types/currentMatch";
 import { DraftData, DraftState } from "../types/draft";
 import { InternalActionLog } from "../types/log";
-import { DbCardData } from "../types/Metadata";
 import { SettingsData } from "../types/settings";
 import DraftElements from "./DraftElements";
 import MatchElements from "./MatchElements";
@@ -30,12 +29,11 @@ export interface OverlayWindowletProps {
   match?: MatchData;
   settings: SettingsData;
   setDraftStateCallback: (state: DraftState) => void;
-  setHoverCardCallback: (card?: DbCardData) => void;
   setOddsCallback: (sampleSize: number) => void;
   turnPriority: number;
 }
 
-function isOverlayDraftMode(mode: number) {
+function isOverlayDraftMode(mode: number): boolean {
   return OVERLAY_DRAFT_MODES.some(draftMode => draftMode === mode);
 }
 
@@ -60,7 +58,6 @@ export default function OverlayWindowlet(
     index,
     match,
     setDraftStateCallback,
-    setHoverCardCallback,
     setOddsCallback,
     settings,
     turnPriority
@@ -97,7 +94,6 @@ export default function OverlayWindowlet(
   const commonProps = {
     index,
     settings: overlaySettings,
-    setHoverCardCallback,
     tileStyle
   };
   if (draft && isOverlayDraftMode(overlaySettings.mode)) {
@@ -139,7 +135,7 @@ export default function OverlayWindowlet(
 
   const backgroundColor = settings.overlay_back_color;
 
-  const bgStyle: any = {
+  const bgStyle: React.CSSProperties = {
     opacity: overlaySettings.alpha_back.toString()
   };
 


### PR DESCRIPTION
This PR fixes the card hover feature in draft and deck lists in the overlays by fully converting the remaining pre-Redux card hover logic into Redux + `useHoverCard`. It also converts the `ActionLog` and cleans up the callback cruft.