### PR TITLE
More typings

### DIFF
--- a/src/proto/GreTypes.ts
+++ b/src/proto/GreTypes.ts
@@ -2,7 +2,6 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
 // generated file, do not touch!
 import ByteBuffer from "bytebuffer";
-import { DetailsKeyType } from "../types/greInterpreter";
 
 export interface AIConfig {
   matchConfig?: MatchConfig;
@@ -1142,7 +1141,7 @@ export interface JoinQueueResponse {
 }
 
 export interface KeyValuePairInfo {
-  key?: DetailsKeyType;
+  key?: string;
   type?: KeyValuePairValueType;
   valueUint32: number[];
   valueInt32: number[];

--- a/src/proto/GreTypes.ts
+++ b/src/proto/GreTypes.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
 // generated file, do not touch!
 import ByteBuffer from "bytebuffer";
+import { DetailsKeyType } from "../types/greInterpreter";
 
 export interface AIConfig {
   matchConfig?: MatchConfig;
@@ -1141,7 +1142,7 @@ export interface JoinQueueResponse {
 }
 
 export interface KeyValuePairInfo {
-  key?: string;
+  key?: DetailsKeyType;
   type?: KeyValuePairValueType;
   valueUint32: number[];
   valueInt32: number[];

--- a/src/types/greInterpreter.ts
+++ b/src/types/greInterpreter.ts
@@ -48,7 +48,7 @@ export type DetailsSrcDestCategoryType =
   | "Destroy";
 
 export interface DetailsSrcDest {
-  category?: DetailsSrcDestCategoryType
+  category?: DetailsSrcDestCategoryType;
   zone_src: number;
   zone_dest: number;
 }
@@ -64,19 +64,17 @@ export type DetailsType =
   | DetailsAbilityGrpId
   | DetailsScry;
 
-export type AggregatedDetailsType =
-  & DetailsSrcDest
-  & DetailsSourceZone
-  & DetailsIdChange
-  & DetailsGrpId
-  & DetailsDamage
-  & DetailsLife
-  & DetailsPhaseStep
-  & DetailsAbilityGrpId
-  & DetailsScry;
+export type AggregatedDetailsType = DetailsSrcDest &
+  DetailsSourceZone &
+  DetailsIdChange &
+  DetailsGrpId &
+  DetailsDamage &
+  DetailsLife &
+  DetailsPhaseStep &
+  DetailsAbilityGrpId &
+  DetailsScry;
 
-export type DetailsKeyType =
-  keyof AggregatedDetailsType;
+export type DetailsKeyType = keyof AggregatedDetailsType;
 
 /**
  * Annotations union types

--- a/src/types/greInterpreter.ts
+++ b/src/types/greInterpreter.ts
@@ -1,56 +1,54 @@
-export interface Details {
-  category?: string;
-}
-
-export interface DetailsSourceZone extends Details {
+export interface DetailsSourceZone {
   source_zone: number;
 }
 
-export interface DetailsIdChange extends Details {
+export interface DetailsIdChange {
   orig_id: number;
   new_id: number;
 }
 
-export interface DetailsGrpId extends Details {
+export interface DetailsGrpId {
   grpid: number;
 }
 
-export interface DetailsDamage extends Details {
+export interface DetailsDamage {
   damage: number;
   type: number;
 }
 
-export interface DetailsLife extends Details {
+export interface DetailsLife {
   life: number;
 }
 
-export interface DetailsPhaseStep extends Details {
+export interface DetailsPhaseStep {
   phase: number;
   step: number;
 }
 
-export interface DetailsAbilityGrpId extends Details {
+export interface DetailsAbilityGrpId {
   abilityGrpId: number;
   index: number;
 }
 
-export interface DetailsScry extends Details {
+export interface DetailsScry {
   topIds: number | undefined;
   bottomIds: number | undefined;
 }
 
-export interface DetailsSrcDest extends Details {
-  category:
-    | "PlayLand"
-    | "Draw"
-    | "Put"
-    | "SBA_Damage"
-    | "CastSpell"
-    | "Discard"
-    | "Return"
-    | "Exile"
-    | "Countered"
-    | "Destroy";
+export type DetailsSrcDestCategoryType =
+  | "PlayLand"
+  | "Draw"
+  | "Put"
+  | "SBA_Damage"
+  | "CastSpell"
+  | "Discard"
+  | "Return"
+  | "Exile"
+  | "Countered"
+  | "Destroy";
+
+export interface DetailsSrcDest {
+  category?: DetailsSrcDestCategoryType
   zone_src: number;
   zone_dest: number;
 }
@@ -65,6 +63,20 @@ export type DetailsType =
   | DetailsPhaseStep
   | DetailsAbilityGrpId
   | DetailsScry;
+
+export type AggregatedDetailsType =
+  & DetailsSrcDest
+  & DetailsSourceZone
+  & DetailsIdChange
+  & DetailsGrpId
+  & DetailsDamage
+  & DetailsLife
+  & DetailsPhaseStep
+  & DetailsAbilityGrpId
+  & DetailsScry;
+
+export type DetailsKeyType =
+  keyof AggregatedDetailsType;
 
 /**
  * Annotations union types

--- a/src/window_background/greToClientInterpreter.ts
+++ b/src/window_background/greToClientInterpreter.ts
@@ -537,7 +537,7 @@ function annotationsSwitch(ann: Annotations, type: AnnotationType): void {
 function extractNumberValueFromKVP(obj: KeyValuePairInfo): number | undefined {
   const numberArray = extractNumberArrayFromKVP(obj);
 
-  return numberArray.length > 0 ? numberArray[0] : undefined;
+  return numberArray.length === 1 ? numberArray[0] : undefined;
 }
 
 function extractNumberArrayFromKVP(obj: KeyValuePairInfo): number[] {
@@ -562,7 +562,7 @@ function extractNumberArrayFromKVP(obj: KeyValuePairInfo): number[] {
 function extractBooleanValueFromKVP(
   obj: KeyValuePairInfo
 ): boolean | undefined {
-  return obj.valueBool.length > 0 ? obj.valueBool[0] : undefined;
+  return obj.valueBool.length === 1 ? obj.valueBool[0] : undefined;
 }
 
 function extractBooleanArrayFromKVP(obj: KeyValuePairInfo): boolean[] {
@@ -570,7 +570,7 @@ function extractBooleanArrayFromKVP(obj: KeyValuePairInfo): boolean[] {
 }
 
 function extractStringValueFromKVP(obj: KeyValuePairInfo): string | undefined {
-  return obj.valueString.length > 0 ? obj.valueString[0] : undefined;
+  return obj.valueString.length === 1 ? obj.valueString[0] : undefined;
 }
 
 function extractStringArrayFromKVP(obj: KeyValuePairInfo): string[] {

--- a/src/window_background/greToClientInterpreter.ts
+++ b/src/window_background/greToClientInterpreter.ts
@@ -12,10 +12,9 @@ import {
   Annotations,
   GameObject,
   //GameObjectTypeAbility,
-  DetailsType,
-  DetailsPhaseStep,
   AggregatedDetailsType,
-  DetailsSrcDestCategoryType
+  DetailsSrcDestCategoryType,
+  DetailsKeyType
 } from "../types/greInterpreter";
 
 import {
@@ -573,56 +572,57 @@ function keyValuePair(kvp: KeyValuePairInfo[]): AggregatedDetailsType {
   };
 
   for (const obj of kvp) {
-    switch (obj.key) {
+    const key = obj.key as DetailsKeyType | undefined;
+    switch (key) {
       case undefined:
         break;
       case "abilityGrpId":
-        aggregate[obj.key] = extractNumberFromKVP(obj) ?? 0;
+        aggregate[key] = extractNumberFromKVP(obj) ?? 0;
         break;
       case "bottomIds":
-        aggregate[obj.key] = extractNumberFromKVP(obj);
+        aggregate[key] = extractNumberFromKVP(obj);
         break;
       case "category":
-        aggregate[obj.key] = obj.valueString[0] as DetailsSrcDestCategoryType;
+        aggregate[key] = obj.valueString[0] as DetailsSrcDestCategoryType;
         break;
       case "damage":
-        aggregate[obj.key] = extractNumberFromKVP(obj) ?? 0;
+        aggregate[key] = extractNumberFromKVP(obj) ?? 0;
         break;
       case "grpid":
-        aggregate[obj.key] = extractNumberFromKVP(obj) ?? 0;
+        aggregate[key] = extractNumberFromKVP(obj) ?? 0;
         break;
       case "index":
-        aggregate[obj.key] = extractNumberFromKVP(obj) ?? 0;
+        aggregate[key] = extractNumberFromKVP(obj) ?? 0;
         break;
       case "life":
-        aggregate[obj.key] = extractNumberFromKVP(obj) ?? 0;
+        aggregate[key] = extractNumberFromKVP(obj) ?? 0;
         break;
       case "new_id":
-        aggregate[obj.key] = extractNumberFromKVP(obj) ?? 0;
+        aggregate[key] = extractNumberFromKVP(obj) ?? 0;
         break;
       case "orig_id":
-        aggregate[obj.key] = extractNumberFromKVP(obj) ?? 0;
+        aggregate[key] = extractNumberFromKVP(obj) ?? 0;
         break;
       case "phase":
-        aggregate[obj.key] = extractNumberFromKVP(obj) ?? 0;
+        aggregate[key] = extractNumberFromKVP(obj) ?? 0;
         break;
       case "source_zone":
-        aggregate[obj.key] = extractNumberFromKVP(obj) ?? 0;
+        aggregate[key] = extractNumberFromKVP(obj) ?? 0;
         break;
       case "step":
-        aggregate[obj.key] = extractNumberFromKVP(obj) ?? 0;
+        aggregate[key] = extractNumberFromKVP(obj) ?? 0;
         break;
       case "topIds":
-        aggregate[obj.key] = extractNumberFromKVP(obj);
+        aggregate[key] = extractNumberFromKVP(obj);
         break;
       case "type":
-        aggregate[obj.key] = extractNumberFromKVP(obj) ?? 0;
+        aggregate[key] = extractNumberFromKVP(obj) ?? 0;
         break;
       case "zone_dest":
-        aggregate[obj.key] = extractNumberFromKVP(obj) ?? 0;
+        aggregate[key] = extractNumberFromKVP(obj) ?? 0;
         break;
       case "zone_src":
-        aggregate[obj.key] = extractNumberFromKVP(obj) ?? 0;
+        aggregate[key] = extractNumberFromKVP(obj) ?? 0;
         break;
     }
   }

--- a/src/window_background/greToClientInterpreter.ts
+++ b/src/window_background/greToClientInterpreter.ts
@@ -534,25 +534,33 @@ function annotationsSwitch(ann: Annotations, type: AnnotationType): void {
   }
 }
 
-function extractNumberFromKVP(obj: KeyValuePairInfo): number | undefined {
+function extractValueFromKVP(
+  obj: KeyValuePairInfo
+): number | string | boolean | number[] | string[] | boolean[] | undefined {
   switch (obj.type) {
     case "KeyValuePairValueType_uint32":
-      return obj.valueUint32[0];
+      return obj.valueUint32.length == 1 ? obj.valueUint32[0] : obj.valueUint32;
     case "KeyValuePairValueType_int32":
-      return obj.valueInt32[0];
+      return obj.valueInt32.length == 1 ? obj.valueInt32[0] : obj.valueInt32;
     case "KeyValuePairValueType_uint64":
-      return obj.valueUint64[0];
+      return obj.valueUint64.length == 1 ? obj.valueUint64[0] : obj.valueUint64;
     case "KeyValuePairValueType_int64":
-      return obj.valueInt64[0];
+      return obj.valueInt64.length == 1 ? obj.valueInt64[0] : obj.valueInt64;
     case "KeyValuePairValueType_float":
-      return obj.valueFloat[0];
+      return obj.valueFloat.length == 1 ? obj.valueFloat[0] : obj.valueFloat;
     case "KeyValuePairValueType_double":
-      return obj.valueDouble[0];
+      return obj.valueDouble.length == 1 ? obj.valueDouble[0] : obj.valueDouble;
+    case "KeyValuePairValueType_string":
+      return obj.valueString.length == 1 ? obj.valueString[0] : obj.valueString;
+    case "KeyValuePairValueType_bool":
+      return obj.valueBool.length == 1 ? obj.valueBool[0] : obj.valueBool;
+    default:
+      return undefined;
   }
 }
 
 function keyValuePair(kvp: KeyValuePairInfo[]): AggregatedDetailsType {
-  let aggregate: AggregatedDetailsType = {
+  const aggregate: AggregatedDetailsType = {
     abilityGrpId: 0,
     bottomIds: undefined,
     category: undefined,
@@ -577,52 +585,26 @@ function keyValuePair(kvp: KeyValuePairInfo[]): AggregatedDetailsType {
       case undefined:
         break;
       case "abilityGrpId":
-        aggregate[key] = extractNumberFromKVP(obj) ?? 0;
+      case "grpid":
+      case "damage":
+      case "index":
+      case "life":
+      case "new_id":
+      case "orig_id":
+      case "phase":
+      case "source_zone":
+      case "step":
+      case "type":
+      case "zone_dest":
+      case "zone_src":
+        aggregate[key] = (extractValueFromKVP(obj) as number) ?? 0;
         break;
       case "bottomIds":
-        aggregate[key] = extractNumberFromKVP(obj);
+      case "topIds":
+        aggregate[key] = extractValueFromKVP(obj) as number;
         break;
       case "category":
-        aggregate[key] = obj.valueString[0] as DetailsSrcDestCategoryType;
-        break;
-      case "damage":
-        aggregate[key] = extractNumberFromKVP(obj) ?? 0;
-        break;
-      case "grpid":
-        aggregate[key] = extractNumberFromKVP(obj) ?? 0;
-        break;
-      case "index":
-        aggregate[key] = extractNumberFromKVP(obj) ?? 0;
-        break;
-      case "life":
-        aggregate[key] = extractNumberFromKVP(obj) ?? 0;
-        break;
-      case "new_id":
-        aggregate[key] = extractNumberFromKVP(obj) ?? 0;
-        break;
-      case "orig_id":
-        aggregate[key] = extractNumberFromKVP(obj) ?? 0;
-        break;
-      case "phase":
-        aggregate[key] = extractNumberFromKVP(obj) ?? 0;
-        break;
-      case "source_zone":
-        aggregate[key] = extractNumberFromKVP(obj) ?? 0;
-        break;
-      case "step":
-        aggregate[key] = extractNumberFromKVP(obj) ?? 0;
-        break;
-      case "topIds":
-        aggregate[key] = extractNumberFromKVP(obj);
-        break;
-      case "type":
-        aggregate[key] = extractNumberFromKVP(obj) ?? 0;
-        break;
-      case "zone_dest":
-        aggregate[key] = extractNumberFromKVP(obj) ?? 0;
-        break;
-      case "zone_src":
-        aggregate[key] = extractNumberFromKVP(obj) ?? 0;
+        aggregate[key] = extractValueFromKVP(obj) as DetailsSrcDestCategoryType;
         break;
     }
   }

--- a/src/window_background/greToClientInterpreter.ts
+++ b/src/window_background/greToClientInterpreter.ts
@@ -534,29 +534,47 @@ function annotationsSwitch(ann: Annotations, type: AnnotationType): void {
   }
 }
 
-function extractValueFromKVP(
-  obj: KeyValuePairInfo
-): number | string | boolean | number[] | string[] | boolean[] | undefined {
+function extractNumberValueFromKVP(obj: KeyValuePairInfo): number | undefined {
+  const numberArray = extractNumberArrayFromKVP(obj);
+
+  return numberArray.length > 0 ? numberArray[0] : undefined;
+}
+
+function extractNumberArrayFromKVP(obj: KeyValuePairInfo): number[] {
   switch (obj.type) {
     case "KeyValuePairValueType_uint32":
-      return obj.valueUint32.length == 1 ? obj.valueUint32[0] : obj.valueUint32;
+      return obj.valueUint32;
     case "KeyValuePairValueType_int32":
-      return obj.valueInt32.length == 1 ? obj.valueInt32[0] : obj.valueInt32;
+      return obj.valueInt32;
     case "KeyValuePairValueType_uint64":
-      return obj.valueUint64.length == 1 ? obj.valueUint64[0] : obj.valueUint64;
+      return obj.valueUint64;
     case "KeyValuePairValueType_int64":
-      return obj.valueInt64.length == 1 ? obj.valueInt64[0] : obj.valueInt64;
+      return obj.valueInt64;
     case "KeyValuePairValueType_float":
-      return obj.valueFloat.length == 1 ? obj.valueFloat[0] : obj.valueFloat;
+      return obj.valueFloat;
     case "KeyValuePairValueType_double":
-      return obj.valueDouble.length == 1 ? obj.valueDouble[0] : obj.valueDouble;
-    case "KeyValuePairValueType_string":
-      return obj.valueString.length == 1 ? obj.valueString[0] : obj.valueString;
-    case "KeyValuePairValueType_bool":
-      return obj.valueBool.length == 1 ? obj.valueBool[0] : obj.valueBool;
+      return obj.valueDouble;
     default:
-      return undefined;
+      return [];
   }
+}
+
+function extractBooleanValueFromKVP(
+  obj: KeyValuePairInfo
+): boolean | undefined {
+  return obj.valueBool.length > 0 ? obj.valueBool[0] : undefined;
+}
+
+function extractBooleanArrayFromKVP(obj: KeyValuePairInfo): boolean[] {
+  return obj.valueBool;
+}
+
+function extractStringValueFromKVP(obj: KeyValuePairInfo): string | undefined {
+  return obj.valueString.length > 0 ? obj.valueString[0] : undefined;
+}
+
+function extractStringArrayFromKVP(obj: KeyValuePairInfo): string[] {
+  return obj.valueString;
 }
 
 function keyValuePair(kvp: KeyValuePairInfo[]): AggregatedDetailsType {
@@ -597,14 +615,16 @@ function keyValuePair(kvp: KeyValuePairInfo[]): AggregatedDetailsType {
       case "type":
       case "zone_dest":
       case "zone_src":
-        aggregate[key] = (extractValueFromKVP(obj) as number) ?? 0;
+        aggregate[key] = extractNumberValueFromKVP(obj) ?? 0;
         break;
       case "bottomIds":
       case "topIds":
-        aggregate[key] = extractValueFromKVP(obj) as number;
+        aggregate[key] = extractNumberValueFromKVP(obj);
         break;
       case "category":
-        aggregate[key] = extractValueFromKVP(obj) as DetailsSrcDestCategoryType;
+        aggregate[key] = extractStringValueFromKVP(
+          obj
+        ) as DetailsSrcDestCategoryType;
         break;
     }
   }

--- a/src/window_background/greToClientInterpreter.ts
+++ b/src/window_background/greToClientInterpreter.ts
@@ -86,14 +86,14 @@ function isAnnotationProcessed(id: number): boolean {
   return anns.includes(id);
 }
 
-const actionLogGenerateLink = function (grpId: number): string {
+const actionLogGenerateLink = function(grpId: number): string {
   const card = db.card(grpId);
   return card
     ? '<log-card id="' + grpId + '">' + card.name + "</log-card>"
     : "";
 };
 
-const actionLogGenerateAbilityLink = function (abId: number): string {
+const actionLogGenerateAbilityLink = function(abId: number): string {
   return `<log-ability id="${abId}">ability</log-ability>`;
 };
 
@@ -132,14 +132,14 @@ function instanceIdToObject(instanceID: number): GameObject {
   throw new NoInstanceException(orig, instanceID, instance);
 }
 
-const AnnotationType_ObjectIdChanged = function (ann: Annotations): void {
+const AnnotationType_ObjectIdChanged = function(ann: Annotations): void {
   if (ann.type !== "AnnotationType_ObjectIdChanged") return;
   //let newObj = cloneDeep(getGameObject(details.orig_id));
   //getGameObject(details.new_id) = newObj;
   setIdChange(ann.details);
 };
 
-const AnnotationType_ZoneTransfer = function (ann: Annotations): void {
+const AnnotationType_ZoneTransfer = function(ann: Annotations): void {
   if (ann.type !== "AnnotationType_ZoneTransfer") return;
 
   // A player played a land
@@ -322,7 +322,7 @@ const AnnotationType_ZoneTransfer = function (ann: Annotations): void {
   }
 };
 
-const AnnotationType_AbilityInstanceCreated = function (ann: Annotations): void {
+const AnnotationType_AbilityInstanceCreated = function(ann: Annotations): void {
   if (ann.type !== "AnnotationType_AbilityInstanceCreated") return;
   /*
   const affected = ann.affectedIds[0];
@@ -346,7 +346,7 @@ const AnnotationType_AbilityInstanceCreated = function (ann: Annotations): void 
   */
 };
 
-const AnnotationType_ResolutionStart = function (ann: Annotations): void {
+const AnnotationType_ResolutionStart = function(ann: Annotations): void {
   if (ann.type !== "AnnotationType_ResolutionStart") return;
   const affected = instanceIdToObject(ann.affectedIds[0]);
   const grpId = ann.details.grpid;
@@ -364,7 +364,7 @@ const AnnotationType_ResolutionStart = function (ann: Annotations): void {
   }
 };
 
-const AnnotationType_DamageDealt = function (ann: Annotations): void {
+const AnnotationType_DamageDealt = function(ann: Annotations): void {
   if (ann.type !== "AnnotationType_DamageDealt") return;
   let recipient = "";
   if (ann.affectedIds[0] < 5) {
@@ -387,7 +387,7 @@ const AnnotationType_DamageDealt = function (ann: Annotations): void {
   );
 };
 
-const AnnotationType_ModifiedLife = function (ann: Annotations): void {
+const AnnotationType_ModifiedLife = function(ann: Annotations): void {
   if (ann.type !== "AnnotationType_ModifiedLife") return;
   const players = globalStore.currentMatch.players;
   const affected = ann.affectedIds[0];
@@ -401,7 +401,7 @@ const AnnotationType_ModifiedLife = function (ann: Annotations): void {
   );
 };
 
-const AnnotationType_TargetSpec = function (ann: Annotations): void {
+const AnnotationType_TargetSpec = function(ann: Annotations): void {
   if (ann.type !== "AnnotationType_TargetSpec") return;
   let target;
   if (ann.affectedIds[0] < 5) {
@@ -425,7 +425,7 @@ const AnnotationType_TargetSpec = function (ann: Annotations): void {
   actionLog(seat, globals.logTime, `${text} targetted ${target}`);
 };
 
-const AnnotationType_Scry = function (ann: Annotations): void {
+const AnnotationType_Scry = function(ann: Annotations): void {
   if (ann.type !== "AnnotationType_Scry") return;
   // REVIEW SCRY ANNOTATION
   let affector = ann.affectorId;
@@ -482,7 +482,7 @@ const AnnotationType_Scry = function (ann: Annotations): void {
   }
 };
 
-const AnnotationType_CardRevealed = function (ann: Annotations): void {
+const AnnotationType_CardRevealed = function(ann: Annotations): void {
   const playerSeat = globalStore.currentMatch.playerSeat;
   if (ann.type !== "AnnotationType_CardRevealed") return;
   if (!ann.ignoreForSeatIds.includes(playerSeat)) return;
@@ -864,9 +864,9 @@ function checkTurnDiff(turnInfo: TurnInfo): void {
       -1,
       globals.logTime,
       getNameBySeat(turnInfo.activePlayer || 0) +
-      "'s turn begin. (#" +
-      turnInfo.turnNumber +
-      ")"
+        "'s turn begin. (#" +
+        turnInfo.turnNumber +
+        ")"
     );
   }
 
@@ -909,8 +909,8 @@ const GREMessageType_GameStateMessage = (msg: GREToClientMessage): void => {
       if (gameState.gameInfo.matchID) {
         setMatchId(
           gameState.gameInfo.matchID +
-          "-" +
-          globals.store.getState().playerdata.arenaId
+            "-" +
+            globals.store.getState().playerdata.arenaId
         );
       }
       if (gameState.gameInfo.stage == "GameStage_GameOver") {


### PR DESCRIPTION
This in an attempt at removing a forced cast to `any`, that was previously necessary.

Multiple things going on here:

- `Details` only had a single optional property that was never used. Removed the type.
- Introduced some helper type (`DetailsSrcDestCategoryType`) to help with later typings
- Introduced an intersection type of all possible `DetailsXYZ` types, possibly making the union type obsolete. I've left it in for now though.
- Now to the real thing: With the intersection type in place, it is possible to switch over all possible keys in all possible `DetailsXYZ` types. In a given switch case, the compiler can infer what property of the intersection type he is looking at. In can be in any of the properties in the `KeyValuePairInfo` though, so use the helper method to extract the value from one of them and fall back to `0` if that fails.

Admittedly, it has become a lot more verbose. But it is type safe :)

I've not been able to run checks or prettier locally before committing, npm playing its tricks on me...