### PR TITLE
Fix log file selector default extension filter

### DIFF
--- a/src/window_main/components/popups/OutputLogInput.tsx
+++ b/src/window_main/components/popups/OutputLogInput.tsx
@@ -38,7 +38,7 @@ export default function OutputLogInput(
         defaultPath: logUri,
         buttonLabel: "Select",
         filters: [
-          { name: "Text", extensions: ["txt", "text"] },
+          { name: "Log", extensions: ["log"] },
           { name: "All Files", extensions: ["*"] }
         ],
         properties: ["openFile"]

--- a/src/window_main/components/settings/SectionData.tsx
+++ b/src/window_main/components/settings/SectionData.tsx
@@ -121,7 +121,7 @@ export default function SectionData(): JSX.Element {
         defaultPath: appSettings.logUri,
         buttonLabel: "Select",
         filters: [
-          { name: "Text", extensions: ["txt", "text"] },
+          { name: "Log File", extensions: ["log"] },
           { name: "All Files", extensions: ["*"] }
         ],
         properties: ["openFile"]


### PR DESCRIPTION
It was defaulting at looking for Text files with specific extensions,
therefore resulting for Player.log file being invisible to user.

---
Screenshot of the issue:
![player_log_1](https://user-images.githubusercontent.com/709500/82622660-a4e90100-9bde-11ea-9974-2747c63cf94d.PNG)

I was unsure of how to label this, I simply picked "Log", but it could also have been "Log File", "Log file", "Log Files" or "Log files".

Also, I'm unable to understand the logic of such a huge codebase, especially with languages I don't know and understand to answer the question myself, but couldn't those two part I modified be a single function called two times? It looks – from far – as duplicated code here, but again I have no knowledge nor understanding/skill here.