### PR TITLE
Remove cards on bottom

### DIFF
--- a/src/shared-store/currentMatchStore.ts
+++ b/src/shared-store/currentMatchStore.ts
@@ -31,6 +31,7 @@ export const matchStateObject = {
   currentDeck: new Deck(),
   originalDeck: new Deck(),
   cardsLeft: new Deck(),
+  cardsBottom: [] as number[],
   // Info
   player: {} as InternalPlayer,
   players: [] as PlayerInfo[],
@@ -210,6 +211,10 @@ export function addCardCast(arg: CardCast): void {
 
 export function clearCardsCast(): void {
   globalStore.currentMatch.cardsCast = [];
+}
+
+export function setCardsBottom(arg: number[]): void {
+  globalStore.currentMatch.cardsBottom = arg;
 }
 
 export function setInitialLibraryInstanceIds(arg: number[]): void {

--- a/src/window_background/forceDeckUpdate.ts
+++ b/src/window_background/forceDeckUpdate.ts
@@ -35,6 +35,7 @@ const forceDeckUpdate = function(removeUsed = true): void {
   let typeLan = 0;
   const currentMatch = globalStore.currentMatch;
   const playerCardsUsed = currentMatch.player.cardsUsed;
+  const playerCardsBottom = currentMatch.cardsBottom;
   const playerCardsLeft = globalStore.currentMatch.currentDeck.clone();
 
   if (globals.debugLog || !globals.firstPass) {
@@ -53,6 +54,12 @@ const forceDeckUpdate = function(removeUsed = true): void {
         playerCardsLeft.getMainboard().remove(grpId, 1);
       });
     }
+    // Remove cards that were put on the bottom
+    playerCardsBottom.forEach((grpId: number) => {
+      playerCardsLeft.getMainboard().remove(grpId, 1);
+    });
+    cardsleft -= playerCardsBottom.length;
+
     const main = playerCardsLeft.getMainboard();
     //main.addProperty("chance", card =>
     main.addChance((card: CardObject) =>

--- a/src/window_background/forceDeckUpdate.ts
+++ b/src/window_background/forceDeckUpdate.ts
@@ -152,12 +152,20 @@ const forceDeckUpdate = function(removeUsed = true): void {
     chancesObj.cardsLeft = cardsleft;
 
     setCardsOdds(chancesObj);
+
+    // Add that that were put on the bottom again, so it
+    // doesnt affect the display of the decklist
+    playerCardsBottom.forEach((grpId: number) => {
+      playerCardsLeft.getMainboard().add(grpId, 1);
+    });
+    cardsleft += playerCardsBottom.length;
   } else {
     const main = playerCardsLeft.getMainboard();
     main.addChance(() => 1);
     const chancesObj = new Chances();
     setCardsOdds(chancesObj);
   }
+
   globalStore.currentMatch.cardsLeft = playerCardsLeft;
 };
 

--- a/src/window_background/greToClientInterpreter.ts
+++ b/src/window_background/greToClientInterpreter.ts
@@ -51,7 +51,8 @@ import {
   resetCurrentGame,
   setHandDrawn,
   setGameBeginTime,
-  setGameWinner
+  setGameWinner,
+  setCardsBottom
 } from "../shared-store/currentMatchStore";
 
 function changePriority(previous: number, current: number, time: number): void {
@@ -71,6 +72,20 @@ function getGameObject(id: number): GameObject {
 
 function getZone(id: number): ZoneInfo {
   return globalStore.currentMatch.zones[id];
+}
+
+function getZoneByType(
+  type: ZoneInfo["type"],
+  seat: number
+): ZoneInfo | undefined {
+  const currentMatch = globalStore.currentMatch;
+  let ret = undefined;
+  Object.values(currentMatch.zones).forEach(zone => {
+    if (zone.type == type && zone.ownerSeatId == seat) {
+      ret = zone;
+    }
+  });
+  return ret;
 }
 
 function getAllAnnotations(): AnnotationInfo[] {
@@ -1004,5 +1019,25 @@ export function GREMessage(message: GREToClientMessage, time: Date): void {
   //globals.currentMatch.cardTypesByZone = getCardsTypeZone();
   setPlayerCardsUsed(getPlayerUsedCards());
   setOppCardsUsed(getOppUsedCards());
+
+  const zoneLibrary = getZoneByType(
+    "ZoneType_Library",
+    globalStore.currentMatch.playerSeat
+  );
+  if (zoneLibrary) {
+    const iids = zoneLibrary.objectInstanceIds;
+    let i = iids.length - 1;
+    const onBottom = [];
+    while (i > 0) {
+      const instance = getGameObject(iids[i])?.grpId;
+      if (instance) {
+        onBottom.push(instance);
+        i--;
+      } else {
+        i = 0;
+      }
+    }
+    setCardsBottom(onBottom);
+  }
   //globals.currentMatch.opponent.cards.concat(getOppUsedCards())
 }

--- a/src/window_main/tabs/ExploreTab.tsx
+++ b/src/window_main/tabs/ExploreTab.tsx
@@ -221,7 +221,7 @@ function ExploreFilters(props: ExploreFiltersProps): JSX.Element {
   const getFirstEvent = useCallback(
     (filter: string): string => {
       let ret = "%%";
-      const i = 0;
+      let i = 0;
       while (ret.startsWith("%%")) {
         ret = getFilterEvents({
           ...filters,


### PR DESCRIPTION
A little thing that was requested many times, scryed cards, or rather, cards that are knowingly on the bottom of the library, should be ignored from the cards odds calculation.

![image](https://user-images.githubusercontent.com/4711391/80283550-bda0ec80-86ee-11ea-83a8-c3cdf888f83c.png)

In the example I scryed to the bottom: An Island, a Temple of Mystery and a Mystical Dispute.
The only issue is that these cards are entirely removed from the cards left in the library rather than just the odds calculation (we probabaly need to add a separate store for the odds)