### PR TITLE
Sort draft pack by rarity and color

### DIFF
--- a/src/shared/utils/getCardColors.ts
+++ b/src/shared/utils/getCardColors.ts
@@ -1,0 +1,33 @@
+import { uniq } from "lodash";
+import { DbCardData } from "mtgatool-shared";
+import { constants } from "mtgatool-shared";
+
+const { WHITE, BLUE, BLACK, RED, GREEN, COLORLESS } = constants;
+
+export default function getCardColors(
+  card: DbCardData,
+  ignoreColorless?: boolean
+): number[] {
+  const colors = card.cost.reduce<number[]>((colorIndices, current) => {
+    switch (current) {
+      case "w":
+        return colorIndices.concat(WHITE);
+      case "u":
+        return colorIndices.concat(BLUE);
+      case "b":
+        return colorIndices.concat(BLACK);
+      case "r":
+        return colorIndices.concat(RED);
+      case "g":
+        return colorIndices.concat(GREEN);
+      default:
+        return colorIndices;
+    }
+  }, []);
+  const sortedAndUniqueColors = uniq(colors.sort());
+  return sortedAndUniqueColors.length
+    ? sortedAndUniqueColors
+    : ignoreColorless
+    ? []
+    : [COLORLESS];
+}

--- a/src/shared/utils/getCardColors.ts
+++ b/src/shared/utils/getCardColors.ts
@@ -4,10 +4,7 @@ import { constants } from "mtgatool-shared";
 
 const { WHITE, BLUE, BLACK, RED, GREEN, COLORLESS } = constants;
 
-export default function getCardColors(
-  card: DbCardData,
-  ignoreColorless?: boolean
-): number[] {
+export default function getCardColors(card: DbCardData): number[] {
   const colors = card.cost.reduce<number[]>((colorIndices, current) => {
     switch (current) {
       case "w":
@@ -25,9 +22,5 @@ export default function getCardColors(
     }
   }, []);
   const sortedAndUniqueColors = uniq(colors.sort());
-  return sortedAndUniqueColors.length
-    ? sortedAndUniqueColors
-    : ignoreColorless
-    ? []
-    : [COLORLESS];
+  return sortedAndUniqueColors.length ? sortedAndUniqueColors : [COLORLESS];
 }


### PR DESCRIPTION
When using the draft viewer, rarities and colors shift constantly which makes for a bad draft replay experience. This PR aims to mimic the sorting found in MTG Arena, so that it's more familiar when looking back at the draft.