### PR TITLE
bugfix useBaseReactTable state mutation

### DIFF
--- a/src/window_main/components/tables/hooks.ts
+++ b/src/window_main/components/tables/hooks.ts
@@ -158,7 +158,7 @@ export function useBaseReactTable<D extends TableData>({
       pageSize: 25,
       hiddenColumns
     }) as TableState<D>;
-    const state = cachedState ?? mergedDefault;
+    const state = { ...(cachedState ?? mergedDefault) };
 
     // ensure data-only columns are all invisible
     const hiddenSet = new Set(state.hiddenColumns ?? []);


### PR DESCRIPTION
This PR is a bugfix for this error (it actually affects all react table pages):
```
Unhandled Error
Invariant Violation: A state mutation was detected inside a dispatch, in the path: `settings.decksTableState.hiddenColumns`. Take a look at the reducer(s) handling the action {"type":"SET_POPUP","value":{"text":"Initialized successfully!","time":1584567160,"duration":3000}}. (http://redux.js.org/docs/Troubleshooting.html#never-mutate-reducer-arguments)
    at invariant (C:/Users/Local Ben/code/MTG-Arena-Tool/node_modules/invariant/invariant.js:40:15)
    at Object.dispatch (C:/Users/Local Ben/code/MTG-Arena-Tool/node_modules/redux-immutable-state-invariant/dist/index.js:62:54)
    at dispatch (<anonymous>:1:28545)
    at dispatchAction (C:/Users/Local Ben/code/MTG-Arena-Tool/lib/shared/redux/reducers.js:371:3)
    at EventEmitter.<anonymous> (C:/Users/Local Ben/code/MTG-Arena-Tool/lib/window_main/app/ipcListeners.js:93:34)
    at Object.onMessage (electron/js2c/renderer_init.js:2188:16)
```