### PR TITLE
Bugfix Archive Buttons on all tabs

### DIFF
--- a/src/shared/redux/reducers.tsx
+++ b/src/shared/redux/reducers.tsx
@@ -47,6 +47,7 @@ export const hoverSlice = createSlice({
 export const rendererSlice = createSlice({
   name: "renderer",
   initialState: {
+    archivedCache: {} as Record<string, boolean>,
     backgroundColor: "rgba(0, 0, 0, 0.25)",
     backgroundGrpId: 0,
     backgroundImage: "default",
@@ -124,6 +125,12 @@ export const rendererSlice = createSlice({
     },
     setUpdateState: (state, action): void => {
       state.updateState = action.payload;
+    },
+    setArchived: (state, action): void => {
+      const { id, archived } = action.payload;
+      if (!id) return;
+      // update local cache (avoids round trip)
+      state.archivedCache[id] = !!archived;
     }
   }
 });

--- a/src/window_main/components/economy/EconomyRow.tsx
+++ b/src/window_main/components/economy/EconomyRow.tsx
@@ -1,31 +1,29 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-use-before-define */
 import React from "react";
-
 import db from "../../../shared/database";
 import pd from "../../../shared/PlayerData";
+import LocalTime from "../../../shared/time-components/LocalTime";
 import {
   collectionSortRarity,
+  getCardArtCrop,
   getCardImage,
-  openScryfallCard,
-  getCardArtCrop
+  openScryfallCard
 } from "../../../shared/util";
-import LocalTime from "../../../shared/time-components/LocalTime";
 import { DbCardData } from "../../../types/Metadata";
-
+import useHoverCard from "../../hooks/useHoverCard";
 import {
   formatNumber,
   formatPercent,
   toggleArchived
 } from "../../rendererUtil";
+import { ArchiveButton } from "../list-item/ListItem";
 import {
   getCollationSet,
   getPrettyContext,
-  vaultPercentFormat,
-  getReadableCode
+  getReadableCode,
+  vaultPercentFormat
 } from "./economyUtils";
-
 import EconomyValueRecord, { EconomyIcon } from "./EconomyValueRecord";
-import useHoverCard from "../../hooks/useHoverCard";
 
 function EconomyRowDate(date: Date): JSX.Element {
   return (
@@ -544,40 +542,6 @@ function FlexTop(props: FlexTopProps): JSX.Element {
   );
 }
 
-interface DeleteButtonProps {
-  change: any;
-  economyId: string;
-  hideRowCallback: () => void;
-}
-
-function DeleteButton(props: DeleteButtonProps): JSX.Element {
-  const { change, economyId, hideRowCallback } = props;
-  const archiveClass = change.archived
-    ? "list_item_unarchive"
-    : "list_item_archive";
-
-  const title = change.archived ? "restore" : "archive (will not delete data)";
-
-  const archiveCallback = React.useCallback(
-    (e: React.MouseEvent<HTMLDivElement>) => {
-      e.stopPropagation();
-      if (!change.archived) {
-        hideRowCallback();
-      }
-      toggleArchived(economyId);
-    },
-    [change, economyId, hideRowCallback]
-  );
-
-  return (
-    <div
-      className={"flex_item " + economyId + "_del " + archiveClass}
-      onClick={archiveCallback}
-      title={title}
-    />
-  );
-}
-
 interface ChangeRowProps {
   economyId: string;
   change: any;
@@ -587,6 +551,14 @@ export function ChangeRow(props: ChangeRowProps): JSX.Element {
   const { economyId, change } = props;
   const fullContext = getPrettyContext(change.originalContext);
   const thingsToCheck = getThingsToCheck(fullContext, change);
+
+  const [hover, setHover] = React.useState(false);
+  const onMouseEnter = React.useCallback(() => {
+    setHover(true);
+  }, []);
+  const onMouseLeave = React.useCallback(() => {
+    setHover(false);
+  }, []);
 
   const flexTopProps = {
     fullContext,
@@ -603,27 +575,22 @@ export function ChangeRow(props: ChangeRowProps): JSX.Element {
     economyId
   };
 
-  const [isHidden, setIsHidden] = React.useState(false);
-
-  const hideRowCallback = React.useCallback(() => {
-    setIsHidden(true);
-  }, []);
-
   return (
     <div
-      className={
-        economyId + " list_economy" + (isHidden ? " economy_row_hidden" : "")
-      }
+      className={economyId + " list_economy"}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
     >
       <div className={"flex_item flexLeft"}>
         <FlexTop {...flexTopProps} />
         <FlexBottom {...flexBottomProps} />
       </div>
       <FlexRight {...flexRightProps} />
-      <DeleteButton
-        change={change}
-        economyId={economyId}
-        hideRowCallback={hideRowCallback}
+      <ArchiveButton
+        archiveCallback={toggleArchived}
+        dataId={economyId}
+        hover={hover}
+        isArchived={change.archived ?? false}
       />
     </div>
   );

--- a/src/window_main/components/events/EventsTable.tsx
+++ b/src/window_main/components/events/EventsTable.tsx
@@ -4,6 +4,7 @@ import { Column, Row } from "react-table";
 import { EVENTS_TABLE_MODE } from "../../../shared/constants";
 import pd from "../../../shared/PlayerData";
 import Aggregator, { AggregatorFilters } from "../../aggregator";
+import { toggleArchived } from "../../rendererUtil";
 import { ListItemEvent } from "../list-item/ListItemEvent";
 import MatchResultsStatsPanel from "../misc/MatchResultsStatsPanel";
 import ResizableDragger from "../misc/ResizableDragger";
@@ -201,7 +202,7 @@ export default function EventsTable({
   const tableProps: BaseTableProps<EventTableData> = {
     cachedState,
     columns,
-    customProps: { editTagCallback },
+    customProps: { archiveCallback: toggleArchived, editTagCallback },
     data,
     defaultState: {
       filters: [{ id: "archivedCol", value: "hideArchived" }],

--- a/src/window_main/components/list-item/ListItem.tsx
+++ b/src/window_main/components/list-item/ListItem.tsx
@@ -1,4 +1,6 @@
-import React, { useCallback } from "react";
+import React from "react";
+import { useDispatch } from "react-redux";
+import { rendererSlice } from "../../../shared/redux/reducers";
 import { getCardArtCrop } from "../../../shared/util";
 
 interface ListItemProps extends JSX.ElementChildrenAttribute {
@@ -111,14 +113,20 @@ function archiveButtonStyle(hover: boolean): React.CSSProperties {
 
 export function ArchiveButton(props: ArchiveButtonProps): JSX.Element {
   const { isArchived, archiveCallback, dataId } = props;
-
+  const dispatcher = useDispatch();
+  const onClick = React.useCallback(
+    (event: React.MouseEvent<HTMLDivElement, MouseEvent>): void => {
+      event.stopPropagation();
+      event.nativeEvent.stopImmediatePropagation();
+      const { setArchived } = rendererSlice.actions;
+      dispatcher(setArchived({ id: dataId, archived: !isArchived }));
+      archiveCallback(dataId);
+    },
+    [archiveCallback, dataId, dispatcher, isArchived]
+  );
   return (
     <div
-      onClick={(e): void => {
-        e.stopPropagation();
-        e.nativeEvent.stopImmediatePropagation();
-        archiveCallback(dataId);
-      }}
+      onClick={onClick}
       className={isArchived ? "list_item_unarchive" : "list_item_archive"}
       title={isArchived ? "restore" : "archive (will not delete data)"}
       style={archiveButtonStyle(props.hover)}

--- a/src/window_main/components/list-item/ListItemMatch.tsx
+++ b/src/window_main/components/list-item/ListItemMatch.tsx
@@ -15,11 +15,11 @@ import { getReadableEvent, toMMSS } from "../../../shared/util";
 import RankSmall from "../misc/RankSmall";
 import ResultDetails from "../misc/ResultDetails";
 import { TagBubble, NewTag } from "../misc/display";
-import { toggleArchived } from "../../rendererUtil";
 
 export default function ListItemMatch({
   match,
   openMatchCallback,
+  archiveCallback,
   addTagCallback,
   editTagCallback,
   deleteTagCallback,
@@ -134,12 +134,14 @@ export default function ListItemMatch({
         </div>
       </Column>
 
-      <ArchiveButton
-        archiveCallback={toggleArchived}
-        dataId={match.id || ""}
-        hover={hover}
-        isArchived={match.archived || false}
-      />
+      {!!archiveCallback && (
+        <ArchiveButton
+          archiveCallback={archiveCallback}
+          dataId={match.id ?? ""}
+          hover={hover}
+          isArchived={match.archived ?? false}
+        />
+      )}
     </ListItem>
   );
 }

--- a/src/window_main/components/matches/types.ts
+++ b/src/window_main/components/matches/types.ts
@@ -61,6 +61,7 @@ export interface ListItemMatchProps {
   tags: TagCounts;
   match: InternalMatch;
   openMatchCallback: (match: InternalMatch) => void;
+  archiveCallback?: (id: string | number) => void;
   addTagCallback?: (id: string, tag: string) => void;
   editTagCallback?: (tag: string, color: string) => void;
   deleteTagCallback?: (id: string, tag: string) => void;

--- a/src/window_main/components/tables/cells.tsx
+++ b/src/window_main/components/tables/cells.tsx
@@ -1,7 +1,9 @@
 import isValid from "date-fns/isValid";
 import _ from "lodash";
 import React from "react";
+import { useDispatch } from "react-redux";
 import { Cell, CellProps } from "react-table";
+import { rendererSlice } from "../../../shared/redux/reducers";
 import LocalTime from "../../../shared/time-components/LocalTime";
 import RelativeTime from "../../../shared/time-components/RelativeTime";
 import { toDDHHMMSS, toMMSS } from "../../../shared/util";
@@ -244,6 +246,18 @@ export function ArchivedCell<D extends TableData>({
 }): JSX.Element {
   const data = cell.row.values;
   const isArchived = data.archived;
+  const dataId = data.id;
+  const dispatcher = useDispatch();
+  const onClick = React.useCallback(
+    (event: React.MouseEvent<HTMLDivElement, MouseEvent>): void => {
+      event.stopPropagation();
+      event.nativeEvent.stopImmediatePropagation();
+      const { setArchived } = rendererSlice.actions;
+      dispatcher(setArchived({ id: dataId, archived: !isArchived }));
+      archiveCallback(dataId);
+    },
+    [archiveCallback, dataId, dispatcher, isArchived]
+  );
   if (!data.custom) {
     return <ArchiveSymbol style={{ visibility: "hidden" }} />;
   }
@@ -251,11 +265,7 @@ export function ArchivedCell<D extends TableData>({
     <ColoredArchivedSymbol
       archived={isArchived}
       title={isArchived ? "restore" : "archive (will not delete data)"}
-      onClick={(e): void => {
-        e.stopPropagation();
-        e.nativeEvent.stopImmediatePropagation();
-        archiveCallback(data.id);
-      }}
+      onClick={onClick}
     />
   );
 }

--- a/src/window_main/components/tables/hooks.ts
+++ b/src/window_main/components/tables/hooks.ts
@@ -1,5 +1,6 @@
 import _ from "lodash";
 import React from "react";
+import { useSelector } from "react-redux";
 import {
   TableInstance,
   TableState,
@@ -10,6 +11,7 @@ import {
   useTable
 } from "react-table";
 import pd from "../../../shared/PlayerData";
+import { AppState } from "../../../shared/redux/reducers";
 import Aggregator, { AggregatorFilters } from "../../aggregator";
 import {
   archivedFilterFn,
@@ -88,7 +90,10 @@ export function useAggregatorData<D extends TableData>({
   showArchived
 }: {
   aggFiltersArg?: AggregatorFilters;
-  getData: (aggregator: Aggregator) => D[];
+  getData: (
+    aggregator: Aggregator,
+    archivedCache: Record<string, boolean>
+  ) => D[];
   showArchived: boolean;
 }): {
   aggFilters: AggregatorFilters;
@@ -101,10 +106,13 @@ export function useAggregatorData<D extends TableData>({
     const defaultAggFilters = getDefaultAggFilters(showArchived, aggFiltersArg);
     setAggFilters(defaultAggFilters);
   }, [aggFiltersArg, showArchived]);
+  const archivedCache = useSelector(
+    (state: AppState) => state.renderer.archivedCache
+  );
   const data = React.useMemo(() => {
     const aggregator = new Aggregator(aggFilters);
-    return getData(aggregator);
-  }, [aggFilters, getData]);
+    return getData(aggregator, archivedCache);
+  }, [aggFilters, archivedCache, getData]);
   return {
     aggFilters,
     data,

--- a/src/window_main/tabs/DecksTab.tsx
+++ b/src/window_main/tabs/DecksTab.tsx
@@ -56,12 +56,16 @@ function saveTableMode(decksTableMode: string): void {
   ipcSend("save_user_settings", { decksTableMode, skipRefresh: true });
 }
 
-function getDecksData(aggregator: Aggregator): DecksData[] {
+function getDecksData(
+  aggregator: Aggregator,
+  archivedCache: Record<string, boolean>
+): DecksData[] {
   return pd.deckList.map(
     (deck: InternalDeck): DecksData => {
       const id = deck.id ?? "";
       const name = (deck.name ?? "").replace("?=?Loc/Decks/Precon/", "");
-      const archivedSortVal = deck.archived ? 1 : deck.custom ? 0.5 : 0;
+      const archived = archivedCache[deck.id] ?? deck.archived ?? false;
+      const archivedSortVal = archived ? 1 : deck.custom ? 0.5 : 0;
       const colorSortVal = deck.colors?.join("") ?? "";
       // compute winrate metrics
       const deckStats: AggregatorStats =
@@ -78,6 +82,7 @@ function getDecksData(aggregator: Aggregator): DecksData[] {
       const lastTouched = dateMaxValid(lastUpdated, lastPlayed);
       return {
         ...deck,
+        archived,
         name,
         format: getReadableFormat(deck.format),
         ...deckStats,

--- a/src/window_main/tabs/EventsTab.tsx
+++ b/src/window_main/tabs/EventsTab.tsx
@@ -103,7 +103,10 @@ function getEventStats(event: InternalEvent): EventStats {
   return stats;
 }
 
-function getEventsData(aggregator: Aggregator): EventTableData[] {
+function getEventsData(
+  aggregator: Aggregator,
+  archivedCache: Record<string, boolean>
+): EventTableData[] {
   return pd.eventList
     .filter((event: InternalEvent) => {
       // legacy filter logic
@@ -118,10 +121,12 @@ function getEventsData(aggregator: Aggregator): EventTableData[] {
         const timestamp = new Date(event.date ?? NaN);
         const colors = event.CourseDeck.colors ?? [];
         const stats = getEventStats(event);
+        const archived = archivedCache[event.id] ?? event.archived ?? false;
         return {
           ...event,
           ...stats,
-          archivedSortVal: event.archived ? 1 : 0,
+          archived,
+          archivedSortVal: archived ? 1 : 0,
           custom: true,
           colors,
           colorSortVal: colors.join(""),

--- a/src/window_main/tabs/MatchesTab.tsx
+++ b/src/window_main/tabs/MatchesTab.tsx
@@ -45,7 +45,10 @@ function saveTableMode(matchesTableMode: string): void {
   ipcSend("save_user_settings", { matchesTableMode, skipRefresh: true });
 }
 
-function getMatchesData(aggregator: Aggregator): MatchTableData[] {
+function getMatchesData(
+  aggregator: Aggregator,
+  archivedCache: Record<string, boolean>
+): MatchTableData[] {
   return pd.matchList
     .filter((match: InternalMatch) => {
       // legacy filter logic
@@ -67,9 +70,11 @@ function getMatchesData(aggregator: Aggregator): MatchTableData[] {
         const oppColors = match.oppDeck.colors ?? [];
         const oppArenaId = match.opponent.name ?? "-#000000";
         const oppName = oppArenaId.slice(0, -6);
+        const archived = archivedCache[match.id] ?? match.archived ?? false;
         return {
           ...match,
-          archivedSortVal: match.archived ? 1 : 0,
+          archived,
+          archivedSortVal: archived ? 1 : 0,
           custom: true,
           colors,
           colorSortVal: colors.join(""),


### PR DESCRIPTION
This PR fixes the archive buttons on the Decks, Matches, Events, and Economy tabs. The general approach is to maintain a cache of item-archival state in Redux. Each tab blends the cache data into the player data upon render, preventing the need for any kind of additional round trip to the background process.