### PR TITLE
Fix negative wildcard input

### DIFF
--- a/src/window_main/components/misc/Input.tsx
+++ b/src/window_main/components/misc/Input.tsx
@@ -10,7 +10,7 @@ interface InputProps {
   title?: string;
   autocomplete?: string;
   callback?: (value: string) => void;
-  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  validate?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 function InputBase(
@@ -32,8 +32,8 @@ function InputBase(
 
   const onChange = React.useCallback(
     (e: React.ChangeEvent<HTMLInputElement>): void => {
-      if (props.onChange) {
-        props.onChange(e);
+      if (props.validate) {
+        props.validate(e);
       }
       setCurrentValue(e.target.value);
     },

--- a/src/window_main/components/misc/Input.tsx
+++ b/src/window_main/components/misc/Input.tsx
@@ -10,6 +10,7 @@ interface InputProps {
   title?: string;
   autocomplete?: string;
   callback?: (value: string) => void;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 function InputBase(
@@ -31,6 +32,9 @@ function InputBase(
 
   const onChange = React.useCallback(
     (e: React.ChangeEvent<HTMLInputElement>): void => {
+      if (props.onChange) {
+        props.onChange(e);
+      }
       setCurrentValue(e.target.value);
     },
     []

--- a/src/window_main/tabs/ExploreTab.tsx
+++ b/src/window_main/tabs/ExploreTab.tsx
@@ -305,7 +305,7 @@ function ExploreFilters(props: ExploreFiltersProps): JSX.Element {
           containerClassName="input_container_explore explore_wc_input"
           value={filters.filterWCC}
           placeholder=""
-          onChange={validateWildcardValues}
+          validate={validateWildcardValues}
           callback={(value: string): void =>
             updateFilters({
               ...filters,
@@ -319,7 +319,7 @@ function ExploreFilters(props: ExploreFiltersProps): JSX.Element {
           containerClassName="input_container_explore explore_wc_input"
           value={filters.filterWCU}
           placeholder=""
-          onChange={validateWildcardValues}
+          validate={validateWildcardValues}
           callback={(value: string): void =>
             updateFilters({
               ...filters,
@@ -333,7 +333,7 @@ function ExploreFilters(props: ExploreFiltersProps): JSX.Element {
           containerClassName="input_container_explore explore_wc_input"
           value={filters.filterWCR}
           placeholder=""
-          onChange={validateWildcardValues}
+          validate={validateWildcardValues}
           callback={(value: string): void =>
             updateFilters({
               ...filters,
@@ -347,7 +347,7 @@ function ExploreFilters(props: ExploreFiltersProps): JSX.Element {
           containerClassName="input_container_explore explore_wc_input"
           value={filters.filterWCM}
           placeholder=""
-          onChange={validateWildcardValues}
+          validate={validateWildcardValues}
           callback={(value: string): void =>
             updateFilters({
               ...filters,

--- a/src/window_main/tabs/ExploreTab.tsx
+++ b/src/window_main/tabs/ExploreTab.tsx
@@ -234,6 +234,14 @@ function ExploreFilters(props: ExploreFiltersProps): JSX.Element {
     [filters, getFilterEvents]
   );
 
+  function validateWildcardValues(
+    e: React.ChangeEvent<HTMLInputElement>
+  ): void {
+    if (parseInt(e.target.value) < 0) {
+      e.target.value = "";
+    }
+  }
+
   return (
     <div className="explore_buttons_container">
       <div className="explore_buttons_row explore_buttons_top">
@@ -297,6 +305,7 @@ function ExploreFilters(props: ExploreFiltersProps): JSX.Element {
           containerClassName="input_container_explore explore_wc_input"
           value={filters.filterWCC}
           placeholder=""
+          onChange={validateWildcardValues}
           callback={(value: string): void =>
             updateFilters({
               ...filters,
@@ -310,6 +319,7 @@ function ExploreFilters(props: ExploreFiltersProps): JSX.Element {
           containerClassName="input_container_explore explore_wc_input"
           value={filters.filterWCU}
           placeholder=""
+          onChange={validateWildcardValues}
           callback={(value: string): void =>
             updateFilters({
               ...filters,
@@ -323,6 +333,7 @@ function ExploreFilters(props: ExploreFiltersProps): JSX.Element {
           containerClassName="input_container_explore explore_wc_input"
           value={filters.filterWCR}
           placeholder=""
+          onChange={validateWildcardValues}
           callback={(value: string): void =>
             updateFilters({
               ...filters,
@@ -334,14 +345,15 @@ function ExploreFilters(props: ExploreFiltersProps): JSX.Element {
         <Input
           type="number"
           containerClassName="input_container_explore explore_wc_input"
-          value={filters.filterWCM}
+          value={parseInt(filters.filterWCM) < 0 ? "" : filters.filterWCM}
           placeholder=""
-          callback={(value: string): void =>
+          onChange={validateWildcardValues}
+          callback={(value: string): void => {
             updateFilters({
               ...filters,
               filterWCM: value
-            })
-          }
+            });
+          }}
         />
       </div>
       <div className="explore_buttons_row explore_buttons_bottom">

--- a/src/window_main/tabs/ExploreTab.tsx
+++ b/src/window_main/tabs/ExploreTab.tsx
@@ -345,7 +345,7 @@ function ExploreFilters(props: ExploreFiltersProps): JSX.Element {
         <Input
           type="number"
           containerClassName="input_container_explore explore_wc_input"
-          value={parseInt(filters.filterWCM) < 0 ? "" : filters.filterWCM}
+          value={filters.filterWCM}
           placeholder=""
           onChange={validateWildcardValues}
           callback={(value: string): void => {

--- a/src/window_main/tabs/ExploreTab.tsx
+++ b/src/window_main/tabs/ExploreTab.tsx
@@ -348,12 +348,12 @@ function ExploreFilters(props: ExploreFiltersProps): JSX.Element {
           value={filters.filterWCM}
           placeholder=""
           onChange={validateWildcardValues}
-          callback={(value: string): void => {
+          callback={(value: string): void =>
             updateFilters({
               ...filters,
               filterWCM: value
-            });
-          }}
+            })
+          }
         />
       </div>
       <div className="explore_buttons_row explore_buttons_bottom">


### PR DESCRIPTION
This attempts to fix #994.

This introduces an optional property `onChange` that can be set on custom `Input` elements. If it is set, it will be executed before the original hook logic. The property is optional on the one hand to not break existing implementations, on the other hand because it seems not to be necessary in most cases.

With `onChange` in place, the wildcard input fields on the explore tab can validate their values and fall back to an empty value in case a non-valid value (read here: a negative value) has been entered.