### PR TITLE
Fix red numbers on positive game win loss ratio

### DIFF
--- a/src/window_main/rendererUtil.ts
+++ b/src/window_main/rendererUtil.ts
@@ -137,7 +137,7 @@ export function getWinrateClass(wr: number): string {
 export function getEventWinLossClass(wlGate: Partial<WinLossGate>): string {
   if (wlGate === undefined) return "white";
   if (wlGate.MaxWins === wlGate.CurrentWins) return "blue";
-  if (wlGate.CurrentWins && wlGate.CurrentLosses) {
+  if (wlGate.CurrentWins !== undefined && wlGate.CurrentLosses !== undefined) {
     if (wlGate.CurrentWins > wlGate.CurrentLosses) return "green";
     if (wlGate.CurrentWins * 2 > wlGate.CurrentLosses) return "orange";
   }


### PR DESCRIPTION
This fixes a small visualisation bug, best illustrated by the screenshot:
![Capture](https://user-images.githubusercontent.com/3832723/79270254-15915500-7e9e-11ea-9664-d5e72e62f136.PNG)

As `0` is falsy, the condition did not evaluate correctly, hence the check on `undefined`.