### PR TITLE
Cards seen by game

### DIFF
--- a/src/types/currentMatch.ts
+++ b/src/types/currentMatch.ts
@@ -231,5 +231,6 @@ export interface MatchGameStats {
   libraryLands: number[];
   sideboardChanges: DeckChanges;
   deck: InternalDeck;
+  cardsSeen: number[];
   onThePlay: number;
 }

--- a/src/types/match.ts
+++ b/src/types/match.ts
@@ -1,6 +1,7 @@
 import Deck from "../shared/deck";
 import { InternalDeck } from "./Deck";
 import { Result } from "./greInterpreter";
+import { MatchGameStats } from "./currentMatch";
 
 interface ReservedPlayer {
   userId: string;
@@ -108,7 +109,7 @@ export interface InternalMatch {
   onThePlay: number;
   eventId: string;
   bestOf: number;
-  gameStats: any[];
+  gameStats: MatchGameStats[];
   toolVersion: number;
   toolRunFromSource: boolean;
   id: string;

--- a/src/window_background/getMatchGameStats.ts
+++ b/src/window_background/getMatchGameStats.ts
@@ -42,6 +42,7 @@ export default function getMatchGameStats(): void {
       added: [],
       removed: []
     },
+    cardsSeen: currentMatch.opponent.cardsUsed,
     deck: {
       id: "",
       commandZoneGRPIds: [],

--- a/src/window_main/components/match-view/MatchView.tsx
+++ b/src/window_main/components/match-view/MatchView.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useCallback } from "react";
 import fs from "fs";
 import path from "path";
 import { InternalMatch, InternalPlayer } from "../../../types/match";
@@ -18,6 +18,7 @@ import { useDispatch } from "react-redux";
 import { reduxAction } from "../../../shared-redux/sharedRedux";
 import { IPC_NONE } from "../../../shared/constants";
 import { getMatch } from "../../../shared-store";
+import { MatchGameStats } from "../../../types/currentMatch";
 
 interface MatchViewProps {
   match: InternalMatch;
@@ -102,11 +103,12 @@ export function MatchView(props: MatchViewProps): JSX.Element {
                 player={match.opponent}
                 deck={oppDeck}
                 eventId={match.eventId}
+                match={match}
                 won={match.opponent.win > match.player.win}
               />
             </div>
             <div>
-              {match.gameStats.map((stats: any, index: number) => {
+              {match.gameStats.map((stats: MatchGameStats, index: number) => {
                 if (stats)
                   return (
                     <GameStats
@@ -141,10 +143,28 @@ interface SeatProps {
   eventId: string;
   player: InternalPlayer;
   won: boolean;
+  match?: InternalMatch;
 }
 
 function Seat(props: SeatProps): JSX.Element {
-  const { deck, player, eventId, won } = props;
+  const { player, eventId, won, match } = props;
+
+  // v4.1.0: Introduced by-game cards seen
+  const gameDetails = match && match.toolVersion >= 262400;
+  const [gameSeen, setGameSeen] = useState(0);
+
+  const deck =
+    gameDetails && match
+      ? new Deck({}, match.gameStats[gameSeen].cardsSeen)
+      : props.deck;
+
+  const gamePrev = useCallback(() => {
+    if (gameSeen > 0) setGameSeen(gameSeen - 1);
+  }, [gameSeen]);
+  const gameNext = useCallback(() => {
+    if (match && gameSeen < match.gameStats.length - 1)
+      setGameSeen(gameSeen + 1);
+  }, [gameSeen, match]);
 
   const isLimited = db.limited_ranked_events.includes(eventId);
   const clickAdd = (): void => {
@@ -179,14 +199,25 @@ function Seat(props: SeatProps): JSX.Element {
         <Button text="Add to Decks" onClick={clickAdd} />
         <Button text="Export to Arena" onClick={clickArena} />
         <Button text="Export to .txt" onClick={clickTxt} />
-        <DeckList deck={deck} showWildcards={true} />
+        {gameDetails && match ? (
+          <>
+            <div className="game_swap">
+              <div className="game_prev" onClick={gamePrev} />
+              <div>Seen in game {gameSeen + 1}</div>
+              <div className="game_next" onClick={gameNext} />
+            </div>
+            <DeckList deck={deck} showWildcards={true} />
+          </>
+        ) : (
+          <DeckList deck={deck} showWildcards={true} />
+        )}
       </div>
     </>
   );
 }
 
 interface GameStatsProps {
-  game: any;
+  game: MatchGameStats;
   index: number;
 }
 

--- a/src/window_main/index.css
+++ b/src/window_main/index.css
@@ -4572,3 +4572,33 @@ a:hover {
     height: calc(100% - 112px);
     overflow: scroll;
 }
+
+
+.game_prev {
+    cursor: pointer;
+    background: url(../images/prev.png) no-repeat center;
+    opacity: 0.5;
+    width: 24px;
+    height: 24px;
+    -webkit-transition: all .2s ease-in;
+}
+
+.game_swap {
+    color: var(--color-light);
+    display: flex;
+    justify-content: space-around;
+    margin: 4px 0;
+}
+
+.game_next {
+    cursor: pointer;
+    background: url(../images/next.png) no-repeat center;
+    opacity: 0.5;
+    width: 24px;
+    height: 24px;
+    -webkit-transition: all .2s ease-in;
+}
+
+.game_prev:hover, .game_next:hover {
+    opacity: 1;
+}


### PR DESCRIPTION
Displays cards seen separated by game number in match history view.

It is coded to work only after `v4.1.0`

![image](https://user-images.githubusercontent.com/4711391/80509431-c9d7b480-894f-11ea-8692-29dc855da2d7.png)
