### PR TITLE
Fix small grammatical error in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "MTG-Arena-Tool",
-  "description": "An MTG Arena deck tracker and statistics manager.",
+  "description": "A MTG Arena deck tracker and statistics manager.",
   "author": "Manuel Etchegaray <manuel.etchegaray7@gmail.com>",
   "contributors": [
     "Ken Browning <cashmonae@gmail.com>",


### PR DESCRIPTION
Fix small grammatical error in package.json: use A instead of An