### PR TITLE
Adjust optional property

### DIFF
--- a/src/proto/GreTypes.ts
+++ b/src/proto/GreTypes.ts
@@ -102,7 +102,7 @@ export interface AnnotationInfo {
   affectorId?: number;
   affectedIds: number[];
   type: AnnotationType[];
-  details: KeyValuePairInfo[];
+  details?: KeyValuePairInfo[];
   allowRedaction?: boolean;
   ignoreForSeatIds: number[];
   redactAffected?: boolean;


### PR DESCRIPTION
Just a miniscule fix adjusting the type according to [this line](https://github.com/Manuel-777/MTG-Arena-Tool/blob/548031d6b742444115a93f0a839809ad045cb8b2/src/window_background/greToClientInterpreter.ts#L657) - mark the property as maybe undefined.