### PR TITLE
bugfix NeDB ensure compaction run at launch

### DIFF
--- a/src/shared/db/NeDbDatabase.ts
+++ b/src/shared/db/NeDbDatabase.ts
@@ -65,9 +65,11 @@ export class NeDbDatabase implements LocalDatabase {
   init(dbName: string, arenaName?: string) {
     this.dbName = sanitize(arenaName ? arenaName : dbName);
     this.datastore = new Datastore({
-      filename: path.join(USER_DATA_DIR, this.dbName + ".db"),
-      autoload: true
+      filename: path.join(USER_DATA_DIR, this.dbName + ".db")
     });
+    // ensure session begins with most compact possible db
+    this.datastore.persistence.compactDatafile();
+    this.datastore.loadDatabase();
     // async wrappers of datastore methods
     // https://nodejs.org/dist/latest-v8.x/docs/api/util.html#util_util_promisify_original
     this._find = util.promisify(


### PR DESCRIPTION
### Motivation
We had a report of a user with a personal DB file over 1GB that caused the tool to be unable to boot. The file included lots and lots of duplication, and could be fixed by "manually" compacting it. We do not know how the DB file got to be so big without auto compact fixing it, and I was unable to cause similar run-away-file-size behavior when I attempted to force it (rapidly starting/stopping the tool without giving compaction time to run).

Although this is still basically a shot in the dark, this PR forces the DB the run compaction as the first thing it does after knowing where the DB file is. These changes are designed to add an additional safety to prevent similar issues from happening if possible.