### PR TITLE
Fix unknown internal event name

### DIFF
--- a/src/background/loadPlayerConfig.ts
+++ b/src/background/loadPlayerConfig.ts
@@ -217,6 +217,7 @@ export async function loadPlayerConfig(): Promise<void> {
           // all the fields required for conversion to InternalDraftv2. This logic
           // will combine the InternalDraft with Pick data and data from the associated
           // type: "event" data. This fix is associated with issue #1117.
+          ipcLog("Issue 1117: fixing draft data prior to conversion to InternalDraftv2 for id: " + id);
           const metadataId = id.replace(/-draft$/, "");
           const metadata = savedData[metadataId] as InternalDraft;
           if (!original.InternalEventName && metadata?.InternalEventName) {

--- a/src/background/loadPlayerConfig.ts
+++ b/src/background/loadPlayerConfig.ts
@@ -210,7 +210,12 @@ export async function loadPlayerConfig(): Promise<void> {
   if (savedData.draft_index) {
     const draftsList: InternalDraftv2[] = savedData.draft_index
       .filter((id: string) => savedData[id])
-      .map((id: string) => convertDraftToV2(savedData[id] as InternalDraft, savedData[id.replace(/-draft$/g,"")] as InternalDraft));
+      .map((id: string) =>
+        convertDraftToV2(
+          savedData[id] as InternalDraft,
+          savedData[id.replace(/-draft$/g, "")] as InternalDraft
+        )
+      );
 
     reduxAction(
       globals.store.dispatch,

--- a/src/background/loadPlayerConfig.ts
+++ b/src/background/loadPlayerConfig.ts
@@ -210,7 +210,7 @@ export async function loadPlayerConfig(): Promise<void> {
   if (savedData.draft_index) {
     const draftsList: InternalDraftv2[] = savedData.draft_index
       .filter((id: string) => savedData[id])
-      .map((id: string) => convertDraftToV2(savedData[id] as InternalDraft));
+      .map((id: string) => convertDraftToV2(savedData[id] as InternalDraft, savedData[id.replace(/-draft/gi,"")] as InternalDraft));
 
     reduxAction(
       globals.store.dispatch,

--- a/src/background/loadPlayerConfig.ts
+++ b/src/background/loadPlayerConfig.ts
@@ -77,11 +77,12 @@ function fixBadPlayerData(savedData: any): any {
         const data = savedData[id];
         return data && !(data.InternalEventName && data.CardPool);
       })
-      .map((id: string) => {
+      .forEach((id: string) => {
         // see if we can find the missing data in the id = "GUID" event data.
         const original = savedData[id] as InternalDraft;
         const eventId = id.replace(/-draft$/, "");
         const eventData = savedData[eventId] as InternalDraft;
+        ipcLog("Issue 1117: Fixing InternalDraft record: " + id);
         if (eventData) {
           const internalEventName =
             original.InternalEventName ?? eventData.InternalEventName;

--- a/src/background/loadPlayerConfig.ts
+++ b/src/background/loadPlayerConfig.ts
@@ -210,7 +210,7 @@ export async function loadPlayerConfig(): Promise<void> {
   if (savedData.draft_index) {
     const draftsList: InternalDraftv2[] = savedData.draft_index
       .filter((id: string) => savedData[id])
-      .map((id: string) => convertDraftToV2(savedData[id] as InternalDraft, savedData[id.replace(/-draft/gi,"")] as InternalDraft));
+      .map((id: string) => convertDraftToV2(savedData[id] as InternalDraft, savedData[id.replace(/-draft$/g,"")] as InternalDraft));
 
     reduxAction(
       globals.store.dispatch,

--- a/src/shared/utils/convertDraftToV2.ts
+++ b/src/shared/utils/convertDraftToV2.ts
@@ -41,7 +41,9 @@ export default function convertDraftToV2(
     id: original.id,
     draftSet:
       database.sets[original.set]?.arenacode ||
-      getSetCodeInEventId(original.InternalEventName || metadata.InternalEventName) ||
+      getSetCodeInEventId(
+        original.InternalEventName || metadata.InternalEventName
+      ) ||
       "",
     currentPack: original.packNumber,
     currentPick: original.pickNumber,

--- a/src/shared/utils/convertDraftToV2.ts
+++ b/src/shared/utils/convertDraftToV2.ts
@@ -7,7 +7,8 @@ import database from "../database";
 import getSetCodeInEventId from "./getSetInEventId";
 
 export default function convertDraftToV2(
-  original: InternalDraft
+  original: InternalDraft,
+  metadata: InternalDraft
 ): InternalDraftv2 {
   // declae empty as default
   const packs: InternalDraftv2["packs"] = [
@@ -36,11 +37,11 @@ export default function convertDraftToV2(
     owner: original.owner,
     arenaId: original.player,
     date: original.date,
-    eventId: original.InternalEventName,
+    eventId: original.InternalEventName || metadata.InternalEventName,
     id: original.id,
     draftSet:
       database.sets[original.set]?.arenacode ||
-      getSetCodeInEventId(original.InternalEventName) ||
+      getSetCodeInEventId(original.InternalEventName || metadata.InternalEventName) ||
       "",
     currentPack: original.packNumber,
     currentPick: original.pickNumber,
@@ -48,7 +49,9 @@ export default function convertDraftToV2(
     // Basically we cant map a string[] | number[] array and get it
     // typed as a number[] automatically based on the map fn
     pickedCards:
-      original.CardPool?.map((n: string | number) => parseInt(n + "")) || [],
+      original.CardPool?.map((n: string | number) => parseInt(n + "")) ||
+      metadata.CardPool?.map((n: string | number) => parseInt(n + "")) ||
+      [],
     packs,
     picks,
     type: "draft",

--- a/src/shared/utils/convertDraftToV2.ts
+++ b/src/shared/utils/convertDraftToV2.ts
@@ -7,8 +7,7 @@ import database from "../database";
 import getSetCodeInEventId from "./getSetInEventId";
 
 export default function convertDraftToV2(
-  original: InternalDraft,
-  metadata: InternalDraft
+  original: InternalDraft
 ): InternalDraftv2 {
   // declae empty as default
   const packs: InternalDraftv2["packs"] = [
@@ -37,13 +36,11 @@ export default function convertDraftToV2(
     owner: original.owner,
     arenaId: original.player,
     date: original.date,
-    eventId: original.InternalEventName || metadata.InternalEventName,
+    eventId: original.InternalEventName,
     id: original.id,
     draftSet:
       database.sets[original.set]?.arenacode ||
-      getSetCodeInEventId(
-        original.InternalEventName || metadata.InternalEventName
-      ) ||
+      getSetCodeInEventId(original.InternalEventName) ||
       "",
     currentPack: original.packNumber,
     currentPick: original.pickNumber,
@@ -51,9 +48,7 @@ export default function convertDraftToV2(
     // Basically we cant map a string[] | number[] array and get it
     // typed as a number[] automatically based on the map fn
     pickedCards:
-      original.CardPool?.map((n: string | number) => parseInt(n + "")) ||
-      metadata.CardPool?.map((n: string | number) => parseInt(n + "")) ||
-      [],
+      original.CardPool?.map((n: string | number) => parseInt(n + "")) || [],
     packs,
     picks,
     type: "draft",

--- a/src/shared/utils/getSetInEventId.ts
+++ b/src/shared/utils/getSetInEventId.ts
@@ -1,17 +1,17 @@
 import database from "../database";
 
 export default function getSetCodeInEventId(
-  eventId: string
+  eventId: string | undefined
 ): string | undefined {
-  if (eventId) {
-    const setCodes = Object.keys(database.sets)
-      .filter(
-        (setName) => eventId.indexOf(database.sets[setName].arenacode) !== -1
-      )
-      .map((setName) => database.sets[setName].arenacode);
-
-    return setCodes[0] || undefined;
+  if (!eventId) {
+    return undefined;
   }
 
-  return undefined;
+  const setCodes = Object.keys(database.sets)
+    .filter(
+      (setName) => eventId.indexOf(database.sets[setName].arenacode) !== -1
+    )
+    .map((setName) => database.sets[setName].arenacode);
+
+  return setCodes[0] || undefined;
 }

--- a/src/shared/utils/getSetInEventId.ts
+++ b/src/shared/utils/getSetInEventId.ts
@@ -4,13 +4,13 @@ export default function getSetCodeInEventId(
   eventId: string
 ): string | undefined {
   if (eventId) {
-      const setCodes = Object.keys(database.sets)
-        .filter(
-          (setName) => eventId.indexOf(database.sets[setName].arenacode) !== -1
-        )
-        .map((setName) => database.sets[setName].arenacode);
+    const setCodes = Object.keys(database.sets)
+      .filter(
+        (setName) => eventId.indexOf(database.sets[setName].arenacode) !== -1
+      )
+      .map((setName) => database.sets[setName].arenacode);
 
-      return setCodes[0] || undefined;
+    return setCodes[0] || undefined;
   }
 
   return undefined;

--- a/src/shared/utils/getSetInEventId.ts
+++ b/src/shared/utils/getSetInEventId.ts
@@ -3,15 +3,15 @@ import database from "../database";
 export default function getSetCodeInEventId(
   eventId: string
 ): string | undefined {
-  const _undefined = undefined;
-  if (eventId === _undefined) {
-    return undefined;
-  }
-  const setCodes = Object.keys(database.sets)
-    .filter(
-      (setName) => eventId.indexOf(database.sets[setName].arenacode) !== -1
-    )
-    .map((setName) => database.sets[setName].arenacode);
+  if (eventId) {
+      const setCodes = Object.keys(database.sets)
+        .filter(
+          (setName) => eventId.indexOf(database.sets[setName].arenacode) !== -1
+        )
+        .map((setName) => database.sets[setName].arenacode);
 
-  return setCodes[0] || undefined;
+      return setCodes[0] || undefined;
+  }
+
+  return undefined;
 }

--- a/src/shared/utils/getSetInEventId.ts
+++ b/src/shared/utils/getSetInEventId.ts
@@ -3,6 +3,10 @@ import database from "../database";
 export default function getSetCodeInEventId(
   eventId: string
 ): string | undefined {
+  const _undefined = undefined;
+  if (eventId === _undefined) {
+    return undefined;
+  }
   const setCodes = Object.keys(database.sets)
     .filter(
       (setName) => eventId.indexOf(database.sets[setName].arenacode) !== -1


### PR DESCRIPTION
A fix for: https://github.com/Manuel-777/MTG-Arena-Tool/issues/1117

Add some fall-back logic to identify draft details when upgrading from InternalDraft to InternalDraftV2, and add some resiliency to undefined input to the getSetCodeInEventId function.