### PR TITLE
Renderer util to Typescript

### DIFF
--- a/src/shared/PlayerData.ts
+++ b/src/shared/PlayerData.ts
@@ -346,6 +346,7 @@ class PlayerData implements Record<string, any> {
   public matches_index: string[] = [];
   public economy_index: string[] = [];
   public draft_index: string[] = [];
+  public tags_colors: Record<string, string> = {};
   public offline = false;
   public patreon = false;
   public patreon_tier = -1;

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -6,6 +6,21 @@ export interface EventInstanceData {
   ProcessedMatchIds?: string[];
 }
 
+export interface WinLossGate {
+  MaxWins: number;
+  MaxLosses: number;
+  MaxGames: number;
+  CurrentWins: number;
+  CurrentLosses: number;
+  CurrentGames: number;
+  ProcessedMatchIds: string[];
+}
+
+export interface WinNoGate {
+  CurrentWins: number;
+  ProcessedMatchIds: string[];
+}
+
 export interface InternalEvent {
   Id?: string;
   _id?: string;
@@ -17,15 +32,8 @@ export interface InternalEvent {
   date: string;
   InternalEventName: string;
   ModuleInstanceData: {
-    WinLossGate?: {
-      CurrentWins: number;
-      CurrentLosses: number;
-      ProcessedMatchIds: string[];
-    };
-    WinNoGate?: {
-      CurrentWins: number;
-      ProcessedMatchIds: string[];
-    };
+    WinLossGate?: WinLossGate;
+    WinNoGate?: WinNoGate;
   };
   type: "Event";
 }

--- a/src/window_main/DateFilter.tsx
+++ b/src/window_main/DateFilter.tsx
@@ -6,7 +6,7 @@ import {
   DATE_SEASON
 } from "../shared/constants";
 import ReactSelect from "../shared/ReactSelect";
-import { ipcSend, showDatepicker } from "./renderer-util";
+import { ipcSend, showDatepicker } from "./util";
 
 export interface DateFilterProps {
   prefixId: string;

--- a/src/window_main/TagOption.tsx
+++ b/src/window_main/TagOption.tsx
@@ -3,7 +3,7 @@
 */
 import Aggregator from "./aggregator";
 import React from "react";
-import { getTagColor } from "./renderer-util";
+import { getTagColor } from "./util";
 import { getReadableFormat } from "../shared/util";
 
 export interface TagOptionProps {

--- a/src/window_main/app/App.tsx
+++ b/src/window_main/app/App.tsx
@@ -29,7 +29,7 @@ import Popup from "../components/main/Popup";
 import CardHover from "../components/main/CardHover";
 import { AppState } from "../../shared/redux/appState";
 import OutputLogInput from "../components/popups/OutputLogInput";
-import { ipcSend } from "../renderer-util";
+import { ipcSend } from "../util";
 import Share from "../components/popups/Share";
 
 function App(): JSX.Element {

--- a/src/window_main/app/ipcListeners.tsx
+++ b/src/window_main/app/ipcListeners.tsx
@@ -32,7 +32,7 @@ import {
   SETTINGS_OVERLAY,
   MAIN_HOME
 } from "../../shared/constants";
-import { ipcSend } from "../renderer-util";
+import { ipcSend } from "../util";
 import { SETTINGS_ABOUT } from "../../shared/constants";
 import pd from "../../shared/PlayerData";
 import uxMove from "../uxMove";

--- a/src/window_main/components/collection/CollectionStatsPanel.tsx
+++ b/src/window_main/components/collection/CollectionStatsPanel.tsx
@@ -9,7 +9,7 @@ import {
   FULL_SETS,
   SINGLETONS
 } from "./collectionStats";
-import { formatNumber } from "../../renderer-util";
+import { formatNumber } from "../../util";
 import {
   BoosterSymbol,
   CalendarSymbol,

--- a/src/window_main/components/deck-view/DeckVIew.tsx
+++ b/src/window_main/components/deck-view/DeckVIew.tsx
@@ -8,7 +8,7 @@ import DeckTypesStats from "../../../shared/DeckTypesStats";
 import DeckManaCurve from "../../../shared/DeckManaCurve";
 import Deck from "../../../shared/deck";
 import Button from "../misc/Button";
-import { ipcSend } from "../../renderer-util";
+import { ipcSend } from "../../util";
 import { useDispatch } from "react-redux";
 import {
   dispatchAction,

--- a/src/window_main/components/decks/cells.tsx
+++ b/src/window_main/components/decks/cells.tsx
@@ -7,7 +7,7 @@ import {
   formatPercent,
   formatWinrateInterval,
   getWinrateClass
-} from "../../renderer-util";
+} from "../../util";
 import { BoosterSymbol, MetricText, RaritySymbol } from "../misc/display";
 import { DecksData, DecksTableCellProps } from "./types";
 

--- a/src/window_main/components/economy/EconomyDayHeader.tsx
+++ b/src/window_main/components/economy/EconomyDayHeader.tsx
@@ -3,7 +3,7 @@ import addDays from "date-fns/addDays";
 import startOfDay from "date-fns/startOfDay";
 
 import LocalTime from "../../../shared/time-components/LocalTime";
-import { formatNumber, formatPercent } from "../../renderer-util";
+import { formatNumber, formatPercent } from "../../util";
 import { vaultPercentFormat } from "./economyUtils";
 import EconomyValueRecord from "./EconomyValueRecord";
 

--- a/src/window_main/components/economy/EconomyHeader.tsx
+++ b/src/window_main/components/economy/EconomyHeader.tsx
@@ -1,4 +1,4 @@
-import { formatNumber, formatPercent } from "../../renderer-util";
+import { formatNumber, formatPercent } from "../../util";
 import pd from "../../../shared/PlayerData";
 
 import { vaultPercentFormat } from "./economyUtils";

--- a/src/window_main/components/economy/EconomyRow.tsx
+++ b/src/window_main/components/economy/EconomyRow.tsx
@@ -16,7 +16,7 @@ import {
   formatNumber,
   formatPercent,
   toggleArchived
-} from "../../renderer-util";
+} from "../../util";
 import {
   getCollationSet,
   getPrettyContext,

--- a/src/window_main/components/list-item/ListItemDeck.tsx
+++ b/src/window_main/components/list-item/ListItemDeck.tsx
@@ -6,7 +6,7 @@ import {
   formatPercent,
   formatWinrateInterval,
   getWinrateClass
-} from "../../renderer-util";
+} from "../../util";
 import format from "date-fns/format";
 import { NewTag, TagBubble } from "../misc/display";
 import WildcardsCost from "../misc/WildcardsCost";

--- a/src/window_main/components/list-item/ListItemDraft.tsx
+++ b/src/window_main/components/list-item/ListItemDraft.tsx
@@ -15,7 +15,7 @@ import db from "../../../shared/database";
 import { DEFAULT_TILE } from "../../../shared/constants";
 import { DbCardData } from "../../../types/Metadata";
 import RoundCard from "../misc/RoundCard";
-import { toggleArchived } from "../../renderer-util";
+import { toggleArchived } from "../../util";
 import { getReadableEvent } from "../../../shared/util";
 
 interface ListItemDraftProps {

--- a/src/window_main/components/list-item/ListItemEvent.tsx
+++ b/src/window_main/components/list-item/ListItemEvent.tsx
@@ -16,7 +16,7 @@ import {
 import ListItemMatch from "./ListItemMatch";
 import ListItemDraft from "./ListItemDraft";
 import { DEFAULT_TILE, SUB_MATCH, SUB_DRAFT } from "../../../shared/constants";
-import { getEventWinLossClass, toggleArchived } from "../../renderer-util";
+import { getEventWinLossClass, toggleArchived } from "../../util";
 import { DbCardData } from "../../../types/Metadata";
 import RoundCard from "../misc/RoundCard";
 import { compareDesc } from "date-fns";

--- a/src/window_main/components/list-item/ListItemExplore.tsx
+++ b/src/window_main/components/list-item/ListItemExplore.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { RANKS } from "../../../shared/constants";
 import ManaCost from "../misc/ManaCost";
-import { formatPercent, getWinrateClass } from "../../renderer-util";
+import { formatPercent, getWinrateClass } from "../../util";
 import { ListItem, Column, HoverTile, FlexTop, FlexBottom } from "./ListItem";
 import WildcardsCostPreset from "../misc/WildcardsCostPreset";
 import RankSmall from "../misc/RankSmall";

--- a/src/window_main/components/list-item/ListItemMatch.tsx
+++ b/src/window_main/components/list-item/ListItemMatch.tsx
@@ -15,7 +15,7 @@ import { getReadableEvent, toMMSS } from "../../../shared/util";
 import RankSmall from "../misc/RankSmall";
 import ResultDetails from "../misc/ResultDetails";
 import { TagBubble, NewTag } from "../misc/display";
-import { toggleArchived } from "../../renderer-util";
+import { toggleArchived } from "../../util";
 
 export default function ListItemMatch({
   match,

--- a/src/window_main/components/main/Auth.tsx
+++ b/src/window_main/components/main/Auth.tsx
@@ -4,7 +4,7 @@ import { useSelector, useDispatch } from "react-redux";
 import { AppState } from "../../../shared/redux/appState";
 import { shell } from "electron";
 import Checkbox from "../misc/Checkbox";
-import { ipcSend } from "../../renderer-util";
+import { ipcSend } from "../../util";
 import { HIDDEN_PW } from "../../../shared/constants";
 import { dispatchAction, SET_CAN_LOGIN } from "../../../shared/redux/reducers";
 const sha1 = require("js-sha1");

--- a/src/window_main/components/main/OfflineSplash.tsx
+++ b/src/window_main/components/main/OfflineSplash.tsx
@@ -2,7 +2,7 @@
 import { remote, shell } from "electron";
 import React from "react";
 import { SETTINGS_PRIVACY } from "../../../shared/constants";
-import { ipcSend } from "../../renderer-util";
+import { ipcSend } from "../../util";
 import { forceOpenSettings } from "../../tabControl";
 
 export default function OfflineSplash(): JSX.Element {

--- a/src/window_main/components/main/TopBar.tsx
+++ b/src/window_main/components/main/TopBar.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ipcSend } from "../../renderer-util";
+import { ipcSend } from "../../util";
 import { forceOpenSettings } from "../../tabControl";
 
 interface TopBarProps {

--- a/src/window_main/components/match-view/MatchView.tsx
+++ b/src/window_main/components/match-view/MatchView.tsx
@@ -6,7 +6,7 @@ import pd from "../../../shared/PlayerData";
 import ShareButton from "../misc/ShareButton";
 import ManaCost from "../misc/ManaCost";
 import Deck from "../../../shared/deck";
-import { actionLogDir, ipcSend } from "../../renderer-util";
+import { actionLogDir, ipcSend } from "../../util";
 import Button from "../misc/Button";
 import DeckList from "../misc/DeckList";
 import RankIcon from "../misc/RankIcon";

--- a/src/window_main/components/matches/RankedStats.tsx
+++ b/src/window_main/components/matches/RankedStats.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { DATE_SEASON, RANKS } from "../../../shared/constants";
 import pd from "../../../shared/PlayerData";
 import Aggregator, { AggregatorFilters } from "../../aggregator";
-import { formatPercent } from "../../renderer-util";
+import { formatPercent } from "../../util";
 
 const { RANKED_CONST, RANKED_DRAFT } = Aggregator;
 

--- a/src/window_main/components/misc/MatchResultsStatsPanel.tsx
+++ b/src/window_main/components/misc/MatchResultsStatsPanel.tsx
@@ -14,7 +14,7 @@ import {
   formatPercent,
   getTagColor,
   getWinrateClass
-} from "../../renderer-util";
+} from "../../util";
 
 const { RANKED_CONST, RANKED_DRAFT } = Aggregator;
 

--- a/src/window_main/components/misc/MatchResultsStatsPanel.tsx
+++ b/src/window_main/components/misc/MatchResultsStatsPanel.tsx
@@ -147,7 +147,7 @@ function FrequencyChart({
               {showTags && (
                 <div
                   className={"mana_curve_tag"}
-                  style={{ backgroundColor: getTagColor(cwr.tag) }}
+                  style={{ backgroundColor: getTagColor(cwr.tag || "") }}
                 >
                   {cwr.tag}
                 </div>

--- a/src/window_main/components/misc/ResizableDragger.tsx
+++ b/src/window_main/components/misc/ResizableDragger.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useDispatch } from "react-redux";
 import pd from "../../../shared/PlayerData";
 import { dispatchAction, SET_SETTINGS } from "../../../shared/redux/reducers";
-import { makeResizable } from "../../renderer-util";
+import { makeResizable } from "../../util";
 
 export default function ResizableDragger(): JSX.Element {
   const draggerRef = React.useRef<HTMLDivElement>(null);

--- a/src/window_main/components/misc/display.tsx
+++ b/src/window_main/components/misc/display.tsx
@@ -3,7 +3,7 @@ import styled from "styled-components";
 import { MANA } from "../../../shared/constants";
 import db from "../../../shared/database";
 import { get_rank_index_16 as getRankIndex16 } from "../../../shared/util";
-import { getTagColor } from "../../renderer-util";
+import { getTagColor } from "../../util";
 import AutosuggestInput from "../tables/AutosuggestInput";
 import { TagCounts } from "../tables/types";
 import useColorPicker from "../../hooks/useColorPicker";

--- a/src/window_main/components/popups/Share.tsx
+++ b/src/window_main/components/popups/Share.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useEffect } from "react";
 import ReactSelect from "../../../shared/ReactSelect";
-import { ipcSend } from "../../renderer-util";
+import { ipcSend } from "../../util";
 import { useSelector, useDispatch } from "react-redux";
 import { AppState } from "../../../shared/redux/appState";
 import { SET_LOADING, dispatchAction } from "../../../shared/redux/reducers";

--- a/src/window_main/components/settings/SectionAbout.tsx
+++ b/src/window_main/components/settings/SectionAbout.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import React from "react";
-import { ipcSend } from "../../renderer-util";
+import { ipcSend } from "../../util";
 import { remote, shell } from "electron";
 import db from "../../../shared/database";
 import { format, fromUnixTime } from "date-fns";

--- a/src/window_main/components/settings/SectionBehaviour.tsx
+++ b/src/window_main/components/settings/SectionBehaviour.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import Toggle from "../misc/Toggle";
 import Input from "../misc/Input";
-import { ipcSend } from "../../renderer-util";
+import { ipcSend } from "../../util";
 import { useSelector } from "react-redux";
 import { AppState } from "../../../shared/redux/appState";
 

--- a/src/window_main/components/settings/SectionData.tsx
+++ b/src/window_main/components/settings/SectionData.tsx
@@ -5,7 +5,7 @@ const { dialog } = remote;
 import Toggle from "../misc/Toggle";
 import Input from "../misc/Input";
 import pd from "../../../shared/PlayerData";
-import { ipcSend } from "../../renderer-util";
+import { ipcSend } from "../../util";
 import ReactSelect from "../../../shared/ReactSelect";
 import { parse, isValid } from "date-fns";
 import Button from "../misc/Button";

--- a/src/window_main/components/settings/SectionLogin.tsx
+++ b/src/window_main/components/settings/SectionLogin.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { remote } from "electron";
 import pd from "../../../shared/PlayerData";
-import { ipcSend } from "../../renderer-util";
+import { ipcSend } from "../../util";
 import Button from "../misc/Button";
 
 function click(): void {

--- a/src/window_main/components/settings/SectionPrivacy.tsx
+++ b/src/window_main/components/settings/SectionPrivacy.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import React from "react";
 import Toggle from "../misc/Toggle";
-import { ipcSend } from "../../renderer-util";
+import { ipcSend } from "../../util";
 import Button from "../misc/Button";
 import { useSelector } from "react-redux";
 import { AppState } from "../../../shared/redux/appState";

--- a/src/window_main/components/settings/SectionShortcuts.tsx
+++ b/src/window_main/components/settings/SectionShortcuts.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import React, { useState, useCallback } from "react";
 import { remote } from "electron";
-import { ipcSend } from "../../renderer-util";
+import { ipcSend } from "../../util";
 import { SHORTCUT_NAMES } from "../../../shared/constants";
 import Toggle from "../misc/Toggle";
 import Button from "../misc/Button";

--- a/src/window_main/components/settings/sectionOverlay.tsx
+++ b/src/window_main/components/settings/sectionOverlay.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import React from "react";
 import Button from "../misc/Button";
-import { ipcSend } from "../../renderer-util";
+import { ipcSend } from "../../util";
 import pd from "../../../shared/PlayerData";
 import Toggle from "../misc/Toggle";
 import Slider from "../misc/Slider";

--- a/src/window_main/components/settings/sectionVisual.tsx
+++ b/src/window_main/components/settings/sectionVisual.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import React from "react";
-import { ipcSend } from "../../renderer-util";
+import { ipcSend } from "../../util";
 import pd from "../../../shared/PlayerData";
 import _ from "lodash";
 import ReactSelect from "../../../shared/ReactSelect";

--- a/src/window_main/components/tables/cells.tsx
+++ b/src/window_main/components/tables/cells.tsx
@@ -5,7 +5,7 @@ import { Cell, CellProps } from "react-table";
 import LocalTime from "../../../shared/time-components/LocalTime";
 import RelativeTime from "../../../shared/time-components/RelativeTime";
 import { toDDHHMMSS, toMMSS } from "../../../shared/util";
-import { formatNumber, formatPercent } from "../../renderer-util";
+import { formatNumber, formatPercent } from "../../util";
 import {
   ArchiveSymbol,
   BriefText,

--- a/src/window_main/tabControl.tsx
+++ b/src/window_main/tabControl.tsx
@@ -30,7 +30,7 @@ import ExploreTab from "./tabs/ExploreTab";
 import HomeTab from "./tabs/HomeTab";
 import MatchesTab from "./tabs/MatchesTab";
 import OfflineSplash from "./components/main/OfflineSplash";
-import { ipcSend } from "./renderer-util";
+import { ipcSend } from "./util";
 import SettingsTab from "./tabs/settings";
 
 export function getOpenNav(tab: number, offline: boolean): JSX.Element {

--- a/src/window_main/tabs/CollectionTab.tsx
+++ b/src/window_main/tabs/CollectionTab.tsx
@@ -14,7 +14,7 @@ import {
 import CollectionTable from "../components/collection/CollectionTable";
 import { CardsData } from "../components/collection/types";
 
-import { ipcSend } from "../renderer-util";
+import { ipcSend } from "../util";
 import { CardCounts } from "../components/decks/types";
 import Deck from "../../shared/deck";
 

--- a/src/window_main/tabs/DecksTab.tsx
+++ b/src/window_main/tabs/DecksTab.tsx
@@ -25,7 +25,7 @@ import DecksTable from "../components/decks/DecksTable";
 import { DecksData } from "../components/decks/types";
 import { isHidingArchived } from "../components/tables/filters";
 import { useAggregatorData } from "../components/tables/hooks";
-import { ipcSend } from "../renderer-util";
+import { ipcSend } from "../util";
 import uxMove from "../uxMove";
 
 function addTag(deckid: string, tag: string): void {

--- a/src/window_main/tabs/EconomyTab.tsx
+++ b/src/window_main/tabs/EconomyTab.tsx
@@ -6,7 +6,7 @@ import pd from "../../shared/PlayerData";
 import EconomyTable from "../components/economy/EconomyTable";
 import { TransactionData } from "../components/economy/types";
 import { getPrettyContext } from "../components/economy/economyUtils";
-import { ipcSend, toggleArchived } from "../renderer-util";
+import { ipcSend, toggleArchived } from "../util";
 
 import { InternalEconomyTransaction } from "../../types/inventory";
 

--- a/src/window_main/tabs/EventsTab.tsx
+++ b/src/window_main/tabs/EventsTab.tsx
@@ -10,7 +10,7 @@ import EventsTable from "../components/events/EventsTable";
 import { EventStats, EventTableData } from "../components/events/types";
 import { isHidingArchived } from "../components/tables/filters";
 import { useAggregatorData } from "../components/tables/hooks";
-import { ipcSend, toggleArchived } from "../renderer-util";
+import { ipcSend, toggleArchived } from "../util";
 
 function editTag(tag: string, color: string): void {
   ipcSend("edit_tag", { tag, color });

--- a/src/window_main/tabs/ExploreTab.tsx
+++ b/src/window_main/tabs/ExploreTab.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
-import { ipcSend } from "../renderer-util";
+import { ipcSend } from "../util";
 import { useDispatch, useSelector } from "react-redux";
 import {
   dispatchAction,

--- a/src/window_main/tabs/HomeTab.tsx
+++ b/src/window_main/tabs/HomeTab.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import db from "../../shared/database";
-import { ipcSend } from "../renderer-util";
+import { ipcSend } from "../util";
 import { timestamp, toDDHHMMSS } from "../../shared/util";
 import {
   dispatchAction,

--- a/src/window_main/tabs/MatchesTab.tsx
+++ b/src/window_main/tabs/MatchesTab.tsx
@@ -18,7 +18,7 @@ import { MatchTableData } from "../components/matches/types";
 import { isHidingArchived } from "../components/tables/filters";
 import { useAggregatorData } from "../components/tables/hooks";
 import { TagCounts } from "../components/tables/types";
-import { ipcSend, toggleArchived } from "../renderer-util";
+import { ipcSend, toggleArchived } from "../util";
 import uxMove from "../uxMove";
 
 const { DEFAULT_ARCH, NO_ARCH } = Aggregator;

--- a/src/window_main/tabs/settings.tsx
+++ b/src/window_main/tabs/settings.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import React from "react";
 import { useSelector } from "react-redux";
-import { ipcSend } from "../renderer-util";
+import { ipcSend } from "../util";
 
 import {
   SETTINGS_BEHAVIOUR,

--- a/src/window_main/util.ts
+++ b/src/window_main/util.ts
@@ -10,7 +10,7 @@ const actionLogDir = path.join(
   (app || remote.app).getPath("userData"),
   "actionlogs"
 );
-function ipcSend(method: string, arg: any, to = IPC_BACKGROUND): void {
+function ipcSend(method: string, arg: any = true, to = IPC_BACKGROUND): void {
   ipc.send("ipc_switch", method, IPC_MAIN, arg, to);
 }
 
@@ -25,7 +25,7 @@ function getTagColor(tag: string): string {
 function makeResizable(
   div: HTMLDivElement,
   resizeCallback: (width: number) => void,
-  finalCallback: (width: number) => void
+  finalCallback?: (width: number) => void
 ) {
   let mPos: number;
   let finalWidth: number | null;


### PR DESCRIPTION
Also move it to a more generic `util.ts`, since it lives in `window_main`, it becomes redundant.
