### PR TITLE
Fix On the Play text: it was always Draw for g1

### DIFF
--- a/src/window_main/components/misc/ResultDetails.tsx
+++ b/src/window_main/components/misc/ResultDetails.tsx
@@ -46,7 +46,7 @@ export default function ResultDetails(props: ResultDetailsProps): JSX.Element {
   let g1Title;
   if (match.gameStats[0]) {
     g1Title =
-      (g2OnThePlay ? "On the Play, " : "On the Draw, ") +
+      (g1OnThePlay ? "On the Play, " : "On the Draw, ") +
       (match.gameStats[0].win ? "Win" : "Loss");
   } else {
     g1Title = "Not played";


### PR DESCRIPTION
This PR fix a probably wrong test for caption text in History for game 1: in every situation it displayed the "On the Draw" text.

I also would expect for `g2OnThePlay` and `g3OnThePlay` variables to not exist in case of BO1, but to be honest I am absolutely not knowledgeable of Node, JS and TypeScript, so there might be perfectly good reasons to declare and set values for those variables that I just don't understand.