### PR TITLE
Fix handling of deck selection

### DIFF
--- a/src/background/selectDeck.ts
+++ b/src/background/selectDeck.ts
@@ -7,14 +7,10 @@ const { IPC_OVERLAY } = constants;
 
 export default function selectDeck(arg: Deck): void {
   debugLog(`Select deck: ${arg}`);
-  // This does not work
-  //globalStore.currentMatch = {
-  //  ...globalStore.currentMatch,
-  //  originalDeck: arg.clone(),
-  //  currentDeck: arg.clone(),
-  //};
-  // This does
-  Object.assign(globalStore.currentMatch.originalDeck, arg.clone());
-  Object.assign(globalStore.currentMatch.currentDeck, arg.clone());
+  globalStore.currentMatch = {
+   ...globalStore.currentMatch,
+   originalDeck: arg.clone(),
+   currentDeck: arg.clone(),
+  };
   ipcSend("set_deck", arg.getSave(), IPC_OVERLAY);
 }

--- a/src/background/selectDeck.ts
+++ b/src/background/selectDeck.ts
@@ -8,9 +8,9 @@ const { IPC_OVERLAY } = constants;
 export default function selectDeck(arg: Deck): void {
   debugLog(`Select deck: ${arg}`);
   globalStore.currentMatch = {
-   ...globalStore.currentMatch,
-   originalDeck: arg.clone(),
-   currentDeck: arg.clone(),
+    ...globalStore.currentMatch,
+    originalDeck: arg.clone(),
+    currentDeck: arg.clone(),
   };
   ipcSend("set_deck", arg.getSave(), IPC_OVERLAY);
 }

--- a/src/shared/store/currentMatchStore.ts
+++ b/src/shared/store/currentMatchStore.ts
@@ -112,9 +112,15 @@ export function setOppCardsUsed(arg: number[]): void {
 }
 
 export function resetCurrentMatch(): void {
+  // Deck selection happens before creating a new match. Need to keep the
+  // already selected deck.
+  const currentDeck: Deck = globalStore.currentMatch.currentDeck;
+  const originalDeck: Deck = globalStore.currentMatch.originalDeck;
   globalStore.currentMatch = Object.assign({}, matchStateObject);
   globalStore.currentMatch = {
     ...globalStore.currentMatch,
+    currentDeck: currentDeck,
+    originalDeck: originalDeck,
     playerStats: {
       lifeLost: 0,
       lifeGained: 0,


### PR DESCRIPTION
The way this interacted with sideboarding was causing `currentDeck` to get stuck and ignore all changes after the first time the player sideboarded.