### PR TITLE
Sort rank by rank + Fix typing.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3050,9 +3050,9 @@
       }
     },
     "@types/react-table": {
-      "version": "7.0.19",
-      "resolved": "https://registry.npmjs.org/@types/react-table/-/react-table-7.0.19.tgz",
-      "integrity": "sha512-RYyEY7Yry6F2JsKhHeFsGdzuFF1hMqBStQrrazDzpBl4m/ECGHJxFVQjLBRzRwK+47ZKNPm79f7qEpHirbiCLA==",
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/@types/react-table/-/react-table-7.0.13.tgz",
+      "integrity": "sha512-JdVbJqyAmbI0aEAmB6UXZVUajA4F6rGITrrHxxhn2fItwIdaXUMhD86l0CQHKohMKf8k3SrkHz9CceoblkW1eg==",
       "dev": true,
       "requires": {
         "@types/react": "*"

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "@types/react-color": "^3.0.1",
     "@types/react-dom": "^16.9.8",
     "@types/react-redux": "^7.1.8",
-    "@types/react-table": "^7.0.12",
+    "@types/react-table": "7.0.13",
     "@types/react-test-renderer": "^16.9.2",
     "@types/react-transition-group": "^4.2.4",
     "@types/styled-components": "^5.1.0",

--- a/src/renderer/components/matches/MatchesTable.tsx
+++ b/src/renderer/components/matches/MatchesTable.tsx
@@ -53,6 +53,25 @@ const { DATE_SEASON, MATCHES_TABLE_MODE } = constants;
 
 const { RANKED_CONST, RANKED_DRAFT } = Aggregator;
 
+function convertRankToNumber(rank: string): number {
+  switch (rank) {
+    case 'Bronze':
+      return 0;
+    case 'Silver':
+      return 1;
+    case 'Gold':
+      return 2;
+    case 'Platinum':
+      return 3;
+    case 'Diamond':
+      return 4;
+    case 'Mythic':
+      return 5;
+    default:
+      return -1;
+  }
+}
+
 const columns: Column<MatchTableData>[] = [
   { accessor: "id" },
   { accessor: "date" },
@@ -201,6 +220,10 @@ const columns: Column<MatchTableData>[] = [
     Filter: RankColumnFilter,
     Cell: RankCell,
     mayToggle: true,
+    sortType: (rowA, rowB) => {
+      const rank = convertRankToNumber(rowA.original.oppRank) - convertRankToNumber(rowB.original.oppRank);
+      return rank > 0 ? 1 : rank < 0 ? -1 : 0;
+    }
   },
   {
     Header: "Op. Tier",


### PR DESCRIPTION
Fixes #1172 

This also fixes a bug with the types used for `react-table`. The current version of `react-table` used is incompatible with the DefinitivelyTyped package. See the top of the readme [here](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/react-table). Once fixed, types will now check correctly for the `Column` type.