### PR TITLE
Sidebar Matchup Matrix using local aggregation data system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4978,6 +4978,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "colormap": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/colormap/-/colormap-2.3.1.tgz",
+      "integrity": "sha512-TEzNlo/qYp6pBoR2SK9JiV+DG1cmUcVO/+DEJqVPSHIKNlWh5L5L4FYog7b/h0bAnhKhpOAvx/c1dFp2QE9sFw==",
+      "requires": {
+        "lerp": "^1.0.3"
+      }
+    },
     "colour": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
@@ -11364,6 +11372,11 @@
       "requires": {
         "invert-kv": "^1.0.0"
       }
+    },
+    "lerp": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/lerp/-/lerp-1.0.3.tgz",
+      "integrity": "sha1-oYyJaPkXiW3hXM/MKNVaa3Med24="
     },
     "leven": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "animejs": "^3.2.0",
     "async": "^3.2.0",
     "bytebuffer": "^5.0.1",
+    "colormap": "^2.3.1",
     "date-fns": "^2.13.0",
     "electron-debug": "^3.0.1",
     "electron-devtools-installer": "^3.0.0",

--- a/src/renderer/aggregator.ts
+++ b/src/renderer/aggregator.ts
@@ -195,9 +195,11 @@ export default class Aggregator {
 
   public colorStats: { [key: string]: AggregatorStats } = {};
   public playerColorStats: { [key: string]: AggregatorStats } = {};
+  public colorColorStats: { [key: string]: AggregatorStats } = {};
+
   public tagStats: { [key: string]: AggregatorStats } = {};
   public playerTagStats: { [key: string]: AggregatorStats } = {};
-  public colorColorStats: { [key: string]: AggregatorStats } = {};
+  public tagTagStats: { [key: string]: AggregatorStats } = {};
 
   public constructedStats: { [key: string]: AggregatorStats } = {};
   public deckMap: { [key: string]: InternalDeck } = {};
@@ -336,6 +338,7 @@ export default class Aggregator {
     this.tagStats = {};
     this.playerTagStats = {};
     this.colorColorStats = {};
+    this.tagTagStats = {};
     this.constructedStats = {};
     this.limitedStats = {};
 
@@ -360,6 +363,7 @@ export default class Aggregator {
       ...Object.values(this.tagStats),
       ...Object.values(this.playerTagStats),
       ...Object.values(this.colorColorStats),
+      ...Object.values(this.tagTagStats),
       ...Object.values(this.constructedStats),
       ...Object.values(this.limitedStats),
     ].forEach(Aggregator.finishStats);
@@ -543,8 +547,23 @@ export default class Aggregator {
           ...new Set([...(this.tagStats[tag].colors || []), ...colors]),
         ];
       }
-      if (!statsToUpdate.includes(this.tagStats[tag]))
+      if (!statsToUpdate.includes(this.tagStats[tag])) {
         statsToUpdate.push(this.tagStats[tag]);
+      }
+
+      // Record a TagTag stat object if both decks have colour data.
+      const playerTag = match.playerDeck.tags?.[0] ?? Aggregator.NO_ARCH;
+      const tagTagKey = `${playerTag} ${tag}`;
+      if (!(tagTagKey in this.tagTagStats)) {
+        this.tagTagStats[tagTagKey] = {
+          ...Aggregator.getDefaultStats(),
+          tag,
+          playerTag,
+        };
+      }
+      if (!statsToUpdate.includes(this.tagTagStats[tagTagKey])) {
+        statsToUpdate.push(this.tagTagStats[tagTagKey]);
+      }
     }
     // update relevant stats
     statsToUpdate.forEach((stats) => {

--- a/src/renderer/components/misc/MatchResultsStatsPanel.tsx
+++ b/src/renderer/components/misc/MatchResultsStatsPanel.tsx
@@ -217,6 +217,7 @@ export default function MatchResultsStatsPanel({
     playerTagStats,
     playerColorStats,
     colorColorStats,
+    tagTagStats,
   } = aggregator;
   const { eventId } = aggregator.filters;
   const isLimited = eventId === RANKED_DRAFT;
@@ -264,6 +265,8 @@ export default function MatchResultsStatsPanel({
   );
   playerFreqStats.sort(frequencySort);
   playerFreqStats = playerFreqStats.slice(0, barsToShow);
+
+  const matrixStats = showTags ? tagTagStats : colorColorStats;
 
   return (
     <div className={indexCss.main_stats} ref={panelRef}>
@@ -393,7 +396,7 @@ export default function MatchResultsStatsPanel({
             <MatchupMatrix
               opponentWinrates={freqStats}
               playerWinrates={playerFreqStats}
-              winrates={colorColorStats}
+              winrates={matrixStats}
               showTags={showTags}
             />
           </div>

--- a/src/renderer/components/misc/MatchResultsStatsPanel.tsx
+++ b/src/renderer/components/misc/MatchResultsStatsPanel.tsx
@@ -25,6 +25,8 @@ import listItemCss from "../list-item/ListItem.css";
 import manaCurveCss from "../../../shared/ManaCurve/ManaCurve.css";
 import sharedCss from "../../../shared/shared.css";
 
+import MatchupMatrix from "./MatrixChart";
+
 const manaClasses: string[] = [];
 manaClasses[WHITE] = sharedCss.manaW;
 manaClasses[BLUE] = sharedCss.manaU;
@@ -58,7 +60,9 @@ function WinrateChart({
   showTags: boolean;
 }): JSX.Element {
   const curveMax = Math.max(
-    ...winrates.map((cwr) => Math.max(cwr.wins || 0, cwr.losses || 0)),
+    ...winrates.map((winRateInfo) =>
+      Math.max(winRateInfo.wins || 0, winRateInfo.losses || 0)
+    ),
     0
   );
   const barStats = [...winrates];
@@ -66,50 +70,53 @@ function WinrateChart({
   return (
     <>
       <div className={manaCurveCss.manaCurve}>
-        {barStats.map((cwr, index) => {
+        {barStats.map((winRateInfo, index) => {
           return (
             <React.Fragment key={index}>
               <div
                 className={
                   manaCurveCss.manaCurveColumn + " " + sharedCss.back_green
                 }
-                style={{ height: getStyleHeight(cwr.wins / curveMax) }}
-                title={`${cwr.wins} won`}
+                style={{ height: getStyleHeight(winRateInfo.wins / curveMax) }}
+                title={`${winRateInfo.wins} won`}
               />
               <div
                 className={
                   manaCurveCss.mana_curve_column + " " + sharedCss.back_red
                 }
-                style={{ height: getStyleHeight(cwr.losses / curveMax) }}
-                title={`${cwr.losses} lost`}
+                style={{
+                  height: getStyleHeight(winRateInfo.losses / curveMax),
+                }}
+                title={`${winRateInfo.losses} lost`}
               />
             </React.Fragment>
           );
         })}
       </div>
       <div className={manaCurveCss.mana_curve_costs}>
-        {barStats.map((cwr, index) => {
+        {barStats.map((winRateInfo, index) => {
           let winRate = 0;
-          if (cwr.wins) {
-            winRate = cwr.wins / (cwr.wins + cwr.losses);
+          if (winRateInfo.wins) {
+            winRate =
+              winRateInfo.wins / (winRateInfo.wins + winRateInfo.losses);
           }
           const colClass = getWinrateClass(winRate, true);
           return (
             <div
               key={index}
               className={manaCurveCss.mana_curve_column_number}
-              title={`${cwr.wins} won : ${cwr.losses} lost`}
+              title={`${winRateInfo.wins} won : ${winRateInfo.losses} lost`}
             >
               <span className={colClass}>{formatPercent(winRate)}</span>
               {showTags && (
                 <div
                   className={manaCurveCss.mana_curve_tag}
-                  style={{ backgroundColor: getTagColor(cwr.tag) }}
+                  style={{ backgroundColor: getTagColor(winRateInfo.tag) }}
                 >
-                  {cwr.tag}
+                  {winRateInfo.tag}
                 </div>
               )}
-              {cwr.colors?.map((color) => (
+              {winRateInfo.colors?.map((color) => (
                 <div
                   key={color}
                   className={sharedCss.manaS16 + " " + manaClasses[color]}
@@ -133,36 +140,38 @@ function FrequencyChart({
   total: number;
   showTags: boolean;
 }): JSX.Element {
-  const curveMax = Math.max(...winrates.map((cwr) => cwr.total));
+  const curveMax = Math.max(
+    ...winrates.map((winRateInfo) => winRateInfo.total)
+  );
   const barStats = [...winrates];
   barStats.sort(frequencySort);
   return (
     <>
       <div className={manaCurveCss.mana_curve}>
-        {barStats.map((cwr, index) => {
+        {barStats.map((winRateInfo, index) => {
           return (
             <div
               key={index}
               className={
                 manaCurveCss.mana_curve_column + " " + sharedCss.back_blue
               }
-              style={{ height: getStyleHeight(cwr.total / curveMax) }}
-              title={`${cwr.total} matches`}
+              style={{ height: getStyleHeight(winRateInfo.total / curveMax) }}
+              title={`${winRateInfo.total} matches`}
             />
           );
         })}
       </div>
       <div className={manaCurveCss.mana_curve_costs}>
-        {barStats.map((cwr, index) => {
+        {barStats.map((winRateInfo, index) => {
           let frequency = 0;
-          if (cwr.total) {
-            frequency = cwr.total / total;
+          if (winRateInfo.total) {
+            frequency = winRateInfo.total / total;
           }
           return (
             <div
               key={index}
               className={manaCurveCss.mana_curve_column_number}
-              title={`${cwr.total} matches`}
+              title={`${winRateInfo.total} matches`}
             >
               <span className={sharedCss.whiteBright}>
                 {formatPercent(frequency)}
@@ -170,12 +179,12 @@ function FrequencyChart({
               {showTags && (
                 <div
                   className={manaCurveCss.mana_curve_tag}
-                  style={{ backgroundColor: getTagColor(cwr.tag) }}
+                  style={{ backgroundColor: getTagColor(winRateInfo.tag) }}
                 >
-                  {cwr.tag}
+                  {winRateInfo.tag}
                 </div>
               )}
-              {cwr.colors?.map((color) => (
+              {winRateInfo.colors?.map((color) => (
                 <div
                   key={color}
                   className={sharedCss.manaS16 + " " + manaClasses[color]}
@@ -199,7 +208,16 @@ export default function MatchResultsStatsPanel({
   aggregator: Aggregator;
   showCharts: boolean;
 }): JSX.Element {
-  const { stats, playStats, drawStats, tagStats, colorStats } = aggregator;
+  const {
+    stats,
+    playStats,
+    drawStats,
+    tagStats,
+    colorStats,
+    playerTagStats,
+    playerColorStats,
+    colorColorStats,
+  } = aggregator;
   const { eventId } = aggregator.filters;
   const isLimited = eventId === RANKED_DRAFT;
   const isConstructed = eventId === RANKED_CONST;
@@ -234,14 +252,19 @@ export default function MatchResultsStatsPanel({
   }, [checkResize]);
 
   const barsToShow = Math.max(3, Math.round(panelWidth / 40));
-  // Archetypes
-  const tagsWinrates = [...Object.values(tagStats)];
-  tagsWinrates.sort(frequencySort);
-  const freqTagStats = tagsWinrates.slice(0, barsToShow);
-  // Colors
-  const colorsWinrates = [...Object.values(colorStats)];
-  colorsWinrates.sort(frequencySort);
-  const freqColorStats = colorsWinrates.slice(0, barsToShow);
+
+  // Opponent: Archetypes or Colour source stats
+  let freqStats = Object.values(showTags ? tagStats : colorStats);
+  freqStats.sort(frequencySort);
+  freqStats = freqStats.slice(0, barsToShow);
+
+  // Player: Archetypes or Colour source stats
+  let playerFreqStats = Object.values(
+    showTags ? playerTagStats : playerColorStats
+  );
+  playerFreqStats.sort(frequencySort);
+  playerFreqStats = playerFreqStats.slice(0, barsToShow);
+
   return (
     <div className={indexCss.main_stats} ref={panelRef}>
       <div className={prefixId + "_winrate"}>
@@ -355,7 +378,7 @@ export default function MatchResultsStatsPanel({
               Frequent Matchups
             </div>
             <FrequencyChart
-              winrates={showTags ? freqTagStats : freqColorStats}
+              winrates={freqStats}
               total={stats.total}
               showTags={showTags}
             />
@@ -365,8 +388,12 @@ export default function MatchResultsStatsPanel({
             >
               Wins vs Losses
             </div>
-            <WinrateChart
-              winrates={showTags ? freqTagStats : freqColorStats}
+            <WinrateChart winrates={freqStats} showTags={showTags} />
+
+            <MatchupMatrix
+              opponentWinrates={freqStats}
+              playerWinrates={playerFreqStats}
+              winrates={colorColorStats}
               showTags={showTags}
             />
           </div>

--- a/src/renderer/components/misc/MatrixChart.tsx
+++ b/src/renderer/components/misc/MatrixChart.tsx
@@ -278,12 +278,18 @@ export default function MatchupMatrix({
 
   const matrix: Array<Array<AggregatorStats | undefined>> = [];
 
+  function getKey(pi: AggregatorStats, oi: AggregatorStats): string {
+    if (showTags) {
+      return `${pi.playerTag} ${oi.tag}`;
+    } else {
+      return `${pi.playerColors?.join(",")} ${oi.colors?.join(",")}`;
+    }
+  }
+
   playerWinrates.forEach((pInfo) => {
-    const pColors = pInfo.playerColors?.join(",");
     const row: Array<AggregatorStats | undefined> = [];
     opponentWinrates.forEach((oInfo) => {
-      const oColors = oInfo.colors?.join(",");
-      const key = `${pColors} ${oColors}`;
+      const key = getKey(pInfo, oInfo);
       if (key in winrates) {
         row.push(winrates[key]);
       } else {

--- a/src/renderer/components/misc/MatrixChart.tsx
+++ b/src/renderer/components/misc/MatrixChart.tsx
@@ -1,0 +1,317 @@
+import React from "react";
+
+import colormap from "colormap";
+
+import { AggregatorStats } from "../../aggregator";
+import { formatPercent, getTagColor } from "../../rendererUtil";
+
+import indexCss from "../../index.css";
+import sharedCss from "../../../shared/shared.css";
+import manaCurveCss from "../../../shared/ManaCurve/ManaCurve.css";
+
+import {
+  WHITE,
+  BLUE,
+  BLACK,
+  RED,
+  GREEN,
+  COLORLESS,
+} from "../../../shared/constants";
+
+const manaClasses: string[] = [];
+manaClasses[WHITE] = sharedCss.manaW;
+manaClasses[BLUE] = sharedCss.manaU;
+manaClasses[BLACK] = sharedCss.manaB;
+manaClasses[RED] = sharedCss.manaR;
+manaClasses[GREEN] = sharedCss.manaG;
+manaClasses[COLORLESS] = sharedCss.manaC;
+
+const frequencySort = (a: AggregatorStats, b: AggregatorStats): number =>
+  b.total - a.total;
+
+const tileColors = colormap({
+  colormap: "viridis",
+  nshades: 100,
+  format: "hex",
+  alpha: 1,
+});
+
+function tileColor(winrate: number): string {
+  return tileColors[0 | (winrate * (tileColors.length - 1))];
+  // Map 0% to 100% win rates to a red/yellow/green gradient.
+  // hsl(0, 50%, 40%)
+  // hsl(60, 80%, 55%)
+  // hsl(120, 100%, 60%)
+  // const h = winrate * 120;
+  // const s = 0 | (50 + winrate * 50);
+  // const l = 0 | (40 + winrate * 20);
+  // return `hsl(${h}, ${s}%, ${l}%)`;
+}
+
+function tileGradient(color: string, size: number): string {
+  // 1 =>    radial-gradient(rgb(34, 141, 141), rgb(34, 141, 141) 20%, transparent 50%);
+  // 10 =>    radial-gradient(rgb(34, 141, 141), rgb(34, 141, 141) 35%, transparent 60%);
+  // 20 =>   radial-gradient(rgb(34, 141, 141), rgb(34, 141, 141) 50%, transparent 70%);
+  // 50 =>   radial-gradient(rgb(34, 141, 141), rgb(34, 141, 141) 65%, transparent 80%);
+  // 150 =>  radial-gradient(rgb(34, 141, 141), rgb(34, 141, 141) 80%, transparent 90%);
+  // 400 => radial-gradient(rgb(34, 141, 141), rgb(34, 141, 141) 95%, transparent 100%);
+  // log[1, 10, 20, 50, 150, 400] => [0.0, 2.302585092994046, 2.995732273553991, 3.912023005428146, 5.0106352940962555, 5.991464547107982]
+
+  const inside = 20 + 12.5 * Math.log(size);
+  const outside = 50 + 8.3 * Math.log(size);
+  return `radial-gradient(${color}, ${color} ${0 | inside}%, transparent ${
+    0 | outside
+  }%)`;
+}
+
+// floating point to rounded integer value.
+const crudePercent = (x: any): number => 0 | ((x || 0) * 100);
+
+function tileTooltipText(
+  winRateInfo: AggregatorStats | undefined
+): string | undefined {
+  if (winRateInfo) {
+    return `${formatPercent(winRateInfo.winrate)} winrate. ${
+      winRateInfo.wins
+    }:${winRateInfo.losses} = ${winRateInfo.total} matches`;
+  }
+}
+
+function Tags({
+  winRateInfo,
+  visible,
+}: {
+  winRateInfo: AggregatorStats;
+  visible: boolean;
+}): JSX.Element {
+  if (visible) {
+    return (
+      <div
+        className={manaCurveCss.tags}
+        style={{ backgroundColor: getTagColor(winRateInfo.tag) }}
+        title={JSON.stringify(winRateInfo)}
+      >
+        {winRateInfo.tag ? winRateInfo.tag : winRateInfo.playerTag}
+      </div>
+    );
+  }
+  return <></>;
+}
+
+function ChartLabel({
+  winRateInfo,
+  showTags,
+}: {
+  winRateInfo: AggregatorStats;
+  showTags: boolean;
+}): JSX.Element {
+  // We don't know if we are displaying player or opponent colours.
+  // But the one we want to show will exist.
+  const colors = winRateInfo.colors?.length
+    ? winRateInfo.colors
+    : winRateInfo.playerColors;
+
+  let winRate = 0;
+  if (winRateInfo.wins) {
+    winRate = winRateInfo.wins / (winRateInfo.wins + winRateInfo.losses);
+  }
+  const totalMatches = winRateInfo?.total || 0;
+
+  // const colClass = getWinrateClass(winRate, true);
+  return (
+    <div className={manaCurveCss.chartLabel}>
+      <Tile
+        value={winRate}
+        size={totalMatches}
+        text={crudePercent(winRate)}
+        title={tileTooltipText(winRateInfo)}
+      />
+      <Tags winRateInfo={winRateInfo} visible={showTags} />
+      <div className={manaCurveCss.colors}>
+        {colors?.map((color) => (
+          <div
+            key={color}
+            className={sharedCss.manaS16 + " " + manaClasses[color]}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ChartLabels({
+  winrates,
+  showTags,
+  vertical,
+}: {
+  winrates: AggregatorStats[];
+  showTags: boolean;
+  vertical?: boolean | undefined;
+}): JSX.Element {
+  return (
+    <div
+      className={`${manaCurveCss.manaCurveCosts} ${
+        vertical ? manaCurveCss.vertical : manaCurveCss.horizontal
+      } ${manaCurveCss.chartLabels}`}
+    >
+      {winrates.map((winRateInfo, index) => (
+        <ChartLabel key={index} winRateInfo={winRateInfo} showTags={showTags} />
+      ))}
+    </div>
+  );
+}
+
+function ChartLegend(): JSX.Element {
+  const winrates = Array(6)
+    .fill(0)
+    .map((_, i) => i / 5);
+
+  // Aproximately exponential
+  const sampleSizes = [1, 10, 20, 50, 150, 400];
+
+  return (
+    <div className={manaCurveCss.legend}>
+      <h5> Legend </h5>
+      <div>
+        <label>Winrate (%):</label>
+        <div>
+          {winrates.map((wr, index) => (
+            <Tile key={index} value={wr} size={10000} text={crudePercent(wr)} />
+          ))}
+        </div>
+      </div>
+      <div>
+        <label>Samples:</label>
+        <div>
+          {sampleSizes.map((ss, index) => (
+            <Tile key={index} value={0.5} size={ss} text={ss} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Tile({
+  value,
+  size,
+  text,
+  title,
+}: {
+  value?: number;
+  size?: number;
+  text?: any;
+  title?: any;
+}): JSX.Element {
+  // Represents a tile in a pairwise comparison plot
+
+  // FIXME: `size` and tileGradient is tweaked for match sample sizes
+  // This will need to be changed if the code is used elsewhere.
+
+  const color = value !== undefined ? tileColor(value) : "rgba(0,0,0,0%)";
+
+  return (
+    <div
+      className={manaCurveCss.tile}
+      title={title}
+      style={{
+        background: tileGradient(color, size || 0),
+      }}
+    >
+      <span>{text}</span>
+    </div>
+  );
+}
+
+function ChartRow({
+  row,
+}: {
+  row: Array<AggregatorStats | undefined>;
+}): JSX.Element {
+  return (
+    <tr className={manaCurveCss.chartRow}>
+      {row.map((winRateInfo, index) => (
+        <td key={index}>
+          <Tile
+            value={winRateInfo?.winrate}
+            size={winRateInfo?.total}
+            title={tileTooltipText(winRateInfo)}
+            text={!winRateInfo ? "" : crudePercent(winRateInfo?.winrate)}
+          />
+        </td>
+      ))}
+    </tr>
+  );
+}
+
+function Chart({
+  matrix,
+}: {
+  matrix: Array<Array<AggregatorStats | undefined>>;
+}): JSX.Element {
+  return (
+    <table className={manaCurveCss.chart}>
+      {matrix.map((row, index) => (
+        <ChartRow key={index} row={row} />
+      ))}
+    </table>
+  );
+}
+
+export default function MatchupMatrix({
+  opponentWinrates,
+  playerWinrates,
+  winrates,
+  showTags,
+}: {
+  opponentWinrates: AggregatorStats[];
+  playerWinrates: AggregatorStats[];
+  winrates: { [key: string]: AggregatorStats };
+  showTags: boolean;
+}): JSX.Element {
+  // We use the opponent winrates data to sort the matrix columns.
+  opponentWinrates = [...opponentWinrates];
+  opponentWinrates.sort(frequencySort);
+
+  playerWinrates = [...playerWinrates];
+  playerWinrates.sort(frequencySort);
+
+  const matrix: Array<Array<AggregatorStats | undefined>> = [];
+
+  playerWinrates.forEach((pInfo) => {
+    const pColors = pInfo.playerColors?.join(",");
+    const row: Array<AggregatorStats | undefined> = [];
+    opponentWinrates.forEach((oInfo) => {
+      const oColors = oInfo.colors?.join(",");
+      const key = `${pColors} ${oColors}`;
+      if (key in winrates) {
+        row.push(winrates[key]);
+      } else {
+        row.push(undefined);
+      }
+    });
+    matrix.push(row);
+  });
+
+  return (
+    <>
+      <h4
+        className={indexCss.ranks_history_title}
+        style={{ marginTop: "24px", marginBottom: "12px" }}
+      >
+        Matchup Matrix
+      </h4>
+
+      <div className={manaCurveCss.chartContainer}>
+        <Chart matrix={matrix} />
+        <ChartLabels
+          winrates={playerWinrates}
+          showTags={showTags}
+          vertical={true}
+        />
+        <ChartLabels winrates={opponentWinrates} showTags={showTags} />
+        <ChartLegend />
+      </div>
+    </>
+  );
+}

--- a/src/shared/ManaCurve/ManaCurve.css
+++ b/src/shared/ManaCurve/ManaCurve.css
@@ -77,3 +77,204 @@
   font-family: var(--sub-font-name);
   transform: rotate(180deg);
 }
+
+/* Main Chart component */
+
+.chart-container {
+  display: grid;
+  grid-template-columns: [start] auto [mid] 1fr [end];
+  grid-template-rows: [start] 1fr [mid] auto [end];
+}
+
+.chart {
+  grid-column: mid / end;
+  grid-row: start / mid;
+
+  /* We don't know how many columns / rows there will be so use flex. */
+  display: flex;
+  flex-direction: column;
+
+
+  border: 2px solid rgba(250, 229, 210, 0.8);
+  border-top: 0;
+  border-right: 0;
+
+  overflow: hidden;
+}
+
+.chart-row {
+  display: flex;
+  flex-direction: row;
+  height: 100%;
+}
+
+.chart tr, .chart td, .chart th {
+  position: relative;
+  padding: 0;
+  margin: 0;
+  border: 0;
+}
+
+.chart tr:hover::after {
+  background-color: rgba(255, 255, 255, 0.9);
+  content: '\00a0';
+  position: absolute;
+  top: calc(50% - 1px);
+  left: -5000px;
+  width: 10000px;
+  height: 2px;
+  z-index: 1;
+}
+
+.chart td:hover::after {
+  background-color: rgba(255, 255, 255, 0.9);
+  content: '\00a0';
+  position: absolute;
+  left: calc(50% - 1px);
+  top: -5000px;
+  height: 10000px;
+  width: 2px;
+  z-index: 1;
+}
+
+.legend {
+  grid-column: start / mid;
+  grid-row: mid / end;
+  padding: 0 10px;
+  font-size: medium;
+}
+
+.legend > div {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+.legend > div > div {
+  display: flex;
+  justify-content: center;
+}
+.legend h5 {
+  margin: 0;
+  margin-top: 0.5em;
+  font-size: medium;
+  text-decoration: underline;
+  font-weight: bold;
+}
+
+.tile {
+  width: 20px;
+  height: 20px;
+  min-width: 20px;
+  min-height: 20px;
+  margin: 2px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: clip;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 100;
+  position: relative;
+
+  color: white;
+  font-weight: bold;
+  font-size: 7pt;
+  font-family: var(--tiny-font-name);
+}
+
+.chart .tile {
+  color: transparent;
+}
+
+.tile:hover {
+  color: white;
+  font-weight: 900;
+  font-size: 9pt;
+}
+
+.tile span {
+  /*An experiment in automatic text colouring*/
+
+  /*mix-blend-mode: difference;*/
+  /* [OR below] */
+  /* background: inherit; */
+  /* -webkit-background-clip: text; */
+  /* color: transparent; */
+  /* filter: invert(1) grayscale(1) contrast(9);*/
+}
+
+/* Chart Labels */
+
+.chart-labels {
+  /* Container */
+}
+.vertical.chart-labels {
+  flex-direction: column;
+  grid-column: start / mid;
+  grid-row: start / mid;
+}
+.horizontal.chart-labels {
+  flex-direction: row;
+  grid-column: mid / end;
+  grid-row: mid / end;
+}
+
+
+.chart-label {
+  display: flex;
+  color: var(--color-text);
+  font-family: "belerenbold";
+  font-size: 12px;
+  line-height: 20px;
+}
+.vertical .chart-label {
+  flex-direction: row-reverse;
+  height: 24px;
+  width: calc(100% - .5em);
+  text-align: left;
+}
+.horizontal .chart-label {
+  flex-direction: column;
+  width: 24px;
+  align-items: center;
+  text-align: center;
+}
+
+
+.colors {
+  display: flex;
+  align-items: center;
+}
+.vertical .colors {
+  flex-direction: row;
+}
+.horizontal .colors {
+  flex-direction: column;
+}
+.vertical .colors > * {
+  margin: 0 2px ;
+}
+.horizontal .colors > * {
+  margin: 2px 0;
+}
+
+
+.tags {
+  border-radius: 10px;
+  font-size: 13px;
+  color: black;
+  font-family: var(--sub-font-name);
+}
+.vertical .tags {
+  height: 20px;
+  padding:  0px 12px;
+  writing-mode: initial;
+}
+.horizontal .tags {
+  width: 20px;
+  padding: 12px 0px;
+  transform: rotate(180deg);
+  writing-mode: tb-rl;
+}
+

--- a/src/shared/ManaCurve/ManaCurve.css.d.ts
+++ b/src/shared/ManaCurve/ManaCurve.css.d.ts
@@ -2,6 +2,18 @@
 // GENERATED FILE; DO NOT EDIT
 declare namespace ManaCurveCssNamespace {
   export interface IManaCurveCss {
+    chart: string;
+    "chart-container": string;
+    "chart-label": string;
+    "chart-labels": string;
+    "chart-row": string;
+    chartContainer: string;
+    chartLabel: string;
+    chartLabels: string;
+    chartRow: string;
+    colors: string;
+    horizontal: string;
+    legend: string;
     manaCurve: string;
     manaCurveColumn: string;
     manaCurveColumnNumber: string;
@@ -18,6 +30,9 @@ declare namespace ManaCurveCssNamespace {
     mana_curve_number: string;
     mana_curve_numbers: string;
     mana_curve_tag: string;
+    tags: string;
+    tile: string;
+    vertical: string;
   }
 }
 

--- a/src/shared/shared.css
+++ b/src/shared/shared.css
@@ -12,7 +12,17 @@
   --sub-font-name-it: "roboto-italic", sans-serif;
   --sub-font-name-bold: "roboto-bold", sans-serif;
   --sub-font-name-bold-it: "roboto-bold-italic", sans-serif;
+
   --main-font-style-it: normal;
+
+
+  /*A note on fonts
+    Chart Tiles' contents very small so should use an easy to read in small spaces font.
+    Based on https://ux.stackexchange.com/questions/3330/
+    Segoe UI, Tahoma, Verdana
+    Otherwise maybe consider a font like minuscule.
+  */
+  --tiny-font-name: "Segoe UI", "Tahoma", "Verdana", sans-serif;
   
   /* Leaving this here for ease of edit */
   /*


### PR DESCRIPTION
The goal is to use local data to provide a useful matchup table with minimal clutter. Once a person is familiar with the table construction it should easily provide useful data by glancing at it / scanning.

It's integrated into the aggregation system and placed in the sidebar so that any of the current filtering methods will work. The below is filtered to ranked constructed.

![image](https://user-images.githubusercontent.com/766048/87254473-e8dbe200-c47a-11ea-8cf5-e22546476262.png)

Floating over cells shows more information and highlights the row and column:
![image](https://user-images.githubusercontent.com/766048/87254583-78819080-c47b-11ea-8fb1-a5d3c8c06eb2.png)

The data is sorted in the same method as the other sidebar charts - by frequency. Shape and size of tiles gives information of sample size for that matchup with roughly exponential scaling.

The colour scheme is viridis from matplotlib, details [here](https://cran.r-project.org/web/packages/viridis/vignettes/intro-to-viridis.html). As future work there should be a setting to switch between different colour palettes. Colour blind simulation of green-red palette versus viridis:
![image](https://user-images.githubusercontent.com/766048/87254692-34db5680-c47c-11ea-8aaf-b87dc70ea8eb.png)

There are issues with the archetype system which are beyond the scope of this pull request and should be fixed separately. The biggest problem is that tags are asymmetric. Opponents decks are tagged with archetype but your decks are tagged with format. Thus there is no easy way of doing a proper archetype vs archetype matchup.