### PR TITLE
Fix erroneous export in background log

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -629,5 +629,3 @@ function dataChop(data: string, startStr: string, endStr: string): string {
 
   return data;
 }
-
-module.exports = {};


### PR DESCRIPTION
Fix the error: Uncaught TypeError: Cannot assign to read only property 'exports' of object '#<Object>'