### PR TITLE
Added pointer-events to the overlay panel's top buttons

### DIFF
--- a/src/overlay/index.css
+++ b/src/overlay/index.css
@@ -9,6 +9,7 @@ body {
     padding: 0 !important;
     height: 100% !important;
     width: 100% !important;
+    pointer-events: all;
 }
 
 .click-on      {pointer-events: all}


### PR DESCRIPTION
This allows to interact with the top buttons of the overlay panels on Linux using GNOME.
You still have to enter the panel from the bottom to the top to get focus, but it is possible now.

Please check that I didn't break anything on Windows or Mac OS because I'm unable to test on those env.