### PR TITLE
no auto refresh during match

### DIFF
--- a/src/shared/redux/reducers.tsx
+++ b/src/shared/redux/reducers.tsx
@@ -3,6 +3,7 @@ import { createSlice } from "@reduxjs/toolkit";
 import { combineReducers } from "redux";
 import { MergedSettings } from "../../types/settings";
 import { WildcardsChange } from "../../window_main/tabs/HomeTab";
+import { ARENA_MODE_IDLE, ARENA_MODE_MATCH } from "../constants";
 import { defaultCfg, playerDataDefault } from "../PlayerData";
 
 export const LOGIN_AUTH = 1;
@@ -51,6 +52,7 @@ export const rendererSlice = createSlice({
   name: "renderer",
   initialState: {
     archivedCache: {} as Record<string, boolean>,
+    arenaState: ARENA_MODE_IDLE,
     backgroundColor: "rgba(0, 0, 0, 0.25)",
     backgroundGrpId: 0,
     backgroundImage: "default",
@@ -84,6 +86,9 @@ export const rendererSlice = createSlice({
     updateState: ""
   },
   reducers: {
+    setArenaState: (state, action): void => {
+      state.arenaState = action.payload;
+    },
     setBackgroundColor: (state, action): void => {
       state.backgroundColor = action.payload;
     },
@@ -106,7 +111,9 @@ export const rendererSlice = createSlice({
       state.patreon = action.payload;
     },
     setPlayerDataTimestamp: (state, action): void => {
-      state.playerDataTimestamp = action.payload;
+      if (state.arenaState !== ARENA_MODE_MATCH) {
+        state.playerDataTimestamp = action.payload;
+      }
     },
     setPopup: (state, action): void => {
       state.popup = action.payload;

--- a/src/window_main/app/ipcListeners.tsx
+++ b/src/window_main/app/ipcListeners.tsx
@@ -3,25 +3,25 @@
 /* eslint-disable no-console */
 import { ipcRenderer as ipc, IpcRendererEvent } from "electron";
 import {
-  LOGIN_OK,
-  LOGIN_FAILED,
-  LOGIN_WAITING,
+  MAIN_HOME,
+  MAIN_SETTINGS,
+  SETTINGS_ABOUT,
+  SETTINGS_OVERLAY
+} from "../../shared/constants";
+import pd from "../../shared/PlayerData";
+import {
   exploreSlice,
   homeSlice,
   hoverSlice,
   loginSlice,
+  LOGIN_FAILED,
+  LOGIN_OK,
+  LOGIN_WAITING,
   rendererSlice,
   settingsSlice
 } from "../../shared/redux/reducers";
 import { timestamp } from "../../shared/util";
-import {
-  MAIN_SETTINGS,
-  SETTINGS_OVERLAY,
-  MAIN_HOME
-} from "../../shared/constants";
 import { ipcSend } from "../rendererUtil";
-import { SETTINGS_ABOUT } from "../../shared/constants";
-import pd from "../../shared/PlayerData";
 import uxMove from "../uxMove";
 
 export default function ipcListeners(dispatcher: any): void {
@@ -40,6 +40,7 @@ export default function ipcListeners(dispatcher: any): void {
     setLoginState
   } = loginSlice.actions;
   const {
+    setArenaState,
     setLoading,
     setOffline,
     setNoLog,
@@ -182,6 +183,10 @@ export default function ipcListeners(dispatcher: any): void {
 
   ipc.on("set_update_state", (event: IpcRendererEvent, arg: any): void => {
     dispatcher(setUpdateState(arg));
+  });
+
+  ipc.on("set_arena_state", (event: IpcRendererEvent, arg: any): void => {
+    dispatcher(setArenaState(arg));
   });
 
   ipc.on("settings_updated", (): void => {


### PR DESCRIPTION
this PR attempts to solve some performance problems by preventing the auto-refresh code on the renderer process unless Arena is _NOT_ currently in a match.